### PR TITLE
AI-Trader Enterprise release candidate stabilization

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Version 1 is the first verified autonomous trading baseline. It successfully exe
 - Hardened release tag: `v1.0.1-production-hardened`
 - Environment verified: Alpaca paper trading
 - Current development branch: `feature/trading-intelligence-engine`
-- Current release candidate: AI-Trader V3 RC1 / PR #57
+- Current release candidate: AI-Trader Enterprise RC1 / PR #59 (tag `v2.0.0-enterprise`)
+- Enterprise release report: `docs/release/AI_TRADER_ENTERPRISE_RC1.md`
 
 RC1 is a paper-trading release candidate. It is not cleared for live-money deployment.
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Some server automation and dev-platform tests bind local ports. In restricted sa
 - Enterprise Trade Lifecycle Manager: `docs/trade-lifecycle/README.md`
 - Autonomous Trading Integration: `docs/autonomous-trading/README.md`
 - Enterprise Learning Intelligence: `docs/learning/README.md`
+- Vercel Frontend Observability: `docs/vercel/README.md`
 - Strategy Analytics: `docs/features/strategy-analytics.md`
 
 ## Local Development

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ Some server automation and dev-platform tests bind local ports. In restricted sa
 - Trade Intelligence Reports: `docs/features/trade-intelligence-reports.md`
 - Daily Intelligence Reports: `docs/features/daily-intelligence-reports.md`
 - Decision Journal: `docs/features/decision-journal.md`
+- Decision Intelligence Engine: `docs/decision-engine/README.md`
+- Event Intelligence Engine: `docs/event-intelligence/README.md`
+- Strategy Orchestrator: `docs/strategy-orchestrator/README.md`
+- Enterprise Risk Intelligence Engine: `docs/risk-engine/README.md`
+- Enterprise Trade Lifecycle Manager: `docs/trade-lifecycle/README.md`
+- Autonomous Trading Integration: `docs/autonomous-trading/README.md`
 - Strategy Analytics: `docs/features/strategy-analytics.md`
 
 ## Local Development

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Some server automation and dev-platform tests bind local ports. In restricted sa
 - Enterprise Risk Intelligence Engine: `docs/risk-engine/README.md`
 - Enterprise Trade Lifecycle Manager: `docs/trade-lifecycle/README.md`
 - Autonomous Trading Integration: `docs/autonomous-trading/README.md`
+- Enterprise Learning Intelligence: `docs/learning/README.md`
 - Strategy Analytics: `docs/features/strategy-analytics.md`
 
 ## Local Development

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,10 +1,23 @@
 # Copy to .env for local development. Never commit real values.
+#
+# The Vite frontend consumes ONLY the two URL variables below. In hosted
+# production the app is served same-origin: vercel.json rewrites /api/* and
+# /socket.io* to the Render backend, so the browser bundle contains no backend
+# origin (enforced by client/scripts/assert-no-backend-url.mjs at build time).
 
+# Backend base URLs.
+# - Local dev: point at the local API.
+# - Production: set these to the SAME origin as the deployed frontend so
+#   requests stay same-origin and are proxied by vercel.json. Do NOT set the
+#   Render origin here — the build guard rejects a backend/loopback origin in
+#   the bundle.
 VITE_API_BASE_URL=http://localhost:4000
 VITE_SOCKET_URL=http://localhost:4000
-VITE_APP_ENV=development
-# Production: set VITE_API_BASE_URL and VITE_SOCKET_URL to the Render backend URL.
 
-# Optional local auth bootstrap. Prefer setting a short-lived JWT or explicit dev token locally.
-VITE_AUTH_TOKEN=<viewer-trader-or-admin-token>
-VITE_AUTH_ROLE=viewer
+# Optional environment label surfaced in the UI only.
+VITE_APP_ENV=development
+
+# NOTE: this release does not use a client-side auth token. The staged
+# authentication foundation runs server-side in "observe" mode (see
+# server/.env.example -> Authentication). VITE_AUTH_TOKEN / VITE_AUTH_ROLE are
+# NOT read by the current frontend and were removed to avoid confusion.

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
+        "@vercel/analytics": "^2.0.1",
+        "@vercel/speed-insights": "^2.0.0",
         "axios": "^1.7.7",
         "lightweight-charts": "^5.1.0",
         "lucide-react": "^0.554.0",
@@ -1104,6 +1106,86 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
       "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "license": "ISC"
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.4",

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,8 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
+    "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "axios": "^1.7.7",
     "lightweight-charts": "^5.1.0",
     "lucide-react": "^0.554.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -64,6 +64,7 @@ import type {
 import type { ChecklistResult, DeskInsight, WatchlistReport, ContractSelectionResult } from './api/analysis';
 import type { ChatContext, ChatMessage, ConversationMeta, ConversationPayload, ConversationResponse } from './types';
 import { acquireLiveMarketSubscription } from './hooks/useCockpitLiveSubscription';
+import { trackOperatorEventOnce } from './lib/operatorAnalytics';
 
 // Map timeframe choices in the UI to the aggregate query parameters expected by the API.
 const TIMEFRAME_MAP = {
@@ -467,6 +468,29 @@ function App() {
   const [mobileTab, setMobileTab] = useState<MobileTab>('trade');
   const [agentLaunch, setAgentLaunch] = useState<{ agentId: string; label: string; nonce: number } | null>(null);
 
+  useEffect(() => {
+    trackOperatorEventOnce('Application Loaded');
+  }, []);
+
+  useEffect(() => {
+    if (view === 'cockpit') {
+      trackOperatorEventOnce('Automation Viewed', { surface: 'desktop' });
+      trackOperatorEventOnce('Cockpit Viewed', { surface: 'desktop' });
+    }
+    if (view === 'intelligence') {
+      trackOperatorEventOnce('Reports Viewed', { surface: 'desktop' });
+    }
+  }, [view]);
+
+  useEffect(() => {
+    if (!isMobile) return;
+    if (mobileTab === 'ai') trackOperatorEventOnce('AI Desk Viewed', { surface: 'mobile' });
+    if (mobileTab === 'cockpit') {
+      trackOperatorEventOnce('Automation Viewed', { surface: 'mobile' });
+      trackOperatorEventOnce('Cockpit Viewed', { surface: 'mobile' });
+    }
+  }, [isMobile, mobileTab]);
+
   // Keyboard-first navigation: ⌘K / Ctrl-K toggles the command palette from
   // anywhere in the workstation.
   useEffect(() => {
@@ -553,6 +577,12 @@ function App() {
   const scannerAllowed = aiEnabled && aiScannerEnabled;
   const chatAllowed = aiEnabled && aiChatEnabled;
   const chartAnalysisAllowed = aiEnabled && aiChartAnalysisEnabled;
+
+  useEffect(() => {
+    if (isChatOpen && chatAllowed) {
+      trackOperatorEventOnce('AI Desk Viewed', { surface: 'desktop' });
+    }
+  }, [chatAllowed, isChatOpen]);
   const useRegularHours = chartSessionMode === 'regular';
   const transcriptsRef = useRef<Record<string, ChatMessage[]>>(transcripts);
   const activeConversationIdRef = useRef<string | null>(activeConversationId);

--- a/client/src/__tests__/autonomousTraderPanel.test.tsx
+++ b/client/src/__tests__/autonomousTraderPanel.test.tsx
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { AutonomousTraderPanel } from '../components/cockpit/AutonomousTraderPanel';
+
+vi.mock('../api/autonomousTrading', () => ({
+  getAutonomousTradingStatus: () =>
+    Promise.resolve({
+      generatedAt: '2026-07-24T14:30:00.000Z',
+      status: 'Running',
+      mode: 'Shadow',
+      modeBanner: 'SHADOW MODE - No broker orders will be submitted.',
+      market: 'Closed',
+      broker: 'Alpaca Paper',
+      automationOwner: 'Owned',
+      marketData: 'Live',
+      nextEvaluationAt: '2026-07-27T13:30:00.000Z',
+      emergencyStop: 'Inactive',
+      watching: ['OXY', 'CVX', 'XLE', 'SPY', 'QQQ'],
+      currentActivity:
+        'The system is monitoring OXY, CVX, XLE, SPY, and QQQ. Risk Engine rejected the current OXY opportunity because MAX_SECTOR_EXPOSURE.',
+      latestPipelineId: 'atp_1',
+      featureFlags: { AUTONOMOUS_TRADING_MODE: 'shadow' },
+    }),
+  getAutonomousTradingCurrent: () =>
+    Promise.resolve({
+      pipelineId: 'atp_1',
+      state: 'RISK_REJECTED',
+      mode: 'SHADOW',
+      symbol: 'OXY',
+      optionContract: 'O:OXY260724C00060000',
+      plainLanguageStatus: 'Risk review rejected OXY because MAX_SECTOR_EXPOSURE.',
+      blockingReasons: [],
+      eventContext: { importance: 90, summary: 'Oil supply event' },
+      decisionContext: { recommendation: 'BUY_CALL', opportunityScore: 88 },
+      strategyContext: { winningStrategy: 'Oil / Commodity', confidence: 0.84, evidenceScore: 82 },
+      riskContext: { approved: false, reasonCodes: ['MAX_SECTOR_EXPOSURE'] },
+      lifecycleContext: { lifecycleId: null },
+      executionContext: { requested: false, source: 'SHADOW_SIMULATION' },
+      evaluationContext: {},
+      timeline: [],
+    }),
+  getAutonomousTradingActive: () =>
+    Promise.resolve({
+      trades: [
+        {
+          contract: 'O:OXY260724C00060000',
+          lifecycleAction: 'HOLD',
+          lifecycleState: 'MONITORING',
+          currentConfidence: 0.76,
+          nextEvaluationAt: '2026-07-24T14:31:00.000Z',
+        },
+      ],
+      positions: [],
+    }),
+  getAutonomousTradingPending: () =>
+    Promise.resolve({
+      trades: [],
+      intents: [],
+      current: {
+        symbol: 'OXY',
+        contract: 'OXY $60 Call',
+        recommendation: 'BUY_CALL',
+        winningStrategy: 'Oil / Commodity',
+        evidenceScore: 82,
+        riskStatus: 'REJECTED',
+        entryStatus: 'WAITING',
+        blockingReason: 'MAX_SECTOR_EXPOSURE',
+        ageSeconds: 42,
+      },
+    }),
+  getAutonomousTradingRecentDecisions: () =>
+    Promise.resolve([
+      {
+        time: '2026-07-24T14:31:00.000Z',
+        symbol: 'CVX',
+        action: 'REJECTED',
+        subsystem: 'Risk Engine',
+        reason: 'Energy exposure exceeded the configured portfolio limit.',
+        pipelineId: 'atp_1',
+      },
+    ]),
+  getAutonomousTradingTimeline: () =>
+    Promise.resolve([
+      {
+        at: '2026-07-24T14:31:04.000Z',
+        pipelineId: 'atp_1',
+        symbol: 'OXY',
+        event: 'Risk rejected',
+        actor: 'risk-engine',
+        reason: 'MAX_SECTOR_EXPOSURE',
+        state: 'RISK_REJECTED',
+        relatedRecords: [],
+      },
+    ]),
+  getAutonomousTradingHealth: () =>
+    Promise.resolve({
+      overall: 'DEGRADED',
+      generatedAt: '2026-07-24T14:31:05.000Z',
+      explanation: 'Degraded services: Massive Options WebSocket.',
+      services: [{ name: 'Risk Engine', status: 'HEALTHY', dataTimestamp: null, stale: false, staleReason: null, lastError: null, featureEnabled: true, ownerStatus: null }],
+    }),
+}));
+
+afterEach(() => cleanup());
+
+describe('AutonomousTraderPanel', () => {
+  it('renders unified status, shadow label, trades, reasons, and collapsed details', async () => {
+    render(<AutonomousTraderPanel />);
+
+    const panel = await screen.findByTestId('autonomous-trader-panel');
+    expect(within(panel).getByText('Running')).toBeInTheDocument();
+    expect(within(panel).getByText('Shadow')).toBeInTheDocument();
+    expect(within(panel).getByText('Closed')).toBeInTheDocument();
+    expect(within(panel).getByText('SHADOW MODE - No broker orders will be submitted.')).toBeInTheDocument();
+    expect(within(panel).getByText(/The system is monitoring OXY/)).toBeInTheDocument();
+    expect(within(panel).getByText('HOLD')).toBeInTheDocument();
+    expect(within(panel).getAllByText('MAX_SECTOR_EXPOSURE').length).toBeGreaterThan(0);
+    expect(within(panel).getByText('Risk rejected')).toBeInTheDocument();
+    const details = screen.getByTestId('autonomous-details') as HTMLDetailsElement;
+    expect(details.open).toBe(false);
+  });
+});
+

--- a/client/src/__tests__/cockpit.test.tsx
+++ b/client/src/__tests__/cockpit.test.tsx
@@ -33,6 +33,125 @@ vi.mock('../hooks/useAutomationVisibility', () => ({
     refresh: vi.fn(),
   }),
 }));
+vi.mock('../api/decisionEngine', () => ({
+  getLatestDecisionEngineScan: () => Promise.resolve(null),
+}));
+vi.mock('../api/eventIntelligence', () => ({
+  getEventIntelligenceContext: () => Promise.resolve(null),
+}));
+vi.mock('../api/strategyOrchestrator', () => ({
+  getLatestStrategyRecommendation: () => Promise.resolve(null),
+}));
+vi.mock('../api/riskEngine', () => ({
+  getRiskEngineSnapshot: () =>
+    Promise.resolve({
+      status: {
+        enabled: true,
+        approvalRequired: true,
+        latestApprovalId: null,
+        latestStatus: null,
+        pendingRecommendations: 0,
+        portfolioHeat: 0,
+        ruleVersion: 'risk-v1',
+      },
+      portfolio: {
+        portfolioSize: 100000,
+        buyingPower: null,
+        exposure: { sectorExposure: {}, currentOpenTrades: 0, maximumConcurrentTrades: 8 },
+        greeks: { delta: null, gamma: null, theta: null, vega: null, rho: null },
+        riskBudget: { riskConsumed: 0, remainingRiskBudget: 1500, openRisk: 0, maximumOpenRisk: 6000 },
+      },
+      history: [],
+      queue: { pending: [] },
+    }),
+}));
+vi.mock('../api/tradeLifecycle', () => ({
+  getTradeLifecycleStatus: () =>
+    Promise.resolve({
+      generatedAt: new Date().toISOString(),
+      flags: { TRADE_LIFECYCLE_ENABLED: true },
+      aiStatus: 'READY',
+      paperTrading: true,
+      market: 'OPEN',
+      currentStrategy: null,
+      currentRegime: null,
+      nextEvaluation: null,
+      currentDecision: null,
+      counts: {},
+      schedulers: {},
+    }),
+  getTradeLifecycleActive: () => Promise.resolve([]),
+  getTradeLifecyclePending: () => Promise.resolve([]),
+  getTradeLifecycleHistory: () => Promise.resolve([]),
+  getTradeLifecycleTimeline: () => Promise.resolve([]),
+}));
+vi.mock('../api/autonomousTrading', () => ({
+  getAutonomousTradingStatus: () =>
+    Promise.resolve({
+      generatedAt: new Date().toISOString(),
+      status: 'Running',
+      mode: 'Shadow',
+      modeBanner: 'SHADOW MODE - No broker orders will be submitted.',
+      market: 'Open',
+      broker: 'Alpaca Paper',
+      automationOwner: 'Owned',
+      marketData: 'Live',
+      nextEvaluationAt: null,
+      emergencyStop: 'Inactive',
+      watching: ['SPY', 'QQQ'],
+      currentActivity: 'The system is monitoring SPY and QQQ. No current strategy recommendation is available.',
+      latestPipelineId: null,
+      featureFlags: {},
+    }),
+  getAutonomousTradingCurrent: () => Promise.resolve(null),
+  getAutonomousTradingActive: () => Promise.resolve({ trades: [], positions: [] }),
+  getAutonomousTradingPending: () => Promise.resolve({ trades: [], intents: [], current: null }),
+  getAutonomousTradingRecentDecisions: () => Promise.resolve([]),
+  getAutonomousTradingTimeline: () => Promise.resolve([]),
+  getAutonomousTradingHealth: () => Promise.resolve(null),
+}));
+vi.mock('../api/system', () => ({
+  getSystemStatus: () =>
+    Promise.resolve({
+      status: 'RUNNING',
+      generatedAt: new Date().toISOString(),
+      summary: 'System schedulers are running.',
+      system: {
+        mongo: 'CONNECTED',
+        automation: 'READY',
+        scheduler: 'ACTIVE',
+        monitor: 'ACTIVE',
+        brokerTruthCurrent: true,
+        mode: 'Shadow',
+        market: 'Open',
+        emergencyStop: 'Inactive',
+        nextEvaluationAt: null,
+      },
+      components: [],
+    }),
+  getSystemMetrics: () =>
+    Promise.resolve({
+      generatedAt: new Date().toISOString(),
+      process: { uptimeSec: 120, memoryRss: 1, memoryHeapUsed: 1, memoryHeapTotal: 1 },
+      marketData: {
+        queueDepth: 0,
+        activeRequests: 0,
+        inflightDeduped: 0,
+        deduplicatedRequests: 2,
+        responseCacheEntries: 3,
+        chartFeeds: 1,
+      },
+      automation: {
+        schedulerState: 'ACTIVE',
+        monitorState: 'ACTIVE',
+        schedulerLastTickAt: null,
+        monitorLastTickAt: null,
+        schedulerSubmittedCount: 0,
+        schedulerSkipReasons: {},
+      },
+      autonomousTrading: [],
+    }),
+}));
 
 import { parseOcc, contractLabel } from '../components/cockpit/occSymbol';
 import { selectActiveTrade, type CockpitTrade } from '../components/cockpit/cockpitUi';
@@ -74,7 +193,7 @@ describe('CockpitLayout health strip', () => {
     expect(screen.getByText('Automation')).toBeInTheDocument();
     expect(screen.getByText('Running')).toBeInTheDocument();
     expect(screen.getByText('Broker')).toBeInTheDocument();
-    expect(screen.getByText('Market')).toBeInTheDocument();
+    expect(screen.getAllByText('Market').length).toBeGreaterThan(0);
     expect(screen.getByText('Open')).toBeInTheDocument();
     expect(screen.getByText('Data')).toBeInTheDocument();
     expect(screen.getAllByText('Connected').length).toBeGreaterThan(1);

--- a/client/src/__tests__/cockpit.test.tsx
+++ b/client/src/__tests__/cockpit.test.tsx
@@ -152,6 +152,25 @@ vi.mock('../api/system', () => ({
       autonomousTrading: [],
     }),
 }));
+vi.mock('../api/learning', () => ({
+  getStatus: () =>
+    Promise.resolve({
+      status: 'CURRENT',
+      generatedAt: new Date().toISOString(),
+      completedTrades: 0,
+      tradeReviews: 0,
+      datasets: 0,
+      pendingReviews: 0,
+      pendingDatasets: 0,
+      latestReviewAt: null,
+      explanation: 'No completed trade reports are available for learning yet.',
+    }),
+  getTrades: () => Promise.resolve([]),
+  getScorecards: () => Promise.resolve([]),
+  getCalibration: () => Promise.resolve([]),
+  getRegimes: () => Promise.resolve([]),
+  getEvents: () => Promise.resolve([]),
+}));
 
 import { parseOcc, contractLabel } from '../components/cockpit/occSymbol';
 import { selectActiveTrade, type CockpitTrade } from '../components/cockpit/cockpitUi';

--- a/client/src/__tests__/learningIntelligencePanel.test.tsx
+++ b/client/src/__tests__/learningIntelligencePanel.test.tsx
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { LearningIntelligencePanel } from '../components/cockpit/LearningIntelligencePanel';
+
+vi.mock('../api', () => ({
+  learningApi: {
+    getStatus: () =>
+      Promise.resolve({
+        status: 'CURRENT',
+        generatedAt: new Date().toISOString(),
+        completedTrades: 2,
+        tradeReviews: 2,
+        datasets: 2,
+        pendingReviews: 0,
+        pendingDatasets: 0,
+        latestReviewAt: new Date().toISOString(),
+        explanation: 'Learning artifacts are current with completed trade reports.',
+      }),
+    getTrades: () =>
+      Promise.resolve([
+        {
+          reviewId: 'learning-review:1',
+          sourceTradeId: 'trade-1',
+          entryTimestamp: null,
+          exitTimestamp: null,
+          entryStrategy: 'momentum-v1',
+          winningStrategy: 'Momentum',
+          marketRegime: 'TRENDING',
+          sector: 'Technology',
+          symbol: 'SPY',
+          direction: 'BULLISH',
+          confidence: 0.72,
+          evidenceScore: 0.81,
+          riskScore: 0.7,
+          actualReturn: 4.2,
+          realizedPnl: 120,
+          outcome: 'WIN',
+          whySucceeded: ['Trend continued after entry.'],
+          whyFailed: [],
+          whatCouldImprove: ['Enter earlier when liquidity confirms.'],
+        },
+      ]),
+    getScorecards: () =>
+      Promise.resolve([
+        {
+          key: 'Momentum',
+          window: 'LIFETIME',
+          totalTrades: 2,
+          wins: 1,
+          losses: 1,
+          winRate: 0.5,
+          averageReturn: 1.1,
+          medianReturn: 1.1,
+          averageHoldTimeMinutes: 42,
+          averageRisk: 0.65,
+          largestWinner: 4.2,
+          largestLoser: -2,
+          sharpe: 0.4,
+          maxDrawdown: -2,
+        },
+      ]),
+    getCalibration: () =>
+      Promise.resolve([
+        {
+          confidenceBand: '65-79%',
+          totalTrades: 2,
+          predictedConfidence: 0.72,
+          actualSuccessRate: 0.5,
+          historicalAccuracy: 0.5,
+          calibrationError: 0.22,
+          verdict: 'Overconfident',
+        },
+      ]),
+    getRegimes: () =>
+      Promise.resolve([
+        {
+          key: 'TRENDING',
+          window: 'LIFETIME',
+          totalTrades: 2,
+          wins: 1,
+          losses: 1,
+          winRate: 0.5,
+          averageReturn: 1.1,
+          medianReturn: 1.1,
+          averageHoldTimeMinutes: 42,
+          averageRisk: 0.65,
+          largestWinner: 4.2,
+          largestLoser: -2,
+          sharpe: 0.4,
+          maxDrawdown: -2,
+        },
+      ]),
+    getEvents: () =>
+      Promise.resolve([
+        {
+          event: 'Fed',
+          trades: 2,
+          winRate: 0.5,
+          averageReturn: 1.1,
+          topStrategies: [{ strategy: 'Momentum', trades: 2 }],
+        },
+      ]),
+  },
+}));
+
+afterEach(() => cleanup());
+
+describe('LearningIntelligencePanel', () => {
+  it('renders learning performance, lessons, scorecards, and calibration in Automation', async () => {
+    render(<LearningIntelligencePanel />);
+    await waitFor(() => expect(screen.getByText('Learning Intelligence')).toBeInTheDocument());
+    expect(screen.getByText('Learning artifacts are current with completed trade reports.')).toBeInTheDocument();
+    expect(screen.getByText('Best Strategy')).toBeInTheDocument();
+    expect(screen.getAllByText('Momentum').length).toBeGreaterThan(0);
+    expect(screen.getByText('Confidence Accuracy')).toBeInTheDocument();
+    expect(screen.getByText('Recent Lessons')).toBeInTheDocument();
+    expect(screen.getByText('Enter earlier when liquidity confirms.')).toBeInTheDocument();
+    expect(screen.getByText('Strategy Scorecards, Trade Reviews, and Calibration')).toBeInTheDocument();
+  });
+});

--- a/client/src/__tests__/tradeLifecyclePanel.test.tsx
+++ b/client/src/__tests__/tradeLifecyclePanel.test.tsx
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { TradeLifecyclePanel } from '../components/cockpit/TradeLifecyclePanel';
+
+vi.mock('../api/tradeLifecycle', () => ({
+  getTradeLifecycleStatus: () =>
+    Promise.resolve({
+      generatedAt: new Date().toISOString(),
+      flags: { TRADE_LIFECYCLE_ENABLED: true },
+      aiStatus: 'READY',
+      paperTrading: true,
+      market: 'OPEN',
+      currentStrategy: 'sv-lifecycle',
+      currentRegime: 'REGULAR_SESSION',
+      nextEvaluation: new Date().toISOString(),
+      currentDecision: {
+        watching: 'SPY260821C00450000',
+        recommendation: 'HOLD',
+        confidence: 91,
+        reason: 'Confidence trend is Improving.',
+      },
+      counts: { MONITORING: 1 },
+      schedulers: {},
+    }),
+  getTradeLifecycleActive: () =>
+    Promise.resolve([
+      {
+        tradeId: 'tl-1',
+        automationPositionId: 'pos-1',
+        automationSessionId: 'sess-1',
+        strategyVersionId: 'sv-lifecycle',
+        underlying: 'SPY',
+        optionSymbol: 'SPY260821C00450000',
+        state: 'MONITORING',
+        previousState: 'ENTRY_FILLED',
+        entryIntentId: 'entry-1',
+        exitIntentId: null,
+        riskDecisionId: 'risk-1',
+        recommendationId: 'rec-1',
+        evaluationReportId: null,
+        confidence: { entry: 82, current: 91, trend: 'Improving', delta: 9 },
+        currentAction: 'HOLD',
+        reasoning: ['Confidence trend is Improving.'],
+        exitReason: null,
+        evaluationSummary: null,
+        lastEvaluatedAt: new Date().toISOString(),
+        nextEvaluationAt: new Date().toISOString(),
+        archivedAt: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    ]),
+  getTradeLifecyclePending: () => Promise.resolve([]),
+  getTradeLifecycleHistory: () => Promise.resolve([]),
+  getTradeLifecycleTimeline: () =>
+    Promise.resolve([
+      {
+        tradeId: 'tl-1',
+        at: new Date().toISOString(),
+        eventType: 'MONITORING_DECISION',
+        state: 'MONITORING',
+      },
+    ]),
+}));
+
+afterEach(() => cleanup());
+
+describe('TradeLifecyclePanel', () => {
+  it('renders the operator lifecycle view inside Automation', async () => {
+    render(<TradeLifecyclePanel />);
+    await waitFor(() => expect(screen.getByText('Trade Lifecycle')).toBeInTheDocument());
+    expect(screen.getByText('AI Status')).toBeInTheDocument();
+    expect(screen.getByText('Paper Trading')).toBeInTheDocument();
+    expect(screen.getByText('Current AI Decision')).toBeInTheDocument();
+    expect(screen.getAllByText('SPY260821C00450000').length).toBeGreaterThan(0);
+    expect(screen.getByText('Open Trades')).toBeInTheDocument();
+    expect(screen.getByText('Pending Trades')).toBeInTheDocument();
+    expect(screen.getByText('Rejected')).toBeInTheDocument();
+    expect(screen.getByText('Activity Timeline')).toBeInTheDocument();
+  });
+});

--- a/client/src/__tests__/vercelObservability.test.ts
+++ b/client/src/__tests__/vercelObservability.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import mainSource from '../main.tsx?raw';
+
+const trackMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@vercel/analytics', () => ({
+  track: trackMock,
+}));
+
+import {
+  OPERATOR_ANALYTICS_EVENTS,
+  trackOperatorEvent,
+  trackOperatorEventOnce,
+} from '../lib/operatorAnalytics';
+
+const sourceFiles = import.meta.glob('../**/*.{ts,tsx,js,jsx}', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>;
+
+describe('Vercel observability wiring', () => {
+  const source = Object.values(sourceFiles).join('\n');
+
+  it('mounts Analytics and Speed Insights exactly once at the React root', () => {
+    expect((source.match(/<Analytics\s*\/>/g) ?? [])).toHaveLength(1);
+    expect((source.match(/<SpeedInsights\s*\/>/g) ?? [])).toHaveLength(1);
+    expect(mainSource).toContain("import { Analytics } from '@vercel/analytics/react';");
+    expect(mainSource).toContain("import { SpeedInsights } from '@vercel/speed-insights/react';");
+    expect(mainSource).toContain('<React.StrictMode>');
+  });
+
+  it('keeps custom operator analytics anonymous and allowlisted', () => {
+    expect(OPERATOR_ANALYTICS_EVENTS).toEqual([
+      'Application Loaded',
+      'Automation Viewed',
+      'Automation Started',
+      'Automation Stopped',
+      'Cockpit Viewed',
+      'AI Desk Viewed',
+      'Strategy Viewed',
+      'Risk Viewed',
+      'Trade Lifecycle Viewed',
+      'Reports Viewed',
+      'Operator Expanded Advanced Details',
+      'Shadow Mode Enabled',
+      'Paper Mode Enabled',
+    ]);
+    expect(OPERATOR_ANALYTICS_EVENTS.join(' ')).not.toMatch(/account|email|token|secret|order|price|broker/i);
+  });
+
+  it('dedupes once-per-session events and trims string properties', () => {
+    trackMock.mockClear();
+    trackOperatorEventOnce('Application Loaded', { surface: 'desktop' });
+    trackOperatorEventOnce('Application Loaded', { surface: 'desktop' });
+    trackOperatorEvent('Cockpit Viewed', { surface: 'x'.repeat(100) });
+
+    expect(trackMock).toHaveBeenCalledTimes(2);
+    expect(trackMock).toHaveBeenNthCalledWith(1, 'Application Loaded', { surface: 'desktop' });
+    expect(trackMock).toHaveBeenNthCalledWith(2, 'Cockpit Viewed', { surface: 'x'.repeat(80) });
+  });
+});

--- a/client/src/api/autonomousTrading.ts
+++ b/client/src/api/autonomousTrading.ts
@@ -1,0 +1,133 @@
+import { http } from './http';
+
+export type AutonomousOperatorStatus = {
+  generatedAt: string;
+  status: 'Running' | 'Paused' | 'Stopped' | 'Degraded';
+  mode: 'Manual' | 'Shadow' | 'Autonomous Paper';
+  modeBanner: string;
+  market: string;
+  broker: 'Alpaca Paper';
+  automationOwner: 'Owned' | 'Not Owned' | 'Unknown';
+  marketData: 'Live' | 'Delayed' | 'Stale' | 'Unavailable';
+  nextEvaluationAt: string | null;
+  emergencyStop: 'Active' | 'Inactive' | 'Unknown';
+  watching: string[];
+  currentActivity: string;
+  latestPipelineId: string | null;
+  featureFlags: Record<string, boolean | string>;
+};
+
+export type AutonomousPipeline = {
+  pipelineId: string;
+  state: string;
+  mode: string;
+  symbol: string | null;
+  optionContract: string | null;
+  plainLanguageStatus: string;
+  blockingReasons: string[];
+  eventContext: Record<string, unknown>;
+  decisionContext: Record<string, unknown>;
+  strategyContext: Record<string, unknown>;
+  riskContext: Record<string, unknown>;
+  lifecycleContext: Record<string, unknown>;
+  executionContext: Record<string, unknown>;
+  evaluationContext: Record<string, unknown>;
+  timeline: Array<Record<string, unknown>>;
+};
+
+export type AutonomousRecentDecision = {
+  time: string;
+  symbol: string | null;
+  action: string;
+  subsystem: string;
+  reason: string;
+  pipelineId: string | null;
+};
+
+export type AutonomousTimelineEvent = {
+  at: string;
+  pipelineId: string | null;
+  symbol: string | null;
+  event: string;
+  actor: string;
+  reason: string;
+  state: string | null;
+  relatedRecords: Array<Record<string, unknown>>;
+};
+
+export type AutonomousHealthResponse = {
+  overall: 'HEALTHY' | 'DEGRADED' | 'BLOCKED' | 'STOPPED';
+  generatedAt: string;
+  explanation: string;
+  services: Array<{
+    name: string;
+    status: string;
+    dataTimestamp: string | null;
+    stale: boolean;
+    staleReason: string | null;
+    lastError: string | null;
+    featureEnabled: boolean;
+    ownerStatus: string | null;
+  }>;
+};
+
+export type AutonomousActiveResponse = {
+  trades: Array<Record<string, unknown>>;
+  positions: Array<Record<string, unknown>>;
+};
+
+export type AutonomousPendingResponse = {
+  trades: Array<Record<string, unknown>>;
+  intents: Array<Record<string, unknown>>;
+  current: {
+    symbol: string | null;
+    contract: string | null;
+    recommendation: string | null;
+    winningStrategy: string | null;
+    evidenceScore: number | null;
+    riskStatus: string;
+    entryStatus: string;
+    blockingReason: string | null;
+    ageSeconds: number;
+  } | null;
+};
+
+export async function getAutonomousTradingStatus(): Promise<AutonomousOperatorStatus | null> {
+  const { data } = await http.get<{ status: AutonomousOperatorStatus }>('/api/autonomous-trading/status');
+  return data.status ?? null;
+}
+
+export async function getAutonomousTradingCurrent(): Promise<AutonomousPipeline | null> {
+  const { data } = await http.get<{ pipeline: AutonomousPipeline }>('/api/autonomous-trading/current');
+  return data.pipeline ?? null;
+}
+
+export async function getAutonomousTradingActive(): Promise<AutonomousActiveResponse> {
+  const { data } = await http.get<AutonomousActiveResponse>('/api/autonomous-trading/active');
+  return { trades: data.trades ?? [], positions: data.positions ?? [] };
+}
+
+export async function getAutonomousTradingPending(): Promise<AutonomousPendingResponse> {
+  const { data } = await http.get<AutonomousPendingResponse>('/api/autonomous-trading/pending');
+  return { trades: data.trades ?? [], intents: data.intents ?? [], current: data.current ?? null };
+}
+
+export async function getAutonomousTradingRecentDecisions(limit = 8): Promise<AutonomousRecentDecision[]> {
+  const { data } = await http.get<{ decisions: AutonomousRecentDecision[] }>('/api/autonomous-trading/recent-decisions', {
+    params: { limit },
+  });
+  return data.decisions ?? [];
+}
+
+export async function getAutonomousTradingTimeline(limit = 8): Promise<AutonomousTimelineEvent[]> {
+  const { data } = await http.get<{ events: AutonomousTimelineEvent[] }>('/api/autonomous-trading/timeline', {
+    params: { limit },
+  });
+  return data.events ?? [];
+}
+
+export async function getAutonomousTradingHealth(): Promise<AutonomousHealthResponse | null> {
+  const { data } = await http.get<AutonomousHealthResponse>('/api/autonomous-trading/health');
+  return data ?? null;
+}
+

--- a/client/src/api/decisionEngine.ts
+++ b/client/src/api/decisionEngine.ts
@@ -1,0 +1,70 @@
+import { http } from './http';
+
+export type ExplainedDecisionScore = {
+  key: string;
+  score: number;
+  maxScore: number;
+  grade: 'STRONG' | 'ACCEPTABLE' | 'WEAK' | 'UNAVAILABLE';
+  explanation: string;
+  inputs: Record<string, number | string | boolean | null>;
+};
+
+export type DecisionEngineCandidate = {
+  id: string;
+  symbol: string;
+  contract: {
+    symbol: string;
+    type: 'call' | 'put';
+    strike: number | null;
+    expiration: string | null;
+    bid: number | null;
+    ask: number | null;
+    mid: number | null;
+    spreadPct: number | null;
+    volume: number | null;
+    openInterest: number | null;
+    iv: number | null;
+    delta: number | null;
+  };
+  confidence: number;
+  overallScore: number;
+  recommendation: 'BUY_CALL' | 'BUY_PUT' | 'WATCH' | 'AVOID';
+  thesis: string;
+  rejectionCodes: string[];
+  rejectionExplanation: string | null;
+  scores: Record<string, ExplainedDecisionScore>;
+};
+
+export type DecisionEngineRejectedCandidate = {
+  candidate: DecisionEngineCandidate;
+  reasonCode: string;
+  explanation: string;
+};
+
+export type DecisionEngineScan = {
+  scanId: string;
+  timestamp: string;
+  watchlist: string[];
+  candidates: DecisionEngineCandidate[];
+  ranking: {
+    bestOpportunity: DecisionEngineCandidate | null;
+    secondBest: DecisionEngineCandidate | null;
+    thirdBest: DecisionEngineCandidate | null;
+    top10: DecisionEngineCandidate[];
+    rejectedCandidates: DecisionEngineRejectedCandidate[];
+  };
+  winner: DecisionEngineCandidate | null;
+  rejections: DecisionEngineRejectedCandidate[];
+  noTradeReason: string | null;
+  schemaVersion: number;
+};
+
+export async function getLatestDecisionEngineScan(): Promise<DecisionEngineScan | null> {
+  try {
+    const res = await http.get('/api/decision-engine/latest');
+    return res.data?.scan ?? null;
+  } catch (error: any) {
+    if (error?.response?.status === 404) return null;
+    throw error;
+  }
+}

--- a/client/src/api/eventIntelligence.ts
+++ b/client/src/api/eventIntelligence.ts
@@ -1,0 +1,64 @@
+import { http } from './http';
+
+export type EventIntelligenceRecord = {
+  event: {
+    id: string;
+    timestamp: string;
+    title: string;
+    summary: string | null;
+    category: string;
+    sentiment: { label: 'bullish' | 'bearish' | 'neutral' | 'unknown'; score: number | null; explanation: string | null };
+    symbols: string[];
+    sectors: string[];
+    confidence: number;
+    importance: number;
+    importanceExplanation: string;
+    source: string | null;
+    url: string | null;
+  };
+  impact: {
+    potentialBullishImpact: string[];
+    potentialBearishImpact: string[];
+    affectedSymbols: string[];
+    affectedEtfs: string[];
+    affectedSectors: string[];
+    affectedCommodities: string[];
+    confidence: number;
+    importance: number;
+    explanation: string;
+  };
+  historicalSimilarity: {
+    previousTrades: number;
+    historicalWinRate: number | null;
+    averageHoldingTimeMinutes: number | null;
+    averageReturn: number | null;
+    explanation: string;
+  };
+  decisionTrigger: {
+    triggered: boolean;
+    status: string;
+    triggeredAt: string | null;
+    decisionScanId: string | null;
+  };
+  createdAt: string;
+};
+
+export type EventMarketContext = {
+  generatedAt: string;
+  highImportanceEvents: EventIntelligenceRecord[];
+  affectedSymbols: string[];
+  affectedEtfs: string[];
+  affectedSectors: string[];
+  sentiment: { bullish: number; bearish: number; neutral: number };
+  latestTrigger: EventIntelligenceRecord['decisionTrigger'] | null;
+};
+
+export async function getEventIntelligenceContext(): Promise<EventMarketContext | null> {
+  try {
+    const res = await http.get('/api/event-intelligence/context');
+    return res.data?.context ?? null;
+  } catch (error: any) {
+    if (error?.response?.status === 404) return null;
+    throw error;
+  }
+}

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -7,3 +7,5 @@ export * as futuresApi from './futures';
 export * as agentApi from './agent';
 export * as portfolioApi from './portfolio';
 export * as intelligenceApi from './intelligence';
+export * as tradeLifecycleApi from './tradeLifecycle';
+export * as systemApi from './system';

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -9,3 +9,4 @@ export * as portfolioApi from './portfolio';
 export * as intelligenceApi from './intelligence';
 export * as tradeLifecycleApi from './tradeLifecycle';
 export * as systemApi from './system';
+export * as learningApi from './learning';

--- a/client/src/api/learning.ts
+++ b/client/src/api/learning.ts
@@ -1,0 +1,116 @@
+import { http } from './http';
+
+export type LearningStatus = {
+  status: string;
+  generatedAt: string;
+  completedTrades: number;
+  tradeReviews: number;
+  datasets: number;
+  pendingReviews: number;
+  pendingDatasets: number;
+  latestReviewAt: string | null;
+  explanation: string;
+};
+
+export type LearningTradeReview = {
+  reviewId: string;
+  sourceTradeId: string;
+  entryTimestamp: string | null;
+  exitTimestamp: string | null;
+  entryStrategy: string | null;
+  winningStrategy: string | null;
+  marketRegime: string | null;
+  sector: string | null;
+  symbol: string | null;
+  direction: string | null;
+  confidence: number | null;
+  evidenceScore: number | null;
+  riskScore: number | null;
+  actualReturn: number | null;
+  realizedPnl: number | null;
+  outcome: string;
+  whySucceeded: string[];
+  whyFailed: string[];
+  whatCouldImprove: string[];
+};
+
+export type LearningScorecard = {
+  key: string;
+  window: string;
+  totalTrades: number;
+  wins: number;
+  losses: number;
+  winRate: number | null;
+  averageReturn: number | null;
+  medianReturn: number | null;
+  averageHoldTimeMinutes: number | null;
+  averageRisk: number | null;
+  largestWinner: number | null;
+  largestLoser: number | null;
+  sharpe: number | null;
+  maxDrawdown: number | null;
+};
+
+export type LearningCalibrationBucket = {
+  confidenceBand: string;
+  totalTrades: number;
+  predictedConfidence: number | null;
+  actualSuccessRate: number | null;
+  historicalAccuracy: number | null;
+  calibrationError: number | null;
+  verdict: string;
+};
+
+export type LearningRegime = LearningScorecard;
+
+export type LearningEvent = {
+  event: string;
+  trades: number;
+  winRate: number | null;
+  averageReturn: number | null;
+  topStrategies: Array<{ strategy: string; trades: number }>;
+};
+
+export type LearningDataset = {
+  datasetId: string;
+  sourceTradeId: string;
+  sourceReportId: string;
+  version: string;
+  generatedAt: string;
+  outcome: { label: string; actualReturn: number | null; realizedPnl: number | null };
+};
+
+export async function getStatus(): Promise<LearningStatus> {
+  const { data } = await http.get<LearningStatus>('/api/learning/status');
+  return data;
+}
+
+export async function getTrades(limit = 20): Promise<LearningTradeReview[]> {
+  const { data } = await http.get<{ reviews: LearningTradeReview[] }>('/api/learning/trades', { params: { limit } });
+  return data.reviews;
+}
+
+export async function getScorecards(): Promise<LearningScorecard[]> {
+  const { data } = await http.get<{ scorecards: LearningScorecard[] }>('/api/learning/scorecards');
+  return data.scorecards;
+}
+
+export async function getCalibration(): Promise<LearningCalibrationBucket[]> {
+  const { data } = await http.get<{ buckets: LearningCalibrationBucket[] }>('/api/learning/calibration');
+  return data.buckets;
+}
+
+export async function getRegimes(): Promise<LearningRegime[]> {
+  const { data } = await http.get<{ regimes: LearningRegime[] }>('/api/learning/regimes');
+  return data.regimes;
+}
+
+export async function getEvents(): Promise<LearningEvent[]> {
+  const { data } = await http.get<{ events: LearningEvent[] }>('/api/learning/events');
+  return data.events;
+}
+
+export async function getDatasets(limit = 20): Promise<LearningDataset[]> {
+  const { data } = await http.get<{ datasets: LearningDataset[] }>('/api/learning/datasets', { params: { limit } });
+  return data.datasets;
+}

--- a/client/src/api/riskEngine.ts
+++ b/client/src/api/riskEngine.ts
@@ -1,0 +1,61 @@
+import { http } from './http';
+
+export type RiskEngineStatus = {
+  enabled: boolean;
+  approvalRequired: boolean;
+  latestApprovalId: string | null;
+  latestStatus: 'APPROVE' | 'REJECT' | null;
+  pendingRecommendations: number;
+  portfolioHeat: number;
+  ruleVersion: string;
+};
+
+export type RiskPortfolio = {
+  portfolioSize: number;
+  buyingPower: number | null;
+  exposure: {
+    sectorExposure: Record<string, number>;
+    currentOpenTrades: number;
+    maximumConcurrentTrades: number;
+  };
+  greeks: { delta: number | null; gamma: number | null; theta: number | null; vega: number | null; rho: number | null };
+  riskBudget: {
+    riskConsumed: number;
+    remainingRiskBudget: number;
+    openRisk: number;
+    maximumOpenRisk: number;
+  };
+};
+
+export type RiskApprovalRecord = {
+  approvalId: string;
+  timestamp: string;
+  approval: {
+    approved: boolean;
+    status: 'APPROVE' | 'REJECT';
+    reasons: Array<{ code: string; explanation: string }>;
+    warnings: string[];
+  };
+};
+
+export type RiskEngineSnapshot = {
+  status: RiskEngineStatus;
+  portfolio: RiskPortfolio;
+  history: RiskApprovalRecord[];
+  queue: { pending: unknown[] };
+};
+
+export async function getRiskEngineSnapshot(): Promise<RiskEngineSnapshot> {
+  const [status, portfolio, history, queue] = await Promise.all([
+    http.get('/api/risk-engine/status'),
+    http.get('/api/risk-engine/portfolio'),
+    http.get('/api/risk-engine/history?limit=5'),
+    http.get('/api/risk-engine/approval-queue'),
+  ]);
+  return {
+    status: status.data.status,
+    portfolio: portfolio.data.portfolio,
+    history: history.data.history ?? [],
+    queue: queue.data.queue ?? { pending: [] },
+  };
+}

--- a/client/src/api/strategyOrchestrator.ts
+++ b/client/src/api/strategyOrchestrator.ts
@@ -1,0 +1,46 @@
+import { http } from './http';
+
+export type StrategyOrchestratorRun = {
+  runId: string;
+  timestamp: string;
+  rankings: Array<{
+    strategyId: string;
+    name: string;
+    score: number;
+    confidence: number;
+    evidenceScore: number;
+    rejected: boolean;
+    rejectionReason: string | null;
+  }>;
+  winner: { strategyId: string; name: string; score: number; confidence: number; evidenceScore: number } | null;
+  conflicts: {
+    hasConflict: boolean;
+    bullishStrategies: string[];
+    bearishStrategies: string[];
+    confidenceAdjustment: number;
+    recommendedAction: string;
+    explanation: string;
+  };
+  recommendation: {
+    action: 'BUY' | 'WATCH' | 'WAIT' | 'SKIP' | 'NO_TRADE';
+    explanation: string;
+    confidence: number;
+    supportingStrategies: StrategyOrchestratorRun['rankings'];
+    rejectedStrategies: StrategyOrchestratorRun['rankings'];
+    evidence: { score: number; explanation: string; components: Record<string, number> };
+    riskHandoff: { allowedForRiskReview: boolean; message: string; packageId: string };
+  };
+  evidence: { score: number; explanation: string; components: Record<string, number> };
+  marketContext: { regime: { current: string; confidence: number; explanation: string }; marketStatus: string };
+  portfolioContext: { adjustmentExplanation: string; sectorExposure: Record<string, number>; openRisk: number | null };
+};
+
+export async function getLatestStrategyRecommendation(): Promise<StrategyOrchestratorRun | null> {
+  try {
+    const res = await http.get('/api/strategy-orchestrator/recommendations');
+    return res.data?.run ?? null;
+  } catch (error: any) {
+    if (error?.response?.status === 404) return null;
+    throw error;
+  }
+}

--- a/client/src/api/system.ts
+++ b/client/src/api/system.ts
@@ -1,0 +1,65 @@
+import { http } from './http';
+
+export type SystemStatusResponse = {
+  status: 'RUNNING' | 'DEGRADED' | 'BLOCKED' | 'STOPPED';
+  generatedAt: string;
+  summary: string;
+  system: {
+    mongo: string;
+    automation: string;
+    scheduler: string;
+    monitor: string;
+    brokerTruthCurrent: boolean;
+    mode: string | null;
+    market: string | null;
+    emergencyStop: string | null;
+    nextEvaluationAt: string | null;
+  };
+  components: Array<{
+    name: string;
+    status: string;
+    stale: boolean;
+    staleReason: string | null;
+    lastError: string | null;
+  }>;
+};
+
+export type SystemMetricsResponse = {
+  generatedAt: string;
+  process: {
+    uptimeSec: number;
+    memoryRss: number;
+    memoryHeapUsed: number;
+    memoryHeapTotal: number;
+  };
+  marketData: {
+    queueDepth: number;
+    activeRequests: number;
+    inflightDeduped: number;
+    deduplicatedRequests: number;
+    responseCacheEntries: number;
+    chartFeeds: number;
+  };
+  automation: {
+    schedulerState: string;
+    monitorState: string;
+    schedulerLastTickAt: string | null;
+    monitorLastTickAt: string | null;
+    schedulerSubmittedCount: number;
+    schedulerSkipReasons: Record<string, number>;
+  };
+  autonomousTrading: Array<Record<string, unknown>>;
+};
+
+export async function getSystemStatus(): Promise<SystemStatusResponse> {
+  const { data } = await http.get<SystemStatusResponse>('/api/system/status', {
+    validateStatus: status => (status >= 200 && status < 300) || status === 503,
+  });
+  return data;
+}
+
+export async function getSystemMetrics(): Promise<SystemMetricsResponse> {
+  const { data } = await http.get<SystemMetricsResponse>('/api/system/metrics');
+  return data;
+}
+

--- a/client/src/api/tradeLifecycle.ts
+++ b/client/src/api/tradeLifecycle.ts
@@ -1,0 +1,95 @@
+import { http } from './http';
+
+export type TradeLifecycleRecord = {
+  tradeId: string;
+  automationPositionId: string | null;
+  automationSessionId: string | null;
+  strategyVersionId: string | null;
+  underlying: string;
+  optionSymbol: string;
+  state: string;
+  previousState: string | null;
+  entryIntentId: string | null;
+  exitIntentId: string | null;
+  riskDecisionId: string | null;
+  recommendationId: string | null;
+  evaluationReportId: string | null;
+  confidence: {
+    entry: number | null;
+    current: number | null;
+    trend: string;
+    delta: number | null;
+  };
+  currentAction: string;
+  reasoning: string[];
+  exitReason: string | null;
+  evaluationSummary: Record<string, unknown> | null;
+  lastEvaluatedAt: string | null;
+  nextEvaluationAt: string | null;
+  archivedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type TradeLifecycleStatus = {
+  generatedAt: string;
+  flags: Record<string, boolean>;
+  aiStatus: string;
+  paperTrading: boolean;
+  market: string;
+  currentStrategy: string | null;
+  currentRegime: string | null;
+  nextEvaluation: string | null;
+  currentDecision: {
+    watching: string;
+    recommendation: string;
+    confidence: number | null;
+    reason: string;
+  } | null;
+  counts: Record<string, number>;
+  schedulers: Record<string, unknown>;
+};
+
+export type TradeLifecycleEvent = {
+  tradeId?: string;
+  at?: string;
+  timestamp?: string;
+  eventType?: string;
+  event?: string;
+  state?: string;
+  previousState?: string | null;
+  source?: string;
+  service?: string;
+  reason?: string;
+  symbol?: string | null;
+  payload?: Record<string, unknown>;
+};
+
+export async function getTradeLifecycleStatus(): Promise<TradeLifecycleStatus> {
+  const { data } = await http.get<TradeLifecycleStatus>('/api/trade-lifecycle/status');
+  return data;
+}
+
+export async function getTradeLifecycleActive(): Promise<TradeLifecycleRecord[]> {
+  const { data } = await http.get<{ trades: TradeLifecycleRecord[] }>('/api/trade-lifecycle/active');
+  return data.trades ?? [];
+}
+
+export async function getTradeLifecyclePending(): Promise<TradeLifecycleRecord[]> {
+  const { data } = await http.get<{ trades: TradeLifecycleRecord[] }>('/api/trade-lifecycle/pending');
+  return data.trades ?? [];
+}
+
+export async function getTradeLifecycleHistory(limit = 50): Promise<TradeLifecycleRecord[]> {
+  const { data } = await http.get<{ trades: TradeLifecycleRecord[] }>('/api/trade-lifecycle/history', {
+    params: { limit },
+  });
+  return data.trades ?? [];
+}
+
+export async function getTradeLifecycleTimeline(limit = 60): Promise<TradeLifecycleEvent[]> {
+  const { data } = await http.get<{ events: TradeLifecycleEvent[] }>('/api/trade-lifecycle/timeline', {
+    params: { limit },
+  });
+  return data.events ?? [];
+}

--- a/client/src/components/cockpit/AutonomousTraderPanel.tsx
+++ b/client/src/components/cockpit/AutonomousTraderPanel.tsx
@@ -222,7 +222,7 @@ export function AutonomousTraderPanel() {
 
         <section className="grid min-w-0 grid-cols-1 gap-3 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
           <div>
-            <h4 className="mb-2 font-mono text-[10px] font-semibold uppercase tracking-label text-intel-ink3">Controls and Safety</h4>
+            <h4 className="mb-2 font-mono text-[10px] font-semibold uppercase tracking-label text-intel-ink3">Controls and Safety (reference)</h4>
             <div className="flex flex-wrap gap-2">
               <ControlHint icon={<Pause className="h-3.5 w-3.5" />} label="Pause Evaluations" />
               <ControlHint icon={<Play className="h-3.5 w-3.5" />} label="Resume Evaluations" />
@@ -231,7 +231,7 @@ export function AutonomousTraderPanel() {
               <ControlHint icon={<XCircle className="h-3.5 w-3.5" />} label="Emergency Stop" />
             </div>
             <p className="mt-2 text-xs text-intel-ink3">
-              Only safe existing automation mutations should be wired here. Live-money controls are not available.
+              These are read-only indicators. Live actions (Pause, Resume, Emergency Stop) are operated from Mission Control at the top of the cockpit. Live-money controls are not available.
             </p>
           </div>
           <div className="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-2">
@@ -328,7 +328,10 @@ function DetailBlock({ title, data }: { title: string; data: Record<string, unkn
 
 function ControlHint({ icon, label }: { icon: ReactNode; label: string }) {
   return (
-    <span className="inline-flex items-center gap-1.5 rounded-md bg-intel-panel2 px-2 py-1 text-xs font-semibold text-intel-ink2">
+    <span
+      className="inline-flex cursor-default items-center gap-1.5 rounded-md border border-dashed border-intel-line px-2 py-1 text-xs font-medium text-intel-ink3"
+      aria-disabled="true"
+    >
       {icon}
       {label}
     </span>

--- a/client/src/components/cockpit/AutonomousTraderPanel.tsx
+++ b/client/src/components/cockpit/AutonomousTraderPanel.tsx
@@ -1,0 +1,333 @@
+import { useEffect, useState, type ReactNode } from 'react';
+import { AlertTriangle, Info, Pause, Play, ShieldAlert, Square, XCircle } from 'lucide-react';
+import {
+  getAutonomousTradingActive,
+  getAutonomousTradingCurrent,
+  getAutonomousTradingHealth,
+  getAutonomousTradingPending,
+  getAutonomousTradingRecentDecisions,
+  getAutonomousTradingStatus,
+  getAutonomousTradingTimeline,
+  type AutonomousActiveResponse,
+  type AutonomousHealthResponse,
+  type AutonomousOperatorStatus,
+  type AutonomousPendingResponse,
+  type AutonomousPipeline,
+  type AutonomousRecentDecision,
+  type AutonomousTimelineEvent,
+} from '../../api/autonomousTrading';
+import { Panel, Pill } from './cockpitUi';
+
+type Snapshot = {
+  status: AutonomousOperatorStatus | null;
+  current: AutonomousPipeline | null;
+  active: AutonomousActiveResponse;
+  pending: AutonomousPendingResponse;
+  recent: AutonomousRecentDecision[];
+  timeline: AutonomousTimelineEvent[];
+  health: AutonomousHealthResponse | null;
+};
+
+const EMPTY: Snapshot = {
+  status: null,
+  current: null,
+  active: { trades: [], positions: [] },
+  pending: { trades: [], intents: [], current: null },
+  recent: [],
+  timeline: [],
+  health: null,
+};
+
+function toneFor(value: string | null | undefined): 'good' | 'warn' | 'bad' | 'neutral' {
+  const normalized = String(value ?? '').toUpperCase();
+  if (['RUNNING', 'OPEN', 'OWNED', 'LIVE', 'INACTIVE', 'HEALTHY', 'APPROVED'].includes(normalized)) return 'good';
+  if (['SHADOW', 'PAUSED', 'CLOSED', 'PRE-MARKET', 'AFTER-HOURS', 'STALE', 'DEGRADED', 'WAITING', 'PENDING'].includes(normalized)) return 'warn';
+  if (['STOPPED', 'BLOCKED', 'ACTIVE', 'UNAVAILABLE', 'REJECTED'].includes(normalized)) return 'bad';
+  return 'neutral';
+}
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return 'Not scheduled';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString(undefined, { weekday: 'short', hour: 'numeric', minute: '2-digit' });
+}
+
+function asText(value: unknown): string {
+  if (value == null || value === '') return 'Not available';
+  if (typeof value === 'number') return Number.isInteger(value) ? String(value) : value.toFixed(2);
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  return String(value);
+}
+
+export function AutonomousTraderPanel() {
+  const [snapshot, setSnapshot] = useState<Snapshot>(EMPTY);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const [status, current, active, pending, recent, timeline, health] = await Promise.all([
+          getAutonomousTradingStatus(),
+          getAutonomousTradingCurrent(),
+          getAutonomousTradingActive(),
+          getAutonomousTradingPending(),
+          getAutonomousTradingRecentDecisions(6),
+          getAutonomousTradingTimeline(8),
+          getAutonomousTradingHealth(),
+        ]);
+        if (!cancelled) {
+          setSnapshot({ status, current, active, pending, recent, timeline, health });
+          setError(null);
+        }
+      } catch (err: any) {
+        if (!cancelled) setError(String(err?.response?.data?.error ?? err?.message ?? err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    const id = window.setInterval(load, 30_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, []);
+
+  const status = snapshot.status;
+  const current = snapshot.current;
+  const pendingCurrent = snapshot.pending.current;
+  const activeTrades = snapshot.active.trades;
+
+  return (
+    <Panel
+      title="Autonomous Trader"
+      badge={status ? <Pill tone={toneFor(status.status)} dot>{status.status}</Pill> : <Pill tone="neutral">Loading</Pill>}
+      className="bg-intel-panel"
+    >
+      <div data-testid="autonomous-trader-panel" className="flex min-w-0 flex-col gap-4">
+        {error ? (
+          <div className="flex items-center gap-2 rounded-md bg-intel-neg/10 px-3 py-2 text-xs text-intel-neg">
+            <AlertTriangle className="h-4 w-4 shrink-0" />
+            Autonomous status is unavailable: {error}
+          </div>
+        ) : null}
+
+        <div className="grid min-w-0 grid-cols-2 gap-2 md:grid-cols-4 xl:grid-cols-8">
+          <StatusTile label="Status" value={status?.status ?? (loading ? 'Loading' : 'Unavailable')} />
+          <StatusTile label="Mode" value={status?.mode ?? 'Unknown'} />
+          <StatusTile label="Market" value={status?.market ?? 'Unknown'} />
+          <StatusTile label="Broker" value={status?.broker ?? 'Alpaca Paper'} />
+          <StatusTile label="Owner" value={status?.automationOwner ?? 'Unknown'} />
+          <StatusTile label="Market Data" value={status?.marketData ?? 'Unavailable'} />
+          <StatusTile label="Next Evaluation" value={formatDate(status?.nextEvaluationAt)} />
+          <StatusTile label="Emergency Stop" value={status?.emergencyStop ?? 'Unknown'} />
+        </div>
+
+        <div className="rounded-md bg-intel-panel2 px-3 py-2 text-xs font-semibold uppercase tracking-label text-intel-ink">
+          {status?.modeBanner ?? 'SHADOW MODE - No broker orders will be submitted.'}
+        </div>
+
+        <section className="grid min-w-0 grid-cols-1 gap-3 xl:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]">
+          <div className="min-w-0">
+            <h4 className="mb-2 font-mono text-[10px] font-semibold uppercase tracking-label text-intel-ink3">Current AI Activity</h4>
+            <p className="text-sm leading-6 text-intel-ink2">
+              {status?.currentActivity ?? 'No current autonomous activity is available. The system is waiting for the next Decision Intelligence scan.'}
+            </p>
+          </div>
+          <div className="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-2">
+            <SummaryBlock label="Watching" value={status?.watching?.length ? status.watching.join(', ') : 'No configured symbols'} />
+            <SummaryBlock label="Leading Strategy" value={asText(current?.strategyContext?.winningStrategy)} />
+            <SummaryBlock label="Risk Review" value={asText(pendingCurrent?.riskStatus ?? current?.riskContext?.approved)} />
+            <SummaryBlock label="Entry Status" value={asText(pendingCurrent?.entryStatus ?? current?.executionContext?.status)} />
+          </div>
+        </section>
+
+        <section className="grid min-w-0 grid-cols-1 gap-3 xl:grid-cols-2">
+          <FeedPanel title="Active Trades" empty="No active autonomous trades are being managed.">
+            {activeTrades.slice(0, 4).map((trade, index) => (
+              <TradeRow key={String(trade.tradeId ?? trade.contract ?? index)} trade={trade} />
+            ))}
+          </FeedPanel>
+          <FeedPanel title="Pending Trades" empty={pendingCurrent ? null : 'No pending autonomous entry is available.'}>
+            {pendingCurrent ? (
+              <div className="rounded-md bg-intel-panel2 p-3 text-xs text-intel-ink2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-semibold text-intel-ink">{pendingCurrent.contract ?? pendingCurrent.symbol ?? 'Current opportunity'}</span>
+                  <Pill tone={toneFor(pendingCurrent.riskStatus)}>{pendingCurrent.riskStatus}</Pill>
+                  <Pill tone={toneFor(pendingCurrent.entryStatus)}>{pendingCurrent.entryStatus}</Pill>
+                </div>
+                <p className="mt-2">{pendingCurrent.blockingReason ?? pendingCurrent.winningStrategy ?? 'Waiting for the next pipeline handoff.'}</p>
+              </div>
+            ) : null}
+          </FeedPanel>
+        </section>
+
+        <section className="grid min-w-0 grid-cols-1 gap-3 xl:grid-cols-2">
+          <FeedPanel title="Recent Decisions" empty="No recent decisions have been journaled.">
+            {snapshot.recent.map((item, index) => (
+              <div key={`${item.time}-${index}`} className="rounded-md bg-intel-panel2 p-3 text-xs">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-intel-ink3">{formatDate(item.time)}</span>
+                  <Pill tone={toneFor(item.action)}>{item.action}</Pill>
+                  <span className="font-semibold text-intel-ink">{item.symbol ?? item.subsystem}</span>
+                </div>
+                <p className="mt-1 text-intel-ink2">{item.reason}</p>
+              </div>
+            ))}
+          </FeedPanel>
+          <FeedPanel title="System Activity Timeline" empty="No autonomous activity timeline is available.">
+            {snapshot.timeline.map((item, index) => (
+              <div key={`${item.at}-${index}`} className="border-l border-intel-divider pl-3 text-xs">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-intel-ink3">{formatDate(item.at)}</span>
+                  <span className="font-semibold text-intel-ink">{item.event}</span>
+                </div>
+                <p className="mt-1 text-intel-ink2">{item.reason}</p>
+              </div>
+            ))}
+          </FeedPanel>
+        </section>
+
+        <details className="group rounded-md bg-intel-panel2 p-3" data-testid="autonomous-details">
+          <summary className="cursor-pointer font-mono text-[10px] font-semibold uppercase tracking-label text-intel-ink3">
+            Expandable Intelligence Details
+          </summary>
+          <div className="mt-3 grid min-w-0 grid-cols-1 gap-3 lg:grid-cols-3">
+            <DetailBlock title="Why this decision?" data={current?.decisionContext} />
+            <DetailBlock title="Event evidence" data={current?.eventContext} />
+            <DetailBlock title="Strategy rankings" data={current?.strategyContext} />
+            <DetailBlock title="Risk review" data={current?.riskContext} />
+            <DetailBlock title="Lifecycle timeline" data={current?.lifecycleContext} />
+            <DetailBlock title="Execution details" data={current?.executionContext} />
+          </div>
+        </details>
+
+        <section className="grid min-w-0 grid-cols-1 gap-3 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+          <div>
+            <h4 className="mb-2 font-mono text-[10px] font-semibold uppercase tracking-label text-intel-ink3">Controls and Safety</h4>
+            <div className="flex flex-wrap gap-2">
+              <ControlHint icon={<Pause className="h-3.5 w-3.5" />} label="Pause Evaluations" />
+              <ControlHint icon={<Play className="h-3.5 w-3.5" />} label="Resume Evaluations" />
+              <ControlHint icon={<Square className="h-3.5 w-3.5" />} label="Shadow Mode" />
+              <ControlHint icon={<ShieldAlert className="h-3.5 w-3.5" />} label="Paper Entry requires confirmation" />
+              <ControlHint icon={<XCircle className="h-3.5 w-3.5" />} label="Emergency Stop" />
+            </div>
+            <p className="mt-2 text-xs text-intel-ink3">
+              Only safe existing automation mutations should be wired here. Live-money controls are not available.
+            </p>
+          </div>
+          <div className="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-2">
+            <Help label="Shadow Mode" text="The AI runs the complete trading process but does not submit broker orders." />
+            <Help label="Evidence Score" text="A combined score from events, market data, strategy agreement, and technical context." />
+            <Help label="Risk Approval" text="The Risk Engine confirms whether the recommendation fits your portfolio limits." />
+            <Help label="Lifecycle Action" text="The current action recommended for an open position, such as HOLD or EXIT." />
+          </div>
+        </section>
+
+        {snapshot.health ? (
+          <div className="rounded-md bg-intel-panel2 p-3 text-xs text-intel-ink2">
+            <div className="mb-2 flex items-center gap-2">
+              <Pill tone={toneFor(snapshot.health.overall)}>{snapshot.health.overall}</Pill>
+              <span>{snapshot.health.explanation}</span>
+            </div>
+            <div className="grid min-w-0 grid-cols-1 gap-1 sm:grid-cols-2 xl:grid-cols-4">
+              {snapshot.health.services.slice(0, 12).map((service) => (
+                <div key={service.name} className="flex items-center justify-between gap-2">
+                  <span className="truncate">{service.name}</span>
+                  <Pill tone={toneFor(service.status)}>{service.status}</Pill>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </Panel>
+  );
+}
+
+function StatusTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0 rounded-md bg-intel-panel2 p-2">
+      <div className="truncate text-[10px] uppercase tracking-widest text-intel-ink3">{label}</div>
+      <div className="mt-1 truncate text-sm font-semibold text-intel-ink">{value}</div>
+    </div>
+  );
+}
+
+function SummaryBlock({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md bg-intel-panel2 p-3">
+      <div className="text-[10px] uppercase tracking-widest text-intel-ink3">{label}</div>
+      <div className="mt-1 text-sm font-semibold text-intel-ink">{value}</div>
+    </div>
+  );
+}
+
+function FeedPanel({ title, empty, children }: { title: string; empty: string | null; children: ReactNode }) {
+  const hasChildren = Array.isArray(children) ? children.some(Boolean) : Boolean(children);
+  return (
+    <div className="min-w-0 rounded-md bg-intel-panel/60 p-3">
+      <h4 className="mb-2 font-mono text-[10px] font-semibold uppercase tracking-label text-intel-ink3">{title}</h4>
+      <div className="flex min-w-0 flex-col gap-2">{hasChildren ? children : empty ? <p className="text-xs text-intel-ink3">{empty}</p> : null}</div>
+    </div>
+  );
+}
+
+function TradeRow({ trade }: { trade: Record<string, unknown> }) {
+  return (
+    <div className="rounded-md bg-intel-panel2 p-3 text-xs text-intel-ink2">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-semibold text-intel-ink">{asText(trade.contract ?? trade.optionSymbol ?? trade.symbol)}</span>
+        <Pill tone={toneFor(String(trade.lifecycleAction ?? trade.currentAction ?? trade.lifecycleState ?? trade.state))}>
+          {asText(trade.lifecycleAction ?? trade.currentAction ?? trade.lifecycleState ?? trade.state)}
+        </Pill>
+      </div>
+      <div className="mt-2 grid grid-cols-2 gap-2">
+        <span>Entry: {asText(trade.entry)}</span>
+        <span>Mark: {asText(trade.currentMark)}</span>
+        <span>P/L: {asText(trade.pnl)}</span>
+        <span>Next: {formatDate(String(trade.nextEvaluationAt ?? ''))}</span>
+      </div>
+    </div>
+  );
+}
+
+function DetailBlock({ title, data }: { title: string; data: Record<string, unknown> | undefined }) {
+  return (
+    <div className="min-w-0 rounded-md bg-intel-panel p-3">
+      <h5 className="mb-2 text-xs font-semibold text-intel-ink">{title}</h5>
+      <dl className="space-y-1 text-xs">
+        {Object.entries(data ?? {}).slice(0, 8).map(([key, value]) => (
+          <div key={key} className="grid grid-cols-[120px_minmax(0,1fr)] gap-2">
+            <dt className="truncate text-intel-ink3">{key}</dt>
+            <dd className="truncate text-intel-ink2">{Array.isArray(value) ? value.join(', ') || 'None' : asText(value)}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+function ControlHint({ icon, label }: { icon: ReactNode; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-md bg-intel-panel2 px-2 py-1 text-xs font-semibold text-intel-ink2">
+      {icon}
+      {label}
+    </span>
+  );
+}
+
+function Help({ label, text }: { label: string; text: string }) {
+  return (
+    <div className="rounded-md bg-intel-panel2 p-3 text-xs">
+      <div className="mb-1 flex items-center gap-1 font-semibold text-intel-ink">
+        <Info className="h-3.5 w-3.5" />
+        {label}
+      </div>
+      <p className="text-intel-ink3">{text}</p>
+    </div>
+  );
+}

--- a/client/src/components/cockpit/AutonomousTraderPanel.tsx
+++ b/client/src/components/cockpit/AutonomousTraderPanel.tsx
@@ -16,6 +16,7 @@ import {
   type AutonomousRecentDecision,
   type AutonomousTimelineEvent,
 } from '../../api/autonomousTrading';
+import { trackOperatorEvent, trackOperatorEventOnce } from '../../lib/operatorAnalytics';
 import { Panel, Pill } from './cockpitUi';
 
 type Snapshot = {
@@ -100,6 +101,12 @@ export function AutonomousTraderPanel() {
   const current = snapshot.current;
   const pendingCurrent = snapshot.pending.current;
   const activeTrades = snapshot.active.trades;
+
+  useEffect(() => {
+    const mode = status?.mode?.toUpperCase();
+    if (mode === 'SHADOW') trackOperatorEventOnce('Shadow Mode Enabled');
+    if (mode === 'AUTONOMOUS PAPER' || mode === 'AUTONOMOUS_PAPER') trackOperatorEventOnce('Paper Mode Enabled');
+  }, [status?.mode]);
 
   return (
     <Panel
@@ -191,7 +198,15 @@ export function AutonomousTraderPanel() {
           </FeedPanel>
         </section>
 
-        <details className="group rounded-md bg-intel-panel2 p-3" data-testid="autonomous-details">
+        <details
+          className="group rounded-md bg-intel-panel2 p-3"
+          data-testid="autonomous-details"
+          onToggle={event => {
+            if (event.currentTarget.open) {
+              trackOperatorEvent('Operator Expanded Advanced Details', { section: 'Autonomous Trader' });
+            }
+          }}
+        >
           <summary className="cursor-pointer font-mono text-[10px] font-semibold uppercase tracking-label text-intel-ink3">
             Expandable Intelligence Details
           </summary>

--- a/client/src/components/cockpit/CockpitLayout.tsx
+++ b/client/src/components/cockpit/CockpitLayout.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useState } from 'react';
-import { portfolioApi } from '../../api';
+import { useCallback, useEffect, useState } from 'react';
+import { portfolioApi, systemApi } from '../../api';
 import type { AutomationVisibility, AutomationVisibilityEvent } from '../../api/portfolio';
 import { useAutomationVisibility } from '../../hooks/useAutomationVisibility';
 import { CockpitWorkspace } from './CockpitWorkspace';
 import { Panel, Pill, selectActiveTrade, statusTone } from './cockpitUi';
 import { statusOrReason } from './cockpitDisplay';
+import { TradeLifecyclePanel } from './TradeLifecyclePanel';
 
 function HealthItem({ label, value, healthy }: { label: string; value: string; healthy: boolean }) {
   return (
@@ -297,6 +298,86 @@ function TodayPanel({ visibility }: { visibility: AutomationVisibility | null })
   );
 }
 
+function SystemOperationsPanel() {
+  const [status, setStatus] = useState<systemApi.SystemStatusResponse | null>(null);
+  const [metrics, setMetrics] = useState<systemApi.SystemMetricsResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const [statusResult, metricsResult] = await Promise.all([
+          systemApi.getSystemStatus(),
+          systemApi.getSystemMetrics(),
+        ]);
+        if (!cancelled) {
+          setStatus(statusResult);
+          setMetrics(metricsResult);
+          setError(null);
+        }
+      } catch (err: any) {
+        if (!cancelled) setError(err?.response?.data?.error ?? err?.message ?? 'System status unavailable');
+      }
+    }
+    load();
+    const id = window.setInterval(load, 30_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, []);
+
+  const components = status?.components ?? [];
+  const blocked = components.filter((component) => component.status === 'BLOCKED');
+  const degraded = components.filter((component) => component.status === 'DEGRADED');
+  return (
+    <Panel
+      title="System Operations"
+      badge={<Pill tone={statusTone(status?.status)}>{status?.status ?? 'Loading'}</Pill>}
+    >
+      {error ? <p className="mb-2 text-xs text-intel-neg">{error}</p> : null}
+      <p className="text-sm leading-6 text-intel-ink2">
+        {status?.summary ?? 'System status is loading.'}
+      </p>
+      <div className="mt-3 grid grid-cols-2 gap-2 md:grid-cols-4">
+        <SystemMetric label="Eval Loop" value={status?.system.scheduler ?? metrics?.automation.schedulerState} />
+        <SystemMetric label="Monitor" value={status?.system.monitor ?? metrics?.automation.monitorState} />
+        <SystemMetric label="Broker Truth" value={status?.system.brokerTruthCurrent === true ? 'Current' : 'Not current'} />
+        <SystemMetric label="Queue" value={num(metrics?.marketData.queueDepth)} />
+        <SystemMetric label="Deduped" value={num(metrics?.marketData.deduplicatedRequests)} />
+        <SystemMetric label="Cache" value={num(metrics?.marketData.responseCacheEntries)} />
+        <SystemMetric label="Chart Feeds" value={num(metrics?.marketData.chartFeeds)} />
+        <SystemMetric label="Uptime" value={metrics ? `${num(metrics.process.uptimeSec)}s` : '—'} />
+      </div>
+      {(blocked.length > 0 || degraded.length > 0) && (
+        <details className="mt-3 rounded bg-intel-panel2 p-2">
+          <summary className="cursor-pointer font-mono text-[10px] uppercase tracking-label text-intel-ink3">
+            Diagnostics
+          </summary>
+          <div className="mt-2 space-y-1 text-xs text-intel-ink2">
+            {[...blocked, ...degraded].slice(0, 8).map((component) => (
+              <div key={component.name} className="flex items-center justify-between gap-3">
+                <span>{component.name}</span>
+                <span className="text-intel-ink3">{component.lastError ?? component.staleReason ?? component.status}</span>
+              </div>
+            ))}
+          </div>
+        </details>
+      )}
+    </Panel>
+  );
+}
+
+function SystemMetric({ label, value }: { label: string; value: string | null | undefined }) {
+  return (
+    <div className="min-w-0 rounded bg-intel-panel2 p-2">
+      <div className={MC_LABEL}>{label}</div>
+      <div className="mt-0.5 truncate font-mono text-xs font-semibold text-intel-ink">{value ?? '—'}</div>
+    </div>
+  );
+}
+
 /** Live automation orders at the broker (working entries/exits). */
 function PendingOrdersPanel({ visibility }: { visibility: AutomationVisibility | null }) {
   const orders: any[] = visibility?.pendingOrders ?? [];
@@ -414,10 +495,12 @@ export function CockpitLayout() {
         <DecisionPanel visibility={visibility} />
         <TodayPanel visibility={visibility} />
       </div>
+      <SystemOperationsPanel />
       <div className="grid min-w-0 grid-cols-1 gap-3 xl:grid-cols-2">
         <PendingOrdersPanel visibility={visibility} />
         <RecentActionsPanel events={events} />
       </div>
+      <TradeLifecyclePanel />
     </div>
   );
 }

--- a/client/src/components/cockpit/CockpitLayout.tsx
+++ b/client/src/components/cockpit/CockpitLayout.tsx
@@ -6,6 +6,7 @@ import { CockpitWorkspace } from './CockpitWorkspace';
 import { Panel, Pill, selectActiveTrade, statusTone } from './cockpitUi';
 import { statusOrReason } from './cockpitDisplay';
 import { TradeLifecyclePanel } from './TradeLifecyclePanel';
+import { LearningIntelligencePanel } from './LearningIntelligencePanel';
 
 function HealthItem({ label, value, healthy }: { label: string; value: string; healthy: boolean }) {
   return (
@@ -501,6 +502,7 @@ export function CockpitLayout() {
         <RecentActionsPanel events={events} />
       </div>
       <TradeLifecyclePanel />
+      <LearningIntelligencePanel />
     </div>
   );
 }

--- a/client/src/components/cockpit/CockpitLayout.tsx
+++ b/client/src/components/cockpit/CockpitLayout.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { portfolioApi, systemApi } from '../../api';
 import type { AutomationVisibility, AutomationVisibilityEvent } from '../../api/portfolio';
 import { useAutomationVisibility } from '../../hooks/useAutomationVisibility';
+import { trackOperatorEvent } from '../../lib/operatorAnalytics';
 import { CockpitWorkspace } from './CockpitWorkspace';
 import { Panel, Pill, selectActiveTrade, statusTone } from './cockpitUi';
 import { statusOrReason } from './cockpitDisplay';
@@ -91,6 +92,9 @@ function MissionControlBar({
       setActionError(null);
       try {
         await fn();
+        if (label === 'resume') trackOperatorEvent('Automation Started', { control: 'resume' });
+        if (label === 'pause') trackOperatorEvent('Automation Stopped', { control: 'pause' });
+        if (label === 'emergency-stop') trackOperatorEvent('Automation Stopped', { control: 'emergency-stop' });
         onActed();
       } catch (err: any) {
         setActionError(err?.response?.data?.error ?? err?.message ?? `${label} failed`);
@@ -352,7 +356,14 @@ function SystemOperationsPanel() {
         <SystemMetric label="Uptime" value={metrics ? `${num(metrics.process.uptimeSec)}s` : '—'} />
       </div>
       {(blocked.length > 0 || degraded.length > 0) && (
-        <details className="mt-3 rounded bg-intel-panel2 p-2">
+        <details
+          className="mt-3 rounded bg-intel-panel2 p-2"
+          onToggle={event => {
+            if (event.currentTarget.open) {
+              trackOperatorEvent('Operator Expanded Advanced Details', { section: 'System Operations Diagnostics' });
+            }
+          }}
+        >
           <summary className="cursor-pointer font-mono text-[10px] uppercase tracking-label text-intel-ink3">
             Diagnostics
           </summary>

--- a/client/src/components/cockpit/CockpitWorkspace.tsx
+++ b/client/src/components/cockpit/CockpitWorkspace.tsx
@@ -6,6 +6,11 @@ import { AutomationThinkingPanel } from './AutomationThinkingPanel';
 import { OperatorActions } from './OperatorActions';
 import { MarketContextPanel } from './MarketContextPanel';
 import { OpportunityPanel } from './OpportunityPanel';
+import { DecisionIntelligencePanel } from './DecisionIntelligencePanel';
+import { EventIntelligencePanel } from './EventIntelligencePanel';
+import { StrategyOrchestratorPanel } from './StrategyOrchestratorPanel';
+import { RiskEnginePanel } from './RiskEnginePanel';
+import { AutonomousTraderPanel } from './AutonomousTraderPanel';
 import { type CockpitTrade } from './cockpitUi';
 import { useContractGreeks } from '../../hooks/useContractGreeks';
 import { useCockpitQuote } from './cockpitQuote';
@@ -30,6 +35,7 @@ export function CockpitWorkspace({
 
   return (
     <div data-testid="cockpit-workspace" className="flex min-w-0 flex-col gap-3">
+      <AutonomousTraderPanel />
       <CockpitCommandBar
         trade={trade}
         quote={quote}
@@ -52,6 +58,10 @@ export function CockpitWorkspace({
         <MarketContextPanel trade={trade} />
         <OpportunityPanel trade={trade} />
       </div>
+      <DecisionIntelligencePanel />
+      <EventIntelligencePanel />
+      <StrategyOrchestratorPanel />
+      <RiskEnginePanel />
     </div>
   );
 }

--- a/client/src/components/cockpit/DecisionIntelligencePanel.tsx
+++ b/client/src/components/cockpit/DecisionIntelligencePanel.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from 'react';
+import { BrainCircuit } from 'lucide-react';
+import { getLatestDecisionEngineScan, type DecisionEngineCandidate, type DecisionEngineScan } from '../../api/decisionEngine';
+import { fmtPercent } from '../../lib/marketFormat';
+import { Panel, Pill, Stat } from './cockpitUi';
+import { contractLabel } from './occSymbol';
+import { greekOrReason, numberOrReason, percentOrReason } from './cockpitDisplay';
+
+function scoreTone(score: number): 'good' | 'warn' | 'bad' | 'neutral' {
+  if (score >= 75) return 'good';
+  if (score >= 55) return 'warn';
+  return 'bad';
+}
+
+function OpportunityRow({ candidate, rank }: { candidate: DecisionEngineCandidate; rank: number }) {
+  return (
+    <tr className="border-t border-intel-lineSoft">
+      <td className="py-1 pr-2 text-[11px] text-intel-ink3">{rank}</td>
+      <td className="py-1">
+        <div className="font-medium text-intel-ink">{candidate.symbol}</div>
+        <div className="truncate text-[11px] text-intel-ink3" title={candidate.contract.symbol}>
+          {contractLabel(candidate.contract.symbol)}
+        </div>
+      </td>
+      <td className="py-1 text-right tabular-nums text-intel-ink2">{candidate.overallScore.toFixed(1)}</td>
+      <td className="py-1 text-right tabular-nums text-intel-ink2">{fmtPercent(candidate.confidence * 100)}</td>
+      <td className="py-1 pl-2 text-right"><Pill tone={scoreTone(candidate.overallScore)}>{candidate.recommendation}</Pill></td>
+    </tr>
+  );
+}
+
+function RejectionRow({ rejection }: { rejection: DecisionEngineScan['rejections'][number] }) {
+  return (
+    <tr className="border-t border-intel-lineSoft">
+      <td className="py-1">
+        <div className="font-medium text-intel-ink2">{rejection.candidate.symbol}</div>
+        <div className="truncate text-[11px] text-intel-ink3" title={rejection.candidate.contract.symbol}>
+          {contractLabel(rejection.candidate.contract.symbol)}
+        </div>
+      </td>
+      <td className="py-1 pl-2"><Pill tone="bad">{rejection.reasonCode}</Pill></td>
+      <td className="py-1 pl-2 text-[11px] text-intel-ink3">{rejection.explanation}</td>
+    </tr>
+  );
+}
+
+export function DecisionIntelligencePanel() {
+  const [scan, setScan] = useState<DecisionEngineScan | null>(null);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'empty' | 'error'>('loading');
+
+  useEffect(() => {
+    let active = true;
+    getLatestDecisionEngineScan()
+      .then(result => {
+        if (!active) return;
+        setScan(result);
+        setStatus(result ? 'ready' : 'empty');
+      })
+      .catch(() => {
+        if (!active) return;
+        setStatus('error');
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const winner = scan?.winner ?? null;
+  const top = scan?.ranking.top10 ?? [];
+  const rejections = scan?.rejections.slice(0, 8) ?? [];
+
+  return (
+    <Panel
+      title="Decision intelligence"
+      badge={<BrainCircuit className="h-4 w-4 text-intel-ink3" aria-hidden="true" />}
+    >
+      {status === 'loading' ? <p className="text-xs text-intel-ink3">Loading latest decision scan.</p> : null}
+      {status === 'error' ? <p className="text-xs text-intel-ink3">Decision scan unavailable.</p> : null}
+      {status === 'empty' ? <p className="text-xs text-intel-ink3">No decision scan has been journaled yet.</p> : null}
+      {status === 'ready' && scan ? (
+        <div className="flex min-w-0 flex-col gap-3">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <Stat label="Watchlist" value={scan.watchlist.length} />
+            <Stat label="Candidates" value={scan.candidates.length} />
+            <Stat label="Accepted" value={top.length} tone={top.length ? 'good' : 'muted'} />
+            <Stat label="Rejected" value={scan.rejections.length} tone={scan.rejections.length ? 'bad' : 'muted'} />
+          </div>
+
+          {winner ? (
+            <div className="border-t border-intel-line pt-3">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="text-[10px] uppercase tracking-widest text-intel-ink3">Best opportunity</div>
+                  <div className="mt-1 truncate text-base font-semibold text-intel-ink">{contractLabel(winner.contract.symbol)}</div>
+                  <p className="mt-1 text-xs text-intel-ink3">{winner.thesis}</p>
+                </div>
+                <Pill tone={scoreTone(winner.overallScore)}>{winner.recommendation}</Pill>
+              </div>
+              <div className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-5">
+                <Stat label="Overall" value={winner.overallScore.toFixed(1)} />
+                <Stat label="Confidence" value={fmtPercent(winner.confidence * 100)} />
+                <Stat label="Delta" value={greekOrReason(winner.contract.delta, 'Not supplied')} />
+                <Stat label="OI" value={numberOrReason(winner.contract.openInterest, 'Not supplied')} />
+                <Stat label="Spread" value={percentOrReason(winner.contract.spreadPct, 'Not supplied')} />
+              </div>
+            </div>
+          ) : (
+            <p className="border-t border-intel-line pt-3 text-xs text-intel-ink3">{scan.noTradeReason}</p>
+          )}
+
+          {top.length ? (
+            <div className="overflow-x-auto border-t border-intel-line pt-3">
+              <table className="min-w-[620px] w-full text-sm">
+                <thead>
+                  <tr className="text-[10px] uppercase tracking-widest text-intel-ink3">
+                    <th className="py-1 pr-2 text-left font-normal">Rank</th>
+                    <th className="py-1 text-left font-normal">Opportunity</th>
+                    <th className="py-1 text-right font-normal">Score</th>
+                    <th className="py-1 text-right font-normal">Confidence</th>
+                    <th className="py-1 pl-2 text-right font-normal">Recommendation</th>
+                  </tr>
+                </thead>
+                <tbody>{top.slice(0, 5).map((candidate, index) => <OpportunityRow key={candidate.id} candidate={candidate} rank={index + 1} />)}</tbody>
+              </table>
+            </div>
+          ) : null}
+
+          {rejections.length ? (
+            <div className="overflow-x-auto border-t border-intel-line pt-3">
+              <div className="mb-1 text-[10px] uppercase tracking-widest text-intel-ink3">Rejected opportunities</div>
+              <table className="min-w-[760px] w-full text-sm">
+                <tbody>{rejections.map(rejection => <RejectionRow key={`${rejection.candidate.id}-${rejection.reasonCode}`} rejection={rejection} />)}</tbody>
+              </table>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </Panel>
+  );
+}

--- a/client/src/components/cockpit/EventIntelligencePanel.tsx
+++ b/client/src/components/cockpit/EventIntelligencePanel.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from 'react';
+import { RadioTower } from 'lucide-react';
+import { getEventIntelligenceContext, type EventIntelligenceRecord, type EventMarketContext } from '../../api/eventIntelligence';
+import { fmtNumber, fmtPercent } from '../../lib/marketFormat';
+import { Panel, Pill, Stat } from './cockpitUi';
+
+function toneForSentiment(label: string): 'good' | 'bad' | 'neutral' | 'warn' {
+  if (label === 'bullish') return 'good';
+  if (label === 'bearish') return 'bad';
+  if (label === 'neutral') return 'neutral';
+  return 'warn';
+}
+
+function EventRow({ record }: { record: EventIntelligenceRecord }) {
+  return (
+    <tr className="border-t border-intel-lineSoft">
+      <td className="py-1 pr-2">
+        <div className="font-medium text-intel-ink">{record.event.title}</div>
+        <div className="mt-0.5 flex flex-wrap gap-1 text-[11px] text-intel-ink3">
+          <span>{record.event.category}</span>
+          <span>{new Date(record.event.timestamp).toLocaleTimeString([], { hour12: false })}</span>
+        </div>
+      </td>
+      <td className="py-1 text-right tabular-nums text-intel-ink2">{record.event.importance.toFixed(1)}</td>
+      <td className="py-1 text-right tabular-nums text-intel-ink2">{fmtPercent(record.event.confidence * 100)}</td>
+      <td className="py-1 pl-2"><Pill tone={toneForSentiment(record.event.sentiment.label)}>{record.event.sentiment.label}</Pill></td>
+      <td className="py-1 pl-2 text-[11px] text-intel-ink3">{record.impact.affectedSymbols.slice(0, 6).join(', ') || 'None'}</td>
+      <td className="py-1 pl-2 text-[11px] text-intel-ink3">{record.impact.affectedEtfs.slice(0, 5).join(', ') || 'None'}</td>
+      <td className="py-1 pl-2"><Pill tone={record.decisionTrigger.triggered ? 'good' : 'neutral'}>{record.decisionTrigger.status}</Pill></td>
+    </tr>
+  );
+}
+
+export function EventIntelligencePanel() {
+  const [context, setContext] = useState<EventMarketContext | null>(null);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'empty' | 'error'>('loading');
+
+  useEffect(() => {
+    let active = true;
+    getEventIntelligenceContext()
+      .then(result => {
+        if (!active) return;
+        setContext(result);
+        setStatus(result ? 'ready' : 'empty');
+      })
+      .catch(() => {
+        if (!active) return;
+        setStatus('error');
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const events = context?.highImportanceEvents ?? [];
+  return (
+    <Panel title="Event intelligence" badge={<RadioTower className="h-4 w-4 text-intel-ink3" aria-hidden="true" />}>
+      {status === 'loading' ? <p className="text-xs text-intel-ink3">Loading market events.</p> : null}
+      {status === 'error' ? <p className="text-xs text-intel-ink3">Event intelligence unavailable.</p> : null}
+      {status === 'empty' ? <p className="text-xs text-intel-ink3">No event context has been journaled yet.</p> : null}
+      {status === 'ready' && context ? (
+        <div className="flex min-w-0 flex-col gap-3">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+            <Stat label="Breaking events" value={events.length} tone={events.length ? 'good' : 'muted'} />
+            <Stat label="Symbols" value={fmtNumber(context.affectedSymbols.length)} />
+            <Stat label="ETFs" value={fmtNumber(context.affectedEtfs.length)} />
+            <Stat label="Sectors" value={fmtNumber(context.affectedSectors.length)} />
+            <Stat label="Decision trigger" value={context.latestTrigger?.status ?? 'None'} size="sm" />
+          </div>
+          {events.length ? (
+            <div className="overflow-x-auto border-t border-intel-line pt-3">
+              <table className="min-w-[860px] w-full text-sm">
+                <thead>
+                  <tr className="text-[10px] uppercase tracking-widest text-intel-ink3">
+                    <th className="py-1 pr-2 text-left font-normal">Event timeline</th>
+                    <th className="py-1 text-right font-normal">Importance</th>
+                    <th className="py-1 text-right font-normal">Confidence</th>
+                    <th className="py-1 pl-2 text-left font-normal">Sentiment</th>
+                    <th className="py-1 pl-2 text-left font-normal">Symbols</th>
+                    <th className="py-1 pl-2 text-left font-normal">ETFs</th>
+                    <th className="py-1 pl-2 text-left font-normal">Trigger</th>
+                  </tr>
+                </thead>
+                <tbody>{events.slice(0, 8).map(record => <EventRow key={record.event.id} record={record} />)}</tbody>
+              </table>
+            </div>
+          ) : (
+            <p className="border-t border-intel-line pt-3 text-xs text-intel-ink3">No high-importance events are currently active.</p>
+          )}
+        </div>
+      ) : null}
+    </Panel>
+  );
+}

--- a/client/src/components/cockpit/LearningIntelligencePanel.tsx
+++ b/client/src/components/cockpit/LearningIntelligencePanel.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useMemo, useState } from 'react';
+import { GraduationCap } from 'lucide-react';
+import { learningApi } from '../../api';
+import type {
+  LearningCalibrationBucket,
+  LearningEvent,
+  LearningRegime,
+  LearningScorecard,
+  LearningStatus,
+  LearningTradeReview,
+} from '../../api/learning';
+import { Panel, Pill, Stat, statusTone } from './cockpitUi';
+
+type Snapshot = {
+  status: LearningStatus | null;
+  reviews: LearningTradeReview[];
+  scorecards: LearningScorecard[];
+  calibration: LearningCalibrationBucket[];
+  regimes: LearningRegime[];
+  events: LearningEvent[];
+};
+
+const EMPTY: Snapshot = {
+  status: null,
+  reviews: [],
+  scorecards: [],
+  calibration: [],
+  regimes: [],
+  events: [],
+};
+
+function pct(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return '-';
+  return `${(value * 100).toFixed(0)}%`;
+}
+
+function ret(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return '-';
+  return `${value >= 0 ? '+' : ''}${value.toFixed(2)}%`;
+}
+
+function bestByReturn<T extends { averageReturn: number | null; totalTrades?: number }>(items: T[]): T | null {
+  return items
+    .filter(item => (item.totalTrades ?? 0) > 0 && item.averageReturn != null)
+    .sort((a, b) => (b.averageReturn ?? -Infinity) - (a.averageReturn ?? -Infinity))[0] ?? null;
+}
+
+function worstByReturn<T extends { averageReturn: number | null; totalTrades?: number }>(items: T[]): T | null {
+  return items
+    .filter(item => (item.totalTrades ?? 0) > 0 && item.averageReturn != null)
+    .sort((a, b) => (a.averageReturn ?? Infinity) - (b.averageReturn ?? Infinity))[0] ?? null;
+}
+
+export function LearningIntelligencePanel() {
+  const [snapshot, setSnapshot] = useState<Snapshot>(EMPTY);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const [status, reviews, scorecards, calibration, regimes, events] = await Promise.all([
+          learningApi.getStatus(),
+          learningApi.getTrades(8),
+          learningApi.getScorecards(),
+          learningApi.getCalibration(),
+          learningApi.getRegimes(),
+          learningApi.getEvents(),
+        ]);
+        if (!cancelled) {
+          setSnapshot({ status, reviews, scorecards, calibration, regimes, events });
+          setError(null);
+        }
+      } catch (err: any) {
+        if (!cancelled) setError(err?.response?.data?.error ?? err?.message ?? 'Learning intelligence unavailable.');
+      }
+    }
+    void load();
+    const id = window.setInterval(() => void load(), 60_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, []);
+
+  const lifetimeScorecards = useMemo(
+    () => snapshot.scorecards.filter(scorecard => scorecard.window === 'LIFETIME'),
+    [snapshot.scorecards]
+  );
+  const bestStrategy = bestByReturn(lifetimeScorecards);
+  const worstStrategy = worstByReturn(lifetimeScorecards);
+  const topRegime = bestByReturn(snapshot.regimes);
+  const confidenceAccuracy = snapshot.calibration
+    .filter(bucket => bucket.historicalAccuracy != null)
+    .sort((a, b) => b.totalTrades - a.totalTrades)[0] ?? null;
+  const latestLesson = snapshot.reviews.find(review => review.whatCouldImprove.length || review.whyFailed.length || review.whySucceeded.length);
+
+  return (
+    <Panel
+      title="Learning Intelligence"
+      badge={<Pill tone={statusTone(snapshot.status?.status)}>{snapshot.status?.status ?? 'Loading'}</Pill>}
+      actions={<GraduationCap className="h-4 w-4 text-intel-ink3" aria-hidden="true" />}
+    >
+      {error ? <p className="mb-3 text-xs text-intel-neg">{error}</p> : null}
+      <p className="mb-3 text-sm leading-6 text-intel-ink2">
+        {snapshot.status?.explanation ?? 'Learning intelligence is loading completed trade evidence.'}
+      </p>
+      <div className="grid gap-3 md:grid-cols-3 xl:grid-cols-6">
+        <Stat label="Today's Performance" value={ret(snapshot.reviews[0]?.actualReturn)} />
+        <Stat label="Best Strategy" value={bestStrategy?.key ?? '-'} size="sm" />
+        <Stat label="Worst Strategy" value={worstStrategy?.key ?? '-'} size="sm" />
+        <Stat label="Confidence Accuracy" value={confidenceAccuracy ? pct(confidenceAccuracy.historicalAccuracy) : '-'} />
+        <Stat label="Top Regime" value={topRegime?.key ?? '-'} size="sm" />
+        <Stat label="Learning Progress" value={`${snapshot.status?.tradeReviews ?? 0}/${snapshot.status?.completedTrades ?? 0}`} />
+      </div>
+      <div className="mt-4 grid gap-3 xl:grid-cols-[minmax(0,1fr)_minmax(280px,0.8fr)]">
+        <div className="rounded-md border border-intel-lineSoft p-3">
+          <div className="mb-2 font-mono text-[10px] uppercase tracking-label text-intel-ink3">Recent Lessons</div>
+          {latestLesson ? (
+            <div className="text-xs text-intel-ink2">
+              <div className="mb-1 flex flex-wrap items-center gap-2">
+                <Pill tone={latestLesson.outcome === 'LOSS' ? 'bad' : 'good'}>{latestLesson.outcome}</Pill>
+                <span className="font-semibold text-intel-ink">{latestLesson.symbol ?? 'Unknown'}</span>
+                <span>{latestLesson.winningStrategy ?? latestLesson.entryStrategy ?? 'No strategy recorded'}</span>
+              </div>
+              <p>{latestLesson.whatCouldImprove[0] ?? latestLesson.whyFailed[0] ?? latestLesson.whySucceeded[0]}</p>
+            </div>
+          ) : (
+            <p className="text-xs text-intel-ink3">No completed trade lessons have been captured yet.</p>
+          )}
+        </div>
+        <div className="rounded-md border border-intel-lineSoft p-3">
+          <div className="mb-2 font-mono text-[10px] uppercase tracking-label text-intel-ink3">Top Event Edge</div>
+          {snapshot.events.slice(0, 3).map(event => (
+            <div key={event.event} className="flex items-center justify-between gap-3 border-t border-intel-lineSoft py-1.5 text-xs first:border-t-0">
+              <span className="text-intel-ink">{event.event}</span>
+              <span className="font-mono text-intel-ink2">{pct(event.winRate)} - {ret(event.averageReturn)}</span>
+            </div>
+          ))}
+          {!snapshot.events.length ? <p className="text-xs text-intel-ink3">No event analytics available.</p> : null}
+        </div>
+      </div>
+      <details className="mt-4 rounded-md bg-intel-panel2 p-3">
+        <summary className="cursor-pointer font-mono text-[10px] font-semibold uppercase tracking-label text-intel-ink3">
+          Strategy Scorecards, Trade Reviews, and Calibration
+        </summary>
+        <div className="mt-3 grid gap-3 xl:grid-cols-3">
+          <DetailTable
+            title="Strategy Scorecards"
+            rows={lifetimeScorecards.slice(0, 6).map(card => [card.key, `${card.totalTrades} trades`, `${pct(card.winRate)} win`, ret(card.averageReturn)])}
+          />
+          <DetailTable
+            title="Trade Reviews"
+            rows={snapshot.reviews.slice(0, 6).map(review => [review.symbol ?? '-', review.outcome, review.winningStrategy ?? '-', ret(review.actualReturn)])}
+          />
+          <DetailTable
+            title="Calibration"
+            rows={snapshot.calibration.map(bucket => [bucket.confidenceBand, `${bucket.totalTrades} trades`, pct(bucket.actualSuccessRate), bucket.verdict])}
+          />
+        </div>
+      </details>
+    </Panel>
+  );
+}
+
+function DetailTable({ title, rows }: { title: string; rows: string[][] }) {
+  return (
+    <div className="min-w-0 rounded-md border border-intel-lineSoft p-3">
+      <div className="mb-2 font-mono text-[10px] uppercase tracking-label text-intel-ink3">{title}</div>
+      <div className="space-y-1.5">
+        {rows.map((row, index) => (
+          <div key={`${title}-${index}`} className="grid grid-cols-4 gap-2 text-xs">
+            {row.map((cell, cellIndex) => (
+              <span key={`${cell}-${cellIndex}`} className={cellIndex === 0 ? 'truncate text-intel-ink' : 'truncate text-intel-ink2'} title={cell}>
+                {cell}
+              </span>
+            ))}
+          </div>
+        ))}
+        {!rows.length ? <p className="text-xs text-intel-ink3">No records yet.</p> : null}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/cockpit/RiskEnginePanel.tsx
+++ b/client/src/components/cockpit/RiskEnginePanel.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ShieldCheck } from 'lucide-react';
+import { getRiskEngineSnapshot, type RiskEngineSnapshot } from '../../api/riskEngine';
+import { fmtMoney, fmtPercent } from '../../lib/marketFormat';
+import { Panel, Pill, Stat } from './cockpitUi';
+
+function tone(status: string | null): 'good' | 'warn' | 'bad' | 'neutral' {
+  if (status === 'APPROVE') return 'good';
+  if (status === 'REJECT') return 'bad';
+  return 'neutral';
+}
+
+export function RiskEnginePanel() {
+  const [snapshot, setSnapshot] = useState<RiskEngineSnapshot | null>(null);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+
+  useEffect(() => {
+    let active = true;
+    getRiskEngineSnapshot()
+      .then(result => {
+        if (!active) return;
+        setSnapshot(result);
+        setStatus('ready');
+      })
+      .catch(() => {
+        if (!active) return;
+        setStatus('error');
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const topSectors = useMemo(() => {
+    const exposure = snapshot?.portfolio.exposure.sectorExposure ?? {};
+    return Object.entries(exposure)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 4);
+  }, [snapshot]);
+
+  return (
+    <Panel title="Enterprise risk" badge={<ShieldCheck className="h-4 w-4 text-intel-ink3" aria-hidden="true" />}>
+      {status === 'loading' ? <p className="text-xs text-intel-ink3">Loading risk engine state.</p> : null}
+      {status === 'error' ? <p className="text-xs text-intel-ink3">Risk engine unavailable.</p> : null}
+      {status === 'ready' && snapshot ? (
+        <div className="flex min-w-0 flex-col gap-3">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+            <Stat label="Latest" value={<Pill tone={tone(snapshot.status.latestStatus)}>{snapshot.status.latestStatus ?? 'NONE'}</Pill>} />
+            <Stat label="Heat" value={fmtPercent(snapshot.status.portfolioHeat * 100)} />
+            <Stat label="Remaining" value={fmtMoney(snapshot.portfolio.riskBudget.remainingRiskBudget)} />
+            <Stat label="Open risk" value={fmtMoney(snapshot.portfolio.riskBudget.openRisk)} />
+            <Stat label="Queue" value={String(snapshot.queue.pending.length)} />
+          </div>
+          <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
+            <div className="min-w-0">
+              <div className="mb-1 text-[10px] uppercase tracking-widest text-intel-ink3">Sector exposure</div>
+              <div className="space-y-1">
+                {topSectors.length ? topSectors.map(([sector, value]) => (
+                  <div key={sector} className="flex items-center justify-between gap-3 text-xs">
+                    <span className="truncate text-intel-ink2">{sector}</span>
+                    <span className="tabular-nums text-intel-ink">{fmtMoney(value)}</span>
+                  </div>
+                )) : <p className="text-xs text-intel-ink3">No persisted sector exposure.</p>}
+              </div>
+            </div>
+            <div className="min-w-0">
+              <div className="mb-1 text-[10px] uppercase tracking-widest text-intel-ink3">Greeks</div>
+              <div className="grid grid-cols-2 gap-2 text-xs text-intel-ink2">
+                <span>Delta {snapshot.portfolio.greeks.delta ?? 'n/a'}</span>
+                <span>Gamma {snapshot.portfolio.greeks.gamma ?? 'n/a'}</span>
+                <span>Theta {snapshot.portfolio.greeks.theta ?? 'n/a'}</span>
+                <span>Vega {snapshot.portfolio.greeks.vega ?? 'n/a'}</span>
+              </div>
+            </div>
+            <div className="min-w-0">
+              <div className="mb-1 text-[10px] uppercase tracking-widest text-intel-ink3">Recent rejections</div>
+              <div className="space-y-1">
+                {snapshot.history.flatMap(record => record.approval.reasons.slice(0, 1)).slice(0, 3).map(reason => (
+                  <Pill key={`${reason.code}:${reason.explanation}`} tone="bad">{reason.code}</Pill>
+                ))}
+                {!snapshot.history.some(record => record.approval.reasons.length) ? (
+                  <p className="text-xs text-intel-ink3">No recent risk rejections.</p>
+                ) : null}
+              </div>
+            </div>
+          </div>
+          <p className="border-t border-intel-line pt-3 text-xs text-intel-ink3">
+            Read only. The risk engine can approve or reject recommendations; execution remains outside this panel.
+          </p>
+        </div>
+      ) : null}
+    </Panel>
+  );
+}

--- a/client/src/components/cockpit/RiskEnginePanel.tsx
+++ b/client/src/components/cockpit/RiskEnginePanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { ShieldCheck } from 'lucide-react';
 import { getRiskEngineSnapshot, type RiskEngineSnapshot } from '../../api/riskEngine';
 import { fmtMoney, fmtPercent } from '../../lib/marketFormat';
+import { trackOperatorEventOnce } from '../../lib/operatorAnalytics';
 import { Panel, Pill, Stat } from './cockpitUi';
 
 function tone(status: string | null): 'good' | 'warn' | 'bad' | 'neutral' {
@@ -13,6 +14,10 @@ function tone(status: string | null): 'good' | 'warn' | 'bad' | 'neutral' {
 export function RiskEnginePanel() {
   const [snapshot, setSnapshot] = useState<RiskEngineSnapshot | null>(null);
   const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+
+  useEffect(() => {
+    trackOperatorEventOnce('Risk Viewed');
+  }, []);
 
   useEffect(() => {
     let active = true;

--- a/client/src/components/cockpit/StrategyOrchestratorPanel.tsx
+++ b/client/src/components/cockpit/StrategyOrchestratorPanel.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+import { Network } from 'lucide-react';
+import { getLatestStrategyRecommendation, type StrategyOrchestratorRun } from '../../api/strategyOrchestrator';
+import { fmtPercent } from '../../lib/marketFormat';
+import { Panel, Pill, Stat } from './cockpitUi';
+
+function toneForAction(action: string): 'good' | 'warn' | 'bad' | 'neutral' {
+  if (action === 'BUY' || action === 'WATCH') return 'good';
+  if (action === 'WAIT') return 'warn';
+  if (action === 'NO_TRADE' || action === 'SKIP') return 'bad';
+  return 'neutral';
+}
+
+export function StrategyOrchestratorPanel() {
+  const [run, setRun] = useState<StrategyOrchestratorRun | null>(null);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'empty' | 'error'>('loading');
+
+  useEffect(() => {
+    let active = true;
+    getLatestStrategyRecommendation()
+      .then(result => {
+        if (!active) return;
+        setRun(result);
+        setStatus(result ? 'ready' : 'empty');
+      })
+      .catch(() => {
+        if (!active) return;
+        setStatus('error');
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const top = run?.rankings.filter(ranking => !ranking.rejected).slice(0, 5) ?? [];
+  return (
+    <Panel title="Strategy orchestrator" badge={<Network className="h-4 w-4 text-intel-ink3" aria-hidden="true" />}>
+      {status === 'loading' ? <p className="text-xs text-intel-ink3">Loading strategy recommendation.</p> : null}
+      {status === 'error' ? <p className="text-xs text-intel-ink3">Strategy orchestrator unavailable.</p> : null}
+      {status === 'empty' ? <p className="text-xs text-intel-ink3">No strategy recommendation has been journaled yet.</p> : null}
+      {status === 'ready' && run ? (
+        <div className="flex min-w-0 flex-col gap-3">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+            <Stat label="Recommendation" value={<Pill tone={toneForAction(run.recommendation.action)}>{run.recommendation.action}</Pill>} />
+            <Stat label="Winner" value={run.winner?.name ?? 'None'} size="sm" />
+            <Stat label="Evidence" value={run.evidence.score.toFixed(1)} />
+            <Stat label="Confidence" value={fmtPercent(run.recommendation.confidence * 100)} />
+            <Stat label="Regime" value={run.marketContext.regime.current} size="sm" />
+          </div>
+          <p className="border-t border-intel-line pt-3 text-xs text-intel-ink3">{run.recommendation.explanation}</p>
+          <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+            <div className="overflow-x-auto">
+              <div className="mb-1 text-[10px] uppercase tracking-widest text-intel-ink3">Active strategies</div>
+              <table className="min-w-[460px] w-full text-sm">
+                <tbody>
+                  {top.map(strategy => (
+                    <tr key={strategy.strategyId} className="border-t border-intel-lineSoft">
+                      <td className="py-1 text-intel-ink">{strategy.name}</td>
+                      <td className="py-1 text-right tabular-nums text-intel-ink2">{strategy.score.toFixed(1)}</td>
+                      <td className="py-1 text-right tabular-nums text-intel-ink2">{fmtPercent(strategy.confidence * 100)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div className="min-w-0">
+              <div className="mb-1 text-[10px] uppercase tracking-widest text-intel-ink3">Conflicts and portfolio impact</div>
+              <p className="text-xs text-intel-ink3">{run.conflicts.explanation}</p>
+              <p className="mt-2 text-xs text-intel-ink3">{run.portfolioContext.adjustmentExplanation}</p>
+              <Pill tone={run.recommendation.riskHandoff.allowedForRiskReview ? 'warn' : 'neutral'}>
+                Risk handoff only
+              </Pill>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </Panel>
+  );
+}

--- a/client/src/components/cockpit/StrategyOrchestratorPanel.tsx
+++ b/client/src/components/cockpit/StrategyOrchestratorPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Network } from 'lucide-react';
 import { getLatestStrategyRecommendation, type StrategyOrchestratorRun } from '../../api/strategyOrchestrator';
 import { fmtPercent } from '../../lib/marketFormat';
+import { trackOperatorEventOnce } from '../../lib/operatorAnalytics';
 import { Panel, Pill, Stat } from './cockpitUi';
 
 function toneForAction(action: string): 'good' | 'warn' | 'bad' | 'neutral' {
@@ -14,6 +15,10 @@ function toneForAction(action: string): 'good' | 'warn' | 'bad' | 'neutral' {
 export function StrategyOrchestratorPanel() {
   const [run, setRun] = useState<StrategyOrchestratorRun | null>(null);
   const [status, setStatus] = useState<'loading' | 'ready' | 'empty' | 'error'>('loading');
+
+  useEffect(() => {
+    trackOperatorEventOnce('Strategy Viewed');
+  }, []);
 
   useEffect(() => {
     let active = true;

--- a/client/src/components/cockpit/TradeLifecyclePanel.tsx
+++ b/client/src/components/cockpit/TradeLifecyclePanel.tsx
@@ -10,6 +10,7 @@ import {
   type TradeLifecycleRecord,
   type TradeLifecycleStatus,
 } from '../../api/tradeLifecycle';
+import { trackOperatorEventOnce } from '../../lib/operatorAnalytics';
 import { Panel, Pill, statusTone } from './cockpitUi';
 
 function clock(value?: string | null): string {
@@ -128,6 +129,10 @@ export function TradeLifecyclePanel() {
   const [history, setHistory] = useState<TradeLifecycleRecord[]>([]);
   const [timeline, setTimeline] = useState<TradeLifecycleEvent[]>([]);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    trackOperatorEventOnce('Trade Lifecycle Viewed');
+  }, []);
 
   useEffect(() => {
     let cancelled = false;

--- a/client/src/components/cockpit/TradeLifecyclePanel.tsx
+++ b/client/src/components/cockpit/TradeLifecyclePanel.tsx
@@ -1,0 +1,267 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Activity, ChevronDown, ChevronRight } from 'lucide-react';
+import {
+  getTradeLifecycleActive,
+  getTradeLifecycleHistory,
+  getTradeLifecyclePending,
+  getTradeLifecycleStatus,
+  getTradeLifecycleTimeline,
+  type TradeLifecycleEvent,
+  type TradeLifecycleRecord,
+  type TradeLifecycleStatus,
+} from '../../api/tradeLifecycle';
+import { Panel, Pill, statusTone } from './cockpitUi';
+
+function clock(value?: string | null): string {
+  if (!value) return 'N/A';
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return 'N/A';
+  return new Date(parsed).toLocaleTimeString();
+}
+
+function age(value?: string | null): string {
+  if (!value) return 'N/A';
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return 'N/A';
+  const mins = Math.max(0, Math.round((Date.now() - parsed) / 60_000));
+  if (mins < 60) return `${mins}m`;
+  return `${Math.floor(mins / 60)}h ${mins % 60}m`;
+}
+
+const LABEL = 'font-mono text-[10px] uppercase tracking-label text-intel-ink3';
+
+function Detail({ trade }: { trade: TradeLifecycleRecord }) {
+  return (
+    <div className="mt-3 grid gap-3 border-t border-intel-lineSoft pt-3 text-xs text-intel-ink2 md:grid-cols-2 xl:grid-cols-4">
+      <div>
+        <div className={LABEL}>Entry</div>
+        <div className="mt-1 font-mono text-intel-ink">{trade.entryIntentId ?? 'N/A'}</div>
+      </div>
+      <div>
+        <div className={LABEL}>Confidence</div>
+        <div className="mt-1 font-mono text-intel-ink">
+          {trade.confidence.entry ?? 'N/A'} {'->'} {trade.confidence.current ?? 'N/A'} - {trade.confidence.trend}
+        </div>
+      </div>
+      <div>
+        <div className={LABEL}>Risk Decision</div>
+        <div className="mt-1 font-mono text-intel-ink">{trade.riskDecisionId ?? 'N/A'}</div>
+      </div>
+      <div>
+        <div className={LABEL}>Exit Recommendation</div>
+        <div className="mt-1 font-mono text-intel-ink">{trade.exitReason ?? trade.currentAction}</div>
+      </div>
+      <div className="md:col-span-2 xl:col-span-4">
+        <div className={LABEL}>Journal</div>
+        <p className="mt-1 text-intel-ink2">{trade.reasoning.join(' ') || 'No lifecycle reasoning captured yet.'}</p>
+      </div>
+    </div>
+  );
+}
+
+function TradeRows({ trades }: { trades: TradeLifecycleRecord[] }) {
+  const [open, setOpen] = useState<string | null>(null);
+  if (!trades.length) return <p className="text-xs text-intel-ink3">No open lifecycle trades.</p>;
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[680px]">
+        <thead>
+          <tr className="border-b border-intel-line">
+            <th className={`py-1.5 pr-3 text-left ${LABEL} font-normal`}>Symbol</th>
+            <th className={`py-1.5 pr-3 text-left ${LABEL} font-normal`}>State</th>
+            <th className={`py-1.5 pr-3 text-right ${LABEL} font-normal`}>P/L</th>
+            <th className={`py-1.5 pr-3 text-right ${LABEL} font-normal`}>Confidence</th>
+            <th className={`py-1.5 pr-3 text-left ${LABEL} font-normal`}>AI Recommendation</th>
+            <th className={`py-1.5 pr-3 text-left ${LABEL} font-normal`}>Time Held</th>
+          </tr>
+        </thead>
+        <tbody>
+          {trades.map((trade) => {
+            const selected = open === trade.tradeId;
+            return (
+              <tr key={trade.tradeId} className="border-b border-intel-lineSoft align-top">
+                <td colSpan={6} className="p-0">
+                  <button
+                    type="button"
+                    className="grid w-full grid-cols-[22px_1.2fr_1fr_0.8fr_0.9fr_1fr_0.8fr] items-center py-2 pr-3 text-left font-mono text-xs text-intel-ink2"
+                    onClick={() => setOpen(selected ? null : trade.tradeId)}
+                  >
+                    {selected ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+                    <span className="font-semibold text-intel-ink">{trade.optionSymbol}</span>
+                    <span><Pill tone={statusTone(trade.state)}>{trade.state}</Pill></span>
+                    <span className="text-right tabular-nums">N/A</span>
+                    <span className="text-right tabular-nums text-intel-ink">{trade.confidence.current ?? 'N/A'}</span>
+                    <span>{trade.currentAction}</span>
+                    <span>{age(trade.createdAt)}</span>
+                  </button>
+                  {selected && <Detail trade={trade} />}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function Timeline({ events }: { events: TradeLifecycleEvent[] }) {
+  const rows = events.slice(0, 12);
+  if (!rows.length) return <p className="text-xs text-intel-ink3">No lifecycle timeline events captured yet.</p>;
+  return (
+    <div className="flex flex-col">
+      {rows.map((event, index) => (
+        <div key={`${event.tradeId ?? event.source ?? event.service}-${event.at ?? event.timestamp}-${index}`} className="flex items-baseline gap-3 border-b border-intel-lineSoft py-1.5 last:border-b-0">
+          <span className="w-[64px] shrink-0 font-mono text-[10px] tabular-nums text-intel-ink3">{clock(event.at ?? event.timestamp)}</span>
+          <span className="min-w-0 truncate font-mono text-xs text-intel-ink2">{event.eventType ?? event.event ?? 'LIFECYCLE_EVENT'}</span>
+          {event.state && <span className="ml-auto shrink-0 font-mono text-[10px] text-intel-ink3">{event.state}</span>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function TradeLifecyclePanel() {
+  const [status, setStatus] = useState<TradeLifecycleStatus | null>(null);
+  const [active, setActive] = useState<TradeLifecycleRecord[]>([]);
+  const [pending, setPending] = useState<TradeLifecycleRecord[]>([]);
+  const [history, setHistory] = useState<TradeLifecycleRecord[]>([]);
+  const [timeline, setTimeline] = useState<TradeLifecycleEvent[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const [nextStatus, nextActive, nextPending, nextHistory, nextTimeline] = await Promise.all([
+          getTradeLifecycleStatus(),
+          getTradeLifecycleActive(),
+          getTradeLifecyclePending(),
+          getTradeLifecycleHistory(20),
+          getTradeLifecycleTimeline(60),
+        ]);
+        if (cancelled) return;
+        setStatus(nextStatus);
+        setActive(nextActive);
+        setPending(nextPending);
+        setHistory(nextHistory);
+        setTimeline(nextTimeline);
+        setError(null);
+      } catch (err: any) {
+        if (!cancelled) setError(err?.response?.data?.error ?? err?.message ?? 'Trade lifecycle unavailable.');
+      }
+    };
+    void load();
+    const id = window.setInterval(() => void load(), 30_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, []);
+
+  const rejected = useMemo(
+    () => pending.filter((trade) => String(trade.reasoning.join(' ')).toUpperCase().includes('REJECT')),
+    [pending]
+  );
+
+  return (
+    <Panel
+      title="Trade Lifecycle"
+      badge={<Pill tone={status?.flags?.TRADE_LIFECYCLE_ENABLED ? 'good' : 'warn'}>{status?.aiStatus ?? 'Loading'}</Pill>}
+      actions={<Activity className="h-4 w-4 text-intel-ink3" />}
+    >
+      {error && <p className="mb-3 text-xs text-intel-neg">{error}</p>}
+      <div className="grid gap-3 md:grid-cols-4 xl:grid-cols-7">
+        {[
+          ['AI Status', status?.aiStatus],
+          ['Paper Trading', status?.paperTrading ? 'PAPER' : 'OFF'],
+          ['Market', status?.market],
+          ['Current Strategy', status?.currentStrategy],
+          ['Current Regime', status?.currentRegime],
+          ['Next Evaluation', clock(status?.nextEvaluation)],
+          ['Recommendation', status?.currentDecision?.recommendation],
+        ].map(([label, value]) => (
+          <div key={label ?? ''} className="min-w-0">
+            <div className={LABEL}>{label}</div>
+            <div className="mt-0.5 truncate font-mono text-sm font-semibold text-intel-ink">{value || 'N/A'}</div>
+          </div>
+        ))}
+      </div>
+      {status?.currentDecision && (
+        <div className="mt-3 rounded border border-intel-lineSoft px-3 py-2">
+          <div className="flex flex-wrap items-center gap-3 text-xs">
+            <span className={LABEL}>Current AI Decision</span>
+            <span className="font-mono text-intel-ink">{status.currentDecision.watching}</span>
+            <span className="font-mono text-intel-accent">{status.currentDecision.recommendation}</span>
+            <span className="font-mono text-intel-ink2">Confidence {status.currentDecision.confidence ?? 'N/A'}</span>
+          </div>
+          <p className="mt-1 text-xs text-intel-ink2">{status.currentDecision.reason}</p>
+        </div>
+      )}
+      <div className="mt-4 grid gap-3 xl:grid-cols-[minmax(0,1.5fr)_minmax(280px,1fr)]">
+        <div>
+          <div className="mb-2 flex items-center justify-between">
+            <span className={LABEL}>Open Trades</span>
+            <Pill tone={active.length ? 'good' : 'neutral'}>{active.length}</Pill>
+          </div>
+          <TradeRows trades={active} />
+        </div>
+        <div className="space-y-3">
+          <div>
+            <div className="mb-2 flex items-center justify-between">
+              <span className={LABEL}>Pending Trades</span>
+              <Pill tone={pending.length ? 'warn' : 'neutral'}>{pending.length}</Pill>
+            </div>
+            <div className="space-y-1.5">
+              {pending.slice(0, 5).map((trade) => (
+                <div key={trade.tradeId} className="flex items-center justify-between gap-3 font-mono text-xs text-intel-ink2">
+                  <span className="truncate">{trade.optionSymbol}</span>
+                  <span className="shrink-0">{trade.state}</span>
+                </div>
+              ))}
+              {!pending.length && <p className="text-xs text-intel-ink3">No pending lifecycle trades.</p>}
+            </div>
+          </div>
+          <div>
+            <div className="mb-2 flex items-center justify-between">
+              <span className={LABEL}>Rejected</span>
+              <Pill tone={rejected.length ? 'warn' : 'neutral'}>{rejected.length}</Pill>
+            </div>
+            {rejected.length ? (
+              rejected.slice(0, 4).map((trade) => (
+                <div key={trade.tradeId} className="flex items-center justify-between gap-3 font-mono text-xs text-intel-ink2">
+                  <span>{trade.underlying}</span>
+                  <span className="truncate">{trade.reasoning[0] ?? 'Rejected'}</span>
+                </div>
+              ))
+            ) : (
+              <p className="text-xs text-intel-ink3">No rejected lifecycle trades.</p>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="mt-4 grid gap-3 xl:grid-cols-2">
+        <div>
+          <div className="mb-2 flex items-center justify-between">
+            <span className={LABEL}>Activity Timeline</span>
+            <Pill tone="neutral">{timeline.length}</Pill>
+          </div>
+          <Timeline events={timeline} />
+        </div>
+        <div>
+          <div className="mb-2 flex items-center justify-between">
+            <span className={LABEL}>Latest Evaluations</span>
+            <Pill tone="neutral">{history.length}</Pill>
+          </div>
+          {history.slice(0, 6).map((trade) => (
+            <div key={trade.tradeId} className="flex items-center justify-between gap-3 border-b border-intel-lineSoft py-1.5 font-mono text-xs text-intel-ink2 last:border-b-0">
+              <span className="truncate">{trade.optionSymbol}</span>
+              <span>{trade.evaluationSummary?.winLoss ? String(trade.evaluationSummary.winLoss) : trade.state}</span>
+            </div>
+          ))}
+          {!history.length && <p className="text-xs text-intel-ink3">No completed lifecycle evaluations.</p>}
+        </div>
+      </div>
+    </Panel>
+  );
+}

--- a/client/src/components/intelligence/ui/Panel.tsx
+++ b/client/src/components/intelligence/ui/Panel.tsx
@@ -1,5 +1,6 @@
 import { useState, type ReactNode } from 'react';
 import { ChevronDown } from 'lucide-react';
+import { trackOperatorEvent } from '../../../lib/operatorAnalytics';
 
 type PanelProps = {
   title: string;
@@ -26,6 +27,13 @@ export function Panel({
 }: PanelProps) {
   const [open, setOpen] = useState(defaultOpen);
   const bodyId = `panel-${title.replace(/\s+/g, '-').toLowerCase()}`;
+  const toggleOpen = () => {
+    setOpen(current => {
+      const next = !current;
+      if (next) trackOperatorEvent('Operator Expanded Advanced Details', { section: title });
+      return next;
+    });
+  };
 
   const header = (
     <>
@@ -56,7 +64,7 @@ export function Panel({
     <section className="rounded-panel border border-intel-line bg-intel-panel">
       <button
         type="button"
-        onClick={() => setOpen(o => !o)}
+        onClick={toggleOpen}
         aria-expanded={open}
         aria-controls={bodyId}
         className="flex w-full items-center gap-2 px-4 py-3 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-intel-accent"

--- a/client/src/components/portfolio/AutomationCommandCenter.tsx
+++ b/client/src/components/portfolio/AutomationCommandCenter.tsx
@@ -3,6 +3,7 @@ import { Download, RefreshCw, Search } from 'lucide-react';
 import { portfolioApi } from '../../api';
 import type { AutomationVisibility, AutomationVisibilityEvent } from '../../api/portfolio';
 import { getSharedSocket } from '../../lib/socket';
+import { trackOperatorEvent } from '../../lib/operatorAnalytics';
 
 type LogFilter = 'All' | 'Scheduler' | 'Monitor' | 'Broker' | 'Risk' | 'Signals' | 'Orders' | 'Positions' | 'Errors';
 
@@ -206,6 +207,9 @@ export function AutomationCommandCenter() {
       setBusy(label);
       try {
         await fn();
+        if (label === 'resume') trackOperatorEvent('Automation Started', { control: 'resume' });
+        if (label === 'pause') trackOperatorEvent('Automation Stopped', { control: 'pause' });
+        if (label === 'emergency-stop') trackOperatorEvent('Automation Stopped', { control: 'emergency-stop' });
         await loadSnapshot();
       } catch (err: any) {
         setError(err?.response?.data?.error ?? err?.message ?? `${label} failed`);

--- a/client/src/lib/operatorAnalytics.ts
+++ b/client/src/lib/operatorAnalytics.ts
@@ -1,0 +1,44 @@
+import { track } from '@vercel/analytics';
+
+export const OPERATOR_ANALYTICS_EVENTS = [
+  'Application Loaded',
+  'Automation Viewed',
+  'Automation Started',
+  'Automation Stopped',
+  'Cockpit Viewed',
+  'AI Desk Viewed',
+  'Strategy Viewed',
+  'Risk Viewed',
+  'Trade Lifecycle Viewed',
+  'Reports Viewed',
+  'Operator Expanded Advanced Details',
+  'Shadow Mode Enabled',
+  'Paper Mode Enabled',
+] as const;
+
+export type OperatorAnalyticsEvent = (typeof OPERATOR_ANALYTICS_EVENTS)[number];
+
+type PropertyValue = string | number | boolean | null | undefined;
+type OperatorAnalyticsProperties = Record<string, PropertyValue>;
+
+const trackedOnce = new Set<string>();
+
+function safeProperties(properties?: OperatorAnalyticsProperties): OperatorAnalyticsProperties | undefined {
+  if (!properties) return undefined;
+  const allowed: OperatorAnalyticsProperties = {};
+  for (const [key, value] of Object.entries(properties)) {
+    allowed[key] = typeof value === 'string' ? value.slice(0, 80) : value;
+  }
+  return allowed;
+}
+
+export function trackOperatorEvent(event: OperatorAnalyticsEvent, properties?: OperatorAnalyticsProperties): void {
+  track(event, safeProperties(properties));
+}
+
+export function trackOperatorEventOnce(event: OperatorAnalyticsEvent, properties?: OperatorAnalyticsProperties): void {
+  const key = `${event}:${JSON.stringify(safeProperties(properties) ?? {})}`;
+  if (trackedOnce.has(key)) return;
+  trackedOnce.add(key);
+  trackOperatorEvent(event, properties);
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { Analytics } from '@vercel/analytics/react';
+import { SpeedInsights } from '@vercel/speed-insights/react';
 import App from './App';
 import './styles.css';
 import { assertApiRuntimeConfig } from './api/http';
@@ -12,5 +14,7 @@ assertApiRuntimeConfig();
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <App />
+    <Analytics />
+    <SpeedInsights />
   </React.StrictMode>
 );

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,64 @@
+# AI-Trader Documentation Index
+
+This index defines the canonical documentation hierarchy for AI-Trader after the `v1.1-enterprise-baseline` certification.
+
+## Canonical Hierarchy
+
+1. Production certification: `docs/release/PRODUCTION_CERTIFICATION.md`
+2. Enterprise baseline: `docs/release/ENTERPRISE_BASELINE.md`
+3. Enterprise readiness audit: `docs/audits/ENTERPRISE_STRATEGY_ENGINE_READINESS_AUDIT.md`
+4. NVIDIA Brev integration strategy: `docs/architecture/NVIDIA_BREV_ENTERPRISE_INTEGRATION_STRATEGY.md`
+5. AI-Trader v2 master architecture: `docs/architecture/AI_TRADER_V2_MASTER_ARCHITECTURE.md`
+6. Implementation backlog: `docs/roadmaps/AI_TRADER_V2_IMPLEMENTATION_BACKLOG.md`
+7. Architecture decision records: `docs/architecture/adr/`
+
+## Authoritative v2 Planning Document
+
+`docs/architecture/AI_TRADER_V2_MASTER_ARCHITECTURE.md` is authoritative for AI-Trader v2 planning.
+
+When source reports, older planning documents, transcripts, runbooks, or implementation notes conflict with the master architecture, follow the master architecture unless a new ADR explicitly changes the decision.
+
+## Architecture Decision Records
+
+Current v2 ADRs:
+
+- `docs/architecture/adr/001-strategy-engine-paper-only.md`
+- `docs/architecture/adr/002-ai-has-no-direct-order-authority.md`
+- `docs/architecture/adr/003-mongo-durable-outbox-before-event-platform.md`
+- `docs/architecture/adr/004-massive-advanced-options-initial-feature-boundary.md`
+- `docs/architecture/adr/005-gpu-services-optional-research-infrastructure.md`
+- `docs/architecture/adr/006-cpu-served-retrieval-without-brev.md`
+- `docs/architecture/adr/007-strategy-promotion-requires-evidence-and-human-approval.md`
+- `docs/architecture/adr/008-rl-offline-research-no-production-execution.md`
+
+## Documentation Governance
+
+Future agents and contributors must:
+
+- Read `docs/architecture/AI_TRADER_V2_MASTER_ARCHITECTURE.md` before architectural changes.
+- Preserve the certified `v1.1-enterprise-baseline` unless a later release explicitly supersedes it.
+- Update the traceability matrix when requirements change.
+- Add or revise an ADR for consequential design decisions.
+- Keep documentation and implementation in sync.
+- Never silently weaken a safety, security, paper-trading, production, or entitlement gate.
+- Never promote raw notes or transcripts above canonical architecture docs.
+- Never commit secrets, cookies, credentials, account tokens, private login URLs, or authentication artifacts.
+- Keep NVIDIA/GPU services optional and outside the required production hot path.
+- Keep Strategy Engine v2 foundation paper-trading-only until a separate live-money certification exists.
+- Keep AI advisory unless deterministic systems and human approvals explicitly authorize a future workflow.
+
+## Related Existing Documentation
+
+Useful supporting docs include:
+
+- `docs/architecture/ENTERPRISE_GROWTH_STRATEGY.md`
+- `docs/automation/execution-boundary.md`
+- `docs/automation/paper-trading-operations-runbook.md`
+- `docs/automation/sprint-2f-production-alignment.md`
+- `docs/market-data/options-advanced-alignment-audit.md`
+- `docs/market-data/options-advanced-alignment-delivery.md`
+- `docs/massive/README.md`
+- `docs/hardening/AUTHENTICATION_FOUNDATION.md`
+- `docs/api-reference.md`
+
+These supporting documents remain valuable, but they are not the authority for v2 architecture when they conflict with the master architecture or ADRs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ This index defines the canonical documentation hierarchy for AI-Trader after the
 
 ## Canonical Hierarchy
 
+0. Enterprise release candidate (v2.0.0-enterprise): `docs/release/AI_TRADER_ENTERPRISE_RC1.md`
 1. Production certification: `docs/release/PRODUCTION_CERTIFICATION.md`
 2. Enterprise baseline: `docs/release/ENTERPRISE_BASELINE.md`
 3. Enterprise readiness audit: `docs/audits/ENTERPRISE_STRATEGY_ENGINE_READINESS_AUDIT.md`

--- a/docs/architecture/AI_TRADER_V2_MASTER_ARCHITECTURE.md
+++ b/docs/architecture/AI_TRADER_V2_MASTER_ARCHITECTURE.md
@@ -1,0 +1,743 @@
+# AI-Trader v2 Master Architecture
+
+Date: 2026-07-25
+Status: authoritative for AI-Trader v2 planning
+Preserved source reports:
+
+- `docs/audits/ENTERPRISE_STRATEGY_ENGINE_READINESS_AUDIT.md`
+- `docs/architecture/NVIDIA_BREV_ENTERPRISE_INTEGRATION_STRATEGY.md`
+
+Baseline preserved:
+
+- Release: `v1.1-enterprise-baseline`
+- Commit: `b31f6c83d1136d9c5093034ae0be50e6b8b2caf3`
+- Production baseline: paper-trading only
+
+This document is planning authority only. It does not authorize production behavior changes, live-money execution, or Strategy Engine implementation before the required foundations are complete.
+
+## 1. Executive Decision
+
+AI-Trader v2 may begin now with foundation work only:
+
+- Strategy contracts.
+- Event contracts.
+- Feature-store design.
+- Backtesting hardening.
+- Experiment tracking.
+- RAG prototype.
+- Paper-trading research.
+- Documentation governance.
+- Authentication and RBAC design/implementation.
+- Durable event/outbox foundation.
+
+AI-Trader v2 remains prohibited from:
+
+- Autonomous live trading.
+- Production reinforcement learning.
+- Unreviewed strategy self-modification.
+- Direct AI order authority.
+- GPU-required production execution.
+- Multi-account automation without identity isolation.
+- Multi-position autonomous trading until specifically designed, tested, and certified.
+
+Decision: AI-Trader is production-stable for the certified paper-trading baseline, but the Strategy Engine must be built as a controlled, paper-only, deterministic, replayable, versioned architecture before any live-money discussion.
+
+Traceability: BOTH.
+
+## 2. Architecture Principles
+
+| Principle | Source |
+| --- | --- |
+| Paper trading first. | AUDIT |
+| Deterministic logic before adaptive logic. | BOTH |
+| AI proposes; deterministic systems decide. | BOTH |
+| Every strategy and decision is versioned. | AUDIT |
+| Every decision is replayable. | AUDIT |
+| Every order is idempotent. | REPOSITORY_VERIFICATION |
+| Every state change is attributable to an actor. | AUDIT |
+| Socket.IO is UI fanout, not the system of record. | AUDIT |
+| Mongo-backed durable events precede a larger event-bus migration. | AUDIT |
+| GPU use must be measurable, stoppable, and optional. | NVIDIA |
+| Massive Advanced Options data is the initial feature boundary. | BOTH |
+| Production must continue operating when Brev/NVIDIA GPU services are unavailable. | NVIDIA |
+| Strategy promotion requires deterministic evidence and human approval. | BOTH |
+| Reinforcement learning remains offline research with no production execution path. | BOTH |
+
+## 3. Target Domains
+
+| Domain | Ownership | Boundary |
+| --- | --- | --- |
+| Market Data | Own Massive REST/WS access, provider health, cache, entitlement state | No browser Massive credentials; no unauthorized equity real-time assumptions |
+| Feature Store | Persist versioned, point-in-time features | Does not choose trades |
+| Strategy Engine | Evaluate versioned strategy contracts over feature windows | Paper-only in v2 foundation |
+| Signal Engine | Produce versioned directional/non-directional signals | Cannot approve orders |
+| Risk Engine | Approve/reject candidates against account, strategy, data, and portfolio rules | Cannot submit orders |
+| Execution Engine | Convert approved intents into broker operations | Paper only until live certification |
+| Broker Adapters | Isolate Alpaca paper and future broker implementations | Live adapters prohibited in v2 foundation |
+| Portfolio Engine | Aggregate positions, P&L, exposure, attribution | Must be account-scoped |
+| Position Manager | Manage position lifecycle and exits | Must consume broker truth |
+| Order Manager | Own order state machine, idempotency, reconciliation | Must emit durable order events |
+| Trade Journal | Persist trade and decision narratives with evidence links | Must be derived from durable state |
+| Backtesting | Replay strategies against versioned datasets | Must prevent look-ahead bias |
+| Experiment Tracking | Record runs, metrics, artifacts, datasets, strategy versions | Required before strategy promotion |
+| Learning Dataset | Curate labels, outcomes, and feedback for future ML/RL | No production RL execution |
+| AI and Retrieval | Advisory context, RAG, summarization, strategy drafting | No direct execution authority |
+| Operations | Health, runbooks, kill switches, deployment evidence | Must not overstate health |
+| Authentication and Authorization | Identity, RBAC, account isolation, actor attribution | Required for v2 state changes |
+| Observability | Logs, metrics, traces, audits, alerts | Must support incident review and replay |
+
+## 4. Data Entitlement Boundary
+
+Initial v2 design uses only current Massive Advanced Options Market Data and already integrated APIs.
+
+Provider fields currently used or verified:
+
+| Field / Source | Entitlement Status | Use |
+| --- | --- | --- |
+| Options chains | Available under options entitlement | Matrix, scanner, selection, strategy features |
+| Options contracts/reference | Available | Expiration, strike, type, metadata |
+| Options quotes | Available | Top of book, spreads, marks, quote freshness |
+| Options trades | Available | Time and sales, flow windows |
+| Options snapshots | Available | Chain hydration, greeks, IV, OI, underlying context fallback |
+| Greeks | Available through options snapshots where provider supplies | Risk, selection, reports |
+| Implied volatility | Available through options snapshots where provider supplies | Volatility features and reports |
+| Open interest | Available | Liquidity and risk filters |
+| Volume/day stats | Available | Liquidity and signal features |
+| Spreads | Calculated from bid/ask | Risk and selection gates |
+| Authorized aggregates | Available where entitlement permits | Charts, feature windows, backtesting where authorized |
+| Market status | Available | Session gates |
+| News/sentiment/context | Available where provider supplies | Advisory AI/RAG context |
+
+Premium real-time equity feeds are not assumed. Current-day stock intraday aggregates are not a production dependency. Stocks WebSocket is not part of the certified options-advanced baseline.
+
+Every feature must include:
+
+- Provider source.
+- Entitlement status.
+- Provider timestamp.
+- Ingest timestamp.
+- Freshness.
+- Calculation version.
+- Missing-data behavior.
+- Quality status.
+- Point-in-time dataset ID when used in backtests.
+
+Traceability: BOTH, REPOSITORY_VERIFICATION.
+
+## 5. Feature Store Specification
+
+The Feature Store is the foundation for Strategy Engine, backtesting, experiment tracking, and future learning.
+
+Feature definition requirements:
+
+- `featureId`: stable identifier.
+- `featureVersion`: semantic or monotonic version.
+- `name`: human-readable name.
+- `description`: what the feature means.
+- `assetClass`: options, equity-context, portfolio, broker, journal, macro, news.
+- `providerSource`: Massive, Alpaca, Mongo-derived, AI-derived advisory, manual.
+- `entitlementStatus`: authorized, delayed, snapshot-only, unavailable, derived.
+- `calculationVersion`: code version used to calculate.
+- `requiredInputs`: upstream fields/events.
+- `timestampPolicy`: provider time, market window, calculation time.
+- `freshnessPolicy`: max age and stale behavior.
+- `missingDataPolicy`: reject, degrade, impute, omit, advisory-only.
+- `qualityStatus`: green, yellow, red, unknown.
+- `retentionPolicy`: online/offline retention.
+
+Historical feature windows:
+
+- Store closed windows only for backtesting.
+- Persist window start/end, market session, timezone, and source event IDs.
+- Prevent look-ahead bias by excluding events ingested after the decision timestamp.
+- Preserve raw or normalized input references.
+
+Online versus offline:
+
+- Online features may feed paper-trading decisions only when freshness and quality gates pass.
+- Offline features may support research, backtesting, RAG, and learning datasets.
+- Offline-only or AI-derived features must not silently enter live decision gates.
+
+Reproducibility:
+
+- Every backtest references dataset ID, feature versions, strategy version, code commit, and configuration snapshot.
+- Every dataset version is immutable after publication.
+- Corrections produce new dataset versions.
+
+Traceability: AUDIT, BOTH.
+
+## 6. Strategy Engine Specification
+
+Strategy contract fields:
+
+- `strategyId`
+- `strategyVersion`
+- `name`
+- `description`
+- `ownerActorId`
+- `lifecycleStatus`
+- `assetClass`
+- `requiredFeatures`
+- `signalRules`
+- `riskRequirements`
+- `entryRules`
+- `exitRules`
+- `sizingPolicy`
+- `timeWindowPolicy`
+- `dataQualityPolicy`
+- `explainabilityTemplate`
+- `performanceAttributionPolicy`
+- `promotionGates`
+- `killSwitches`
+- `rollbackTarget`
+
+Lifecycle:
+
+```mermaid
+stateDiagram-v2
+  [*] --> Draft
+  Draft --> Backtest
+  Backtest --> ApprovedForSimulation
+  ApprovedForSimulation --> ApprovedForPaperTrading
+  ApprovedForPaperTrading --> Paused
+  ApprovedForPaperTrading --> Retired
+  Draft --> Rejected
+  Backtest --> Rejected
+  ApprovedForSimulation --> Rejected
+  Paused --> ApprovedForPaperTrading
+  Paused --> Retired
+  ApprovedForPaperTrading --> Rollback
+  Rollback --> ApprovedForPaperTrading
+```
+
+Promotion requirements:
+
+- Deterministic strategy version.
+- Declared features.
+- Reproducible backtest.
+- Walk-forward validation.
+- Out-of-sample validation.
+- Baseline comparison.
+- Risk review.
+- Human approval.
+- Paper-only approval before any production execution discussion.
+
+Kill switches:
+
+- Per-strategy pause.
+- Global automation emergency stop.
+- Broker submission kill switch.
+- Data-quality kill switch.
+- Risk-budget kill switch.
+
+Traceability: AUDIT, BOTH.
+
+## 7. Durable Event Architecture
+
+Start with a Mongo-backed transactional outbox or equivalent durable event log. Do not introduce Kafka/NATS/etc. before the event contract is proven.
+
+```mermaid
+flowchart LR
+  DomainWrite[Domain State Write] --> Tx[(Mongo Transaction)]
+  Tx --> State[(Domain Collection)]
+  Tx --> Outbox[(Durable Event Outbox)]
+  Outbox --> Projector[Projectors / Read Models]
+  Outbox --> Journal[Trade Journal]
+  Outbox --> Socket[Socket.IO UI Fanout]
+  Outbox --> Experiments[Experiment Records]
+```
+
+Minimum events:
+
+| Event | Purpose |
+| --- | --- |
+| `MarketSnapshotIngested` | Raw/normalized provider data persisted |
+| `FeatureCalculated` | Versioned feature emitted |
+| `StrategyEvaluationStarted` | Strategy evaluation began |
+| `SignalGenerated` | Signal emitted by strategy/signal engine |
+| `RiskDecisionMade` | Risk approval/rejection |
+| `OrderIntentCreated` | Durable intent created |
+| `OrderIntentApproved` | Intent passed approval gates |
+| `OrderSubmitted` | Broker submission attempted |
+| `FillObserved` | Broker fill observed |
+| `PositionOpened` | Position lifecycle opened |
+| `ExitTriggered` | Exit condition triggered |
+| `PositionClosed` | Position lifecycle closed |
+| `JournalEntryCreated` | Journal record created |
+| `BacktestStarted` | Backtest run began |
+| `BacktestCompleted` | Backtest completed |
+| `ExperimentCompleted` | Experiment completed |
+| `DatasetVersionCreated` | Dataset version published |
+| `StrategyPromoted` | Strategy lifecycle promotion |
+| `StrategyPaused` | Strategy paused |
+| `EmergencyStopActivated` | Emergency control activated |
+
+Every event requires:
+
+- `eventId`
+- `eventVersion`
+- `eventType`
+- `aggregateId`
+- `aggregateType`
+- `correlationId`
+- `causationId`
+- `actorId`
+- `strategyId`
+- `strategyVersion`
+- `accountId`
+- `timestamp`
+- `payloadSchemaVersion`
+- `payload`
+- `idempotencyKey`
+- `retentionPolicy`
+- `replayBehavior`
+
+Idempotency behavior:
+
+- Event ID is globally unique.
+- Idempotency key prevents duplicate domain effects.
+- Projectors must be idempotent.
+- Replays must not call brokers or external side-effect services.
+
+Traceability: AUDIT.
+
+## 8. Security Foundation
+
+Required work:
+
+- Global authentication middleware.
+- Session identity.
+- RBAC.
+- Viewer role.
+- Trader role.
+- Operator role.
+- Administrator role.
+- Route-level authorization.
+- Account isolation.
+- Audit attribution.
+- Replay prevention.
+- CSRF policy where applicable.
+- Idempotency policy.
+- Secret scanning in CI.
+- Credential rotation procedure.
+- Emergency controls.
+- Live-trading prohibition.
+
+Role outline:
+
+| Role | Allowed |
+| --- | --- |
+| Viewer | Read-only dashboards and reports |
+| Trader | Paper manual intents and watchlist edits within account |
+| Operator | Automation pause/resume/emergency controls for paper |
+| Administrator | Configuration, admin-gated reports, user/role management |
+
+Protected route classes:
+
+- Watchlist writes.
+- Broker reads and writes.
+- Manual trading.
+- Automation controls.
+- Portfolio close/cancel controls.
+- Strategy/lab mutation.
+- Engine trigger/status changes.
+- Handoff approval.
+- Intelligence generation/backfills.
+- Future event replay/admin tools.
+
+Traceability: AUDIT, REPOSITORY_VERIFICATION.
+
+## 9. Backtesting and Experiment Tracking
+
+Backtesting requirements:
+
+- Reproducible datasets.
+- Dataset versions.
+- Strategy versions.
+- Feature versions.
+- Configuration snapshots.
+- Commission models.
+- Slippage models.
+- Liquidity assumptions.
+- Walk-forward validation.
+- Out-of-sample testing.
+- Naive baseline comparisons.
+- Metrics.
+- Artifacts.
+- Run IDs.
+- Random seeds.
+- Promotion requirements.
+- Rejection requirements.
+
+Experiment tracking record:
+
+- `experimentId`
+- `runId`
+- `strategyId`
+- `strategyVersion`
+- `datasetId`
+- `datasetVersion`
+- `featureVersions`
+- `codeCommit`
+- `configurationSnapshot`
+- `randomSeed`
+- `startedAt`
+- `completedAt`
+- `metrics`
+- `artifacts`
+- `baselineComparison`
+- `reviewStatus`
+- `reviewerActorId`
+- `promotionDecision`
+
+Promotion is rejected when:
+
+- Dataset is not reproducible.
+- Feature versions are missing.
+- Walk-forward validation fails.
+- Naive baseline is not beaten.
+- Risk limits are violated.
+- Metrics are not statistically meaningful.
+- Human approval is absent.
+
+Traceability: AUDIT, BOTH.
+
+## 10. Learning Foundation
+
+Do not design production RL execution in v2.
+
+Design the data foundation:
+
+- Trade history.
+- Decision history.
+- Feature history.
+- Signal history.
+- Risk-decision history.
+- Order history.
+- Fill history.
+- Outcome labels.
+- Reward-candidate datasets.
+- Experiment history.
+- Strategy-performance history.
+- Human-review feedback.
+
+AI or ML may propose changes, but may not automatically promote, deploy, or execute them.
+
+Learning datasets must be:
+
+- Immutable by version.
+- Paper/live segregated.
+- Free of secrets.
+- Point-in-time correct.
+- Traceable to source events.
+- Approved for research use.
+
+Traceability: BOTH.
+
+## 11. NVIDIA Integration
+
+NVIDIA integration is additive retrieval infrastructure:
+
+- Documentation corpus.
+- Architecture corpus.
+- Massive research corpus.
+- Strategy corpus.
+- Trade-journal corpus.
+- Decision-journal corpus.
+- Embedding pipeline.
+- Reranking pipeline.
+- Vector storage.
+- Retrieval service.
+- Provenance and citations.
+- Index versioning.
+- Nightly or scheduled incremental indexing.
+- CPU serving after GPU indexing.
+- GPU shutdown after jobs complete.
+
+Initial proof of value:
+
+1. Prototype embeddings using available hosted NVIDIA developer credits where appropriate.
+2. Use a short Brev L4 session for embedding and reranking validation.
+3. Persist vectors into a CPU-served vector store.
+4. Keep production request path operational even when Brev is unavailable.
+5. Measure retrieval quality, latency, cost, and usefulness before expansion.
+
+Recommended architecture:
+
+```mermaid
+flowchart TD
+  Corpus[Docs + Strategy + Journal + Market Research Corpus] --> Indexer[Batch Indexer]
+  Indexer --> Brev[NVIDIA NIM on Brev L4]
+  Brev --> Embeddings[Embeddings + Rerank Scores]
+  Embeddings --> VectorStore[(CPU-Served Vector Store)]
+  Backend[Node/Express Backend] --> Retrieval[Retrieval Service]
+  Retrieval --> VectorStore
+  Retrieval --> AI[Hosted AI / Existing Agent]
+  AI --> Operator[Operator UI]
+  Brev -. stopped after batch .-> Off[No GPU Hot Path]
+```
+
+NVIDIA requirements:
+
+- GPU is optional.
+- GPU is stoppable.
+- GPU is not required for production trading.
+- Hosted AI remains until measurements justify migration.
+- L4 is preferred for NIM embeddings/reranking.
+- A6000 is optional for embedding fine-tune/benchmarks.
+- L40S is optional for short self-hosted LLM learning.
+- T4 is not used for NIM.
+- RL remains offline research.
+
+Traceability: NVIDIA, BOTH.
+
+## 12. Implementation Roadmap
+
+### Phase 0: Documentation and Architecture Lock
+
+Dependencies:
+
+- Current certified v1.1 baseline.
+- Preserved source reports.
+
+Work:
+
+- Create canonical v2 master architecture.
+- Create implementation backlog.
+- Create ADRs.
+- Update docs index/governance.
+
+Acceptance criteria:
+
+- Both source reports preserved.
+- Traceability matrix includes all source recommendations.
+- Omitted recommendation count is zero.
+
+Rollback:
+
+- Revert documentation-only changes.
+
+Production impact:
+
+- None.
+
+### Phase 1: Auth, RBAC, Contracts, and Event Foundation
+
+Dependencies:
+
+- Phase 0 complete.
+
+Work:
+
+- Global authentication.
+- RBAC.
+- Account isolation model.
+- Strategy contract schema.
+- Durable outbox/event schema.
+- Actor attribution.
+
+Expected tests:
+
+- Auth middleware tests.
+- Route authorization tests.
+- Event idempotency tests.
+- Outbox replay safety tests.
+
+Rollback:
+
+- Feature flags for auth enforcement during rollout.
+- No live execution paths introduced.
+
+Production impact:
+
+- Should be staged carefully because auth changes affect access.
+
+### Phase 2: Feature Store and Reproducible Backtesting
+
+Dependencies:
+
+- Event schema.
+- Strategy contract.
+- Market-data provenance rules.
+
+Work:
+
+- Feature definitions.
+- Feature windows.
+- Dataset versions.
+- Backtest reproducibility.
+- Slippage/commission/liquidity models.
+
+Expected tests:
+
+- Point-in-time correctness.
+- Look-ahead bias prevention.
+- Dataset immutability.
+- Backtest replay determinism.
+
+Rollback:
+
+- Keep existing paper baseline unchanged.
+
+### Phase 3: Experiment Tracking and Paper-Only Strategy Engine
+
+Dependencies:
+
+- Feature Store.
+- Backtesting.
+- Durable event log.
+- RBAC.
+
+Work:
+
+- Experiment records.
+- Paper-only Strategy Engine integration.
+- Promotion/rejection workflow.
+- Human approval.
+
+Expected tests:
+
+- Promotion gate tests.
+- Paper-only execution gate tests.
+- Strategy rollback tests.
+
+Production impact:
+
+- Paper-only, behind explicit gates.
+
+### Phase 4: RAG and Semantic Retrieval
+
+Dependencies:
+
+- Corpus allowlist.
+- Secret-scan policy.
+- Retrieval service design.
+
+Work:
+
+- Embedding pipeline.
+- Reranking validation.
+- CPU vector store.
+- AI citations/provenance.
+- GPU cost controls.
+
+Expected tests:
+
+- Corpus redaction.
+- Index versioning.
+- Retrieval fallback when Brev unavailable.
+- Latency and quality measurement.
+
+Production impact:
+
+- Advisory only.
+
+### Phase 5: Multi-Strategy Simulation
+
+Dependencies:
+
+- Strategy Engine paper integration.
+- Experiment tracking.
+- Portfolio/risk event model.
+
+Work:
+
+- Multi-strategy simulation.
+- Conflict resolution.
+- Portfolio attribution.
+- Risk aggregation.
+
+Production impact:
+
+- Simulation only.
+
+### Phase 6: Learning Datasets and Offline Research
+
+Dependencies:
+
+- Event history.
+- Feature history.
+- Experiment history.
+
+Work:
+
+- Outcome labels.
+- Reward-candidate datasets.
+- Offline ML/RL experiments.
+- Human review feedback loop.
+
+Production impact:
+
+- No production RL execution.
+
+## 13. Traceability Matrix
+
+| Requirement ID | Recommendation | Source | Section | Phase | Status | Verification |
+| --- | --- | --- | --- | --- | --- | --- |
+| V2-001 | Preserve v1.1 certified paper baseline | REPOSITORY_VERIFICATION | 1 | 0 | Planned | Git refs and docs |
+| V2-002 | Strategy Engine remains paper-only during v2 foundation | AUDIT | 1, 6 | 1-3 | Planned | ADR + route gates |
+| V2-003 | Prohibit autonomous live trading | BOTH | 1, 8 | 1 | Planned | Auth/RBAC + config tests |
+| V2-004 | AI has no direct order authority | BOTH | 2, 10 | 1 | Planned | ADR + execution tests |
+| V2-005 | Direct AI strategy self-modification prohibited | BOTH | 1, 10 | 3 | Planned | Promotion workflow tests |
+| V2-006 | Deterministic logic before adaptive logic | BOTH | 2 | 1-6 | Planned | ADR + review gates |
+| V2-007 | Every strategy is versioned | AUDIT | 6 | 1 | Planned | Schema tests |
+| V2-008 | Every decision is replayable | AUDIT | 7 | 1-3 | Planned | Event replay tests |
+| V2-009 | Every order is idempotent | REPOSITORY_VERIFICATION | 2, 7 | 1 | Existing/extend | Existing + new idempotency tests |
+| V2-010 | Every state change has actor attribution | AUDIT | 8 | 1 | Planned | Auth + event tests |
+| V2-011 | Socket.IO remains UI fanout only | AUDIT | 7 | 1 | Planned | ADR + architecture review |
+| V2-012 | Mongo durable outbox before larger event platform | AUDIT | 7 | 1 | Planned | ADR + outbox tests |
+| V2-013 | Massive Advanced Options data is feature boundary | BOTH | 4 | 1-2 | Planned | Feature schema tests |
+| V2-014 | Do not assume premium equity real-time data | BOTH | 4 | 1-2 | Planned | Entitlement tests |
+| V2-015 | Feature records include provider source | AUDIT | 4, 5 | 2 | Planned | Feature schema tests |
+| V2-016 | Feature records include entitlement status | AUDIT | 4, 5 | 2 | Planned | Feature schema tests |
+| V2-017 | Feature records include timestamp/freshness | AUDIT | 4, 5 | 2 | Planned | Staleness tests |
+| V2-018 | Feature records include calculation version | AUDIT | 4, 5 | 2 | Planned | Version tests |
+| V2-019 | Missing data behavior is explicit | AUDIT | 4, 5 | 2 | Planned | Data-quality tests |
+| V2-020 | Quality status is explicit | AUDIT | 4, 5 | 2 | Planned | Data-quality tests |
+| V2-021 | Global authentication required | AUDIT | 8 | 1 | Planned | Middleware tests |
+| V2-022 | RBAC required | AUDIT | 8 | 1 | Planned | Authorization tests |
+| V2-023 | Account isolation required | AUDIT | 8 | 1 | Planned | Multi-account tests |
+| V2-024 | Secret scanning and rotation required | AUDIT | 8 | 1 | Planned | CI scan + runbook |
+| V2-025 | Emergency controls remain mandatory | AUDIT | 8 | 1-3 | Existing/extend | Existing + new role tests |
+| V2-026 | Backtests must be reproducible | AUDIT | 9 | 2 | Planned | Replay tests |
+| V2-027 | Dataset versions required | AUDIT | 5, 9 | 2 | Planned | Dataset immutability tests |
+| V2-028 | Strategy versions required for experiments | AUDIT | 6, 9 | 3 | Planned | Experiment schema tests |
+| V2-029 | Feature versions required for experiments | AUDIT | 5, 9 | 3 | Planned | Experiment schema tests |
+| V2-030 | Walk-forward validation required | BOTH | 9 | 2-3 | Planned | Backtest acceptance tests |
+| V2-031 | Out-of-sample validation required | AUDIT | 9 | 2-3 | Planned | Backtest acceptance tests |
+| V2-032 | Naive baselines required | BOTH | 9 | 2-3 | Planned | Experiment tests |
+| V2-033 | Experiment tracking required | AUDIT | 9 | 3 | Planned | Experiment CRUD/tests |
+| V2-034 | Learning foundation is data-first, not execution-first | BOTH | 10 | 6 | Planned | Dataset review |
+| V2-035 | RL remains offline research | BOTH | 10, 11 | 6 | Planned | ADR + route absence |
+| V2-036 | GPU infrastructure must not be production hot path | NVIDIA | 11 | 4 | Planned | Fallback tests |
+| V2-037 | Highest-value NVIDIA use is embeddings/reranking/RAG | NVIDIA | 11 | 4 | Planned | RAG prototype metrics |
+| V2-038 | Hosted AI remains until measurements justify migration | NVIDIA | 11 | 4 | Planned | Cost/latency report |
+| V2-039 | Use hosted NVIDIA developer credits before Brev spend where available | NVIDIA | 11 | 4 | Planned | Experiment record |
+| V2-040 | Use short Brev L4 for embedding/reranking validation | NVIDIA | 11 | 4 | Planned | Experiment record |
+| V2-041 | Persist vectors into CPU-served vector store | NVIDIA | 11 | 4 | Planned | Retrieval fallback tests |
+| V2-042 | GPU shuts down after indexing/jobs | NVIDIA | 11 | 4 | Planned | Cost-control checklist |
+| V2-043 | T4 is not NIM-compatible and must not be chosen for NIM | NVIDIA | 11 | 4 | Planned | Runbook check |
+| V2-044 | A6000 may be used for optional embedding fine-tune/benchmark | NVIDIA | 11 | 4 | Planned | Experiment approval |
+| V2-045 | L40S may be used for short LLM NIM learning only | NVIDIA | 11 | 4 | Planned | Experiment approval |
+| V2-046 | Do not migrate production AI to self-hosted LLM on current budget | NVIDIA | 11 | 4 | Planned | Architecture review |
+| V2-047 | Do not hand-write CUDA now | NVIDIA | 11 | 6 | Planned | ADR/governance |
+| V2-048 | Do not adopt direct TensorRT/TensorRT-LLM now | NVIDIA | 11 | 6 | Planned | ADR/governance |
+| V2-049 | GPU vector search waits for scale proof | NVIDIA | 11 | 6 | Planned | Benchmark threshold |
+| V2-050 | Time-series foundation models are research-only, not directional authority | NVIDIA | 10, 11 | 6 | Planned | Experiment policy |
+| V2-051 | Stabilize client Vitest teardown flake | AUDIT | 9 | 1 | Planned | Repeat test runs |
+| V2-052 | Correct documentation drift | AUDIT | 12 | 0-1 | Planned | Docs review |
+| V2-053 | Remove or quarantine raw/prototype docs from canonical path | AUDIT | 12 | 1 | Planned | Docs governance |
+| V2-054 | Add load/soak suites for Socket.IO, Massive, automation, AI, broker | AUDIT | 9 | 2-3 | Planned | Load test reports |
+| V2-055 | Multi-position autonomous support requires explicit future design | AUDIT | 1, 6 | 5 | Planned | ADR/design review |
+
+## Requirement-Preservation Count
+
+This master document preserves:
+
+- Enterprise audit recommendations extracted: 35.
+- NVIDIA report recommendations extracted: 20.
+- Merged canonical requirements: 55.
+- Source recommendations retained as independent requirements where not merged: 0.
+- Source recommendations omitted: 0.
+
+The merged requirements intentionally keep overlapping safety recommendations as shared `BOTH` entries rather than dropping either source.

--- a/docs/architecture/NVIDIA_BREV_ENTERPRISE_INTEGRATION_STRATEGY.md
+++ b/docs/architecture/NVIDIA_BREV_ENTERPRISE_INTEGRATION_STRATEGY.md
@@ -1,0 +1,444 @@
+# NVIDIA Brev Enterprise Integration Strategy
+
+Date: 2026-07-25
+Account context: authenticated owner account, organization `mark.velasquez-9bb070-bjor`
+Organization ID: masked as `org-3FaX...01Az`
+Credit balance supplied by owner: approximately `$25`
+Scope: NVIDIA/Brev architecture strategy only. No product features were implemented.
+
+## Executive Summary
+
+For AI-Trader at its current scale, NVIDIA Brev is not a cost-saver for the hosted LLM and transcription work already in production. GPT-4o and transcription are fully outsourced, and a self-hosted small LLM on a GPU would bill wall-clock time whether requests arrive or not. Chasing cheaper inference with only about `$25` in credits is a false economy.
+
+The strongest NVIDIA use case is a capability the platform does not currently have: embeddings, reranking, semantic retrieval, and RAG. The repository currently has no embedding pipeline, no vector search, and no RAG layer. Standing up an NVIDIA embedding and reranking NIM on a short Brev L4 session to index market news, filings, architecture docs, strategy history, decision journals, and trade journals is the one clear high-value use of the credits.
+
+Everything else is learn-or-later:
+
+- Local LLMs are not justified until hosted-token volume and latency/cost measurements justify migration.
+- TensorRT/TensorRT-LLM hand tuning is not needed because NIM packages optimized serving.
+- Time-series foundation models and reinforcement learning are research-only and high false-alpha risk.
+- GPU vector search is premature for the expected corpus size.
+- Model training is not justified until labeled datasets exist, except for a short embedding fine-tune experiment after RAG value is proven.
+
+Brev's strategic value is optionality: a per-hour, stoppable, multi-cloud GPU control plane for research, indexing, training, and benchmarking jobs. It must not become a required production dependency.
+
+One key correction affects GPU choice: the T4 16 GB is the cheapest observed GPU, but it cannot run NVIDIA NIM because its CUDA compute capability is 7.5. NIM optimized engines require compute capability at least 8.0, and FP8 paths require 8.9 or higher. The practical floor for NIM work is an L4 24 GB.
+
+## Account and CLI State
+
+Observed from authenticated Brev CLI v0.6.331:
+
+- CLI installed and authenticated.
+- Active organization: `mark.velasquez-9bb070-bjor`.
+- Organization ID was verified but is intentionally masked in this document.
+- Instances running: `0`.
+- Current burn rate from active instances: `$0/hr`.
+- CLI healthcheck: healthy.
+- CLI supports instance search, creation, shell, exec, open, copy, port-forward, organization management, and device registration.
+- CLI includes `redeem`, but no balance-read command was observed. The owner-supplied approximate credit balance is `$25`; track exact remaining balance in the Brev web console.
+
+No authentication cookies, login URLs, refresh tokens, API keys, or credentials are preserved in this document.
+
+## Brev Platform Primitives
+
+Relevant Brev primitives:
+
+- GPU instances: preconfigured VMs with CUDA/Docker/Jupyter-style ML workflows.
+- CPU instances: low-cost compute boxes, useful mostly as disposable harnesses.
+- Environments: preinstalled software stacks.
+- Launchables: shareable hardware/software/code bundles that can launch VMs, containers, compose stacks, or Kubernetes-style workloads.
+- NIM deployment: first-class deploy path for OpenAI-compatible NIM endpoints, commonly exposed on port `8000`.
+- Access: `brev shell`, `brev exec`, `brev open`, `brev copy`, and `brev port-forward`.
+- Editor support: remote VS Code, Cursor, Windsurf, terminal, and tmux.
+- Public access: tunnel or launchable secure endpoint, if explicitly enabled.
+- Management: CLI-first. No official Python management SDK was identified during the review.
+
+## GPU and CPU Capability Inventory
+
+Pricing observations are from live `brev search` output during the audit and can change by region, provider, capacity, and time. Treat these numbers as observed-at-audit-time estimates, not procurement commitments.
+
+| GPU | VRAM | Architecture / Compute Capability | Observed from $/hr | Approx $25 runtime | NIM suitability | Best use |
+| --- | ---: | --- | ---: | ---: | --- | --- |
+| T4 | 16 GB | Turing / 7.5 | `$0.48/hr` | ~52 hrs | No | Generic CUDA/PyTorch only; not NIM |
+| A6000 | 48 GB | Ampere / 8.6 | `$0.60-$0.68/hr` | ~36-41 hrs | BF16 paths | Best value 48 GB; embedding fine-tune or benchmarks |
+| L4 | 24 GB | Ada / 8.9 | `$0.85/hr` | ~29 hrs | FP8-capable | Top pick for embedding and reranking NIM |
+| L40S | 48 GB | Ada / 8.9 | `$1.06/hr` | ~23 hrs | FP8-capable | LLM NIM learning with headroom |
+| A10G | 22 GB | Ampere / 8.6 | `$1.21/hr` | ~20 hrs | BF16 paths | 8B LLM NIM experiments |
+| A100 | 40/80 GB | Ampere / 8.0 | `$1.63-$1.66/hr` | ~15 hrs | BF16 paths | Short fine-tune bursts, larger batch inference |
+| H100 | 80 GB | Hopper / 9.0 | higher, observed around `$3/hr` class in report context | ~8 hrs at `$3/hr` | FP8-capable | Overkill for current platform |
+
+CPU inventory:
+
+- CPU-only instances start around `$0.05/hr`.
+- Examples observed include GCP `n2d-highcpu-2` at roughly `$0.05/hr` and higher-memory CPU boxes from roughly `$0.09-$0.72/hr`.
+- Recommendation: do not move production Node/Express/Mongo, Socket.IO fanout, or ordinary pandas backtests to Brev CPU. Those workloads belong on existing production infrastructure unless paired with a GPU experiment.
+
+Storage cost note:
+
+- Persistent disks add cost even when compute is stopped.
+- The report estimated about `$0.0001314/GB/hr`, roughly `$0.32/day` for 100 GB. Delete or snapshot intentionally instead of leaving large idle disks.
+
+## GPU Compute-Capability and NIM Compatibility
+
+NIM compatibility matters more than raw hourly cost:
+
+- T4 has compute capability 7.5 and is not suitable for NVIDIA NIM optimized engines.
+- Ampere-class GPUs such as A6000, A10G, and A100 support BF16-oriented NIM paths.
+- Ada-class GPUs such as L4 and L40S support FP8-oriented paths and are better NIM targets.
+- The correct practical floor for NIM embedding/reranking work is L4 24 GB.
+- Use T4 only for generic CUDA or PyTorch experiments that do not require NIM.
+
+## Capability Matrix
+
+| Capability | Verdict | Rationale tied to AI-Trader |
+| --- | --- | --- |
+| Embedding models | Do now | Tiny relative to LLMs, batchable, one-time or nightly indexing, unlocks semantic recall. |
+| RAG pipeline | Do now | Repository has no embeddings/vector/RAG today; this is a genuine new advisory capability. |
+| Reranking NIM | Do now | Pairs with embeddings to improve retrieval quality; L4 is suitable. |
+| NIM microservices | Do now for embeddings/reranking | OpenAI-compatible endpoint means integration can be a base URL/client seam. |
+| Agent orchestration | Later | Existing orchestrator uses hosted GPT; keep it. Revisit NeMo Agent Toolkit only when self-hosting. |
+| Local/self-hosted LLM | Later | Hosted APIs win on cost/latency until measured high utilization. Spend only a small learning session. |
+| CUDA direct | Later | Avoid hand-written CUDA. Use NIM/RAPIDS/cuDF/cuVS when justified. |
+| TensorRT/TensorRT-LLM | Not now | NIM hides most optimization. Direct engine builds are not worth the operational cost now. |
+| Time-series foundation models | Not now | High false-alpha risk; if explored, target volatility/volume research, not directional live trading. |
+| GPU vector search | Not now | CPU pgvector/FAISS is simpler until corpus reaches very large scale or high batched QPS. |
+| Model training | Not now | No labeled dataset assembled. Exception: small embedding-domain fine-tune after RAG value is proven. |
+| Reinforcement learning | Not now | Must remain offline, paper-only research. GPU cost is not the risk; false alpha is. |
+
+## Embedding Recommendation
+
+Use NVIDIA for embeddings first.
+
+Recommended corpus:
+
+- Architecture docs.
+- Production certification docs.
+- Massive integration docs.
+- Strategy definitions.
+- Watchlist and automation docs.
+- Market news and filings where available.
+- Trade journal.
+- Decision journal.
+- Strategy analytics and daily reports.
+
+Recommended workflow:
+
+1. Prototype with hosted NVIDIA developer credits where available.
+2. Batch embed the corpus on a short Brev L4 session.
+3. Persist vectors into a CPU-served vector store.
+4. Turn off or delete the GPU instance.
+5. Query the vector store from the existing Node/agent orchestration path.
+
+## Reranking Recommendation
+
+Use reranking after initial embedding retrieval:
+
+- Retrieve top `k` candidates from CPU vector store.
+- Rerank with an NVIDIA reranking NIM during offline validation or batch jobs.
+- Compare answer quality and citation usefulness against embeddings-only retrieval.
+- Keep reranking optional until latency and cost are measured.
+
+## RAG Recommendation
+
+Build RAG as an additive advisory layer, not as a replacement for deterministic trading logic.
+
+RAG should:
+
+- Retrieve source-grounded context for the AI desk.
+- Support citations/provenance.
+- Improve strategy-review and post-trade analysis.
+- Help operators ask questions across architecture, journal, news, and strategy history.
+
+RAG must not:
+
+- Submit orders.
+- Modify strategies.
+- Promote strategies.
+- Override risk decisions.
+- Become required for production execution.
+
+## Local LLM Recommendation
+
+Keep hosted AI services in place until measurements justify migration.
+
+Only run a short L40S/A10G learning session to:
+
+- Deploy an 8B LLM NIM.
+- Validate the OpenAI-compatible base URL swap.
+- Measure tokens/sec.
+- Compare cost per million tokens against current hosted usage.
+- Document cold start, latency, ops burden, and quality.
+
+Do not migrate production AI to self-hosted LLMs on the current credit budget.
+
+## CUDA Recommendation
+
+Do not hand-write CUDA. Use packaged acceleration through:
+
+- NIM for inference.
+- RAPIDS/cuDF for future feature-prep acceleration.
+- cuVS only when vector scale requires it.
+
+Direct CUDA work is not aligned with the current platform risks.
+
+## TensorRT Recommendation
+
+Do not adopt direct TensorRT or TensorRT-LLM workflows now.
+
+Reasons:
+
+- NIM already packages optimized engines.
+- Engine builds are operationally expensive.
+- Model serving is not the current bottleneck.
+- The team needs strategy, event, feature, and security contracts before low-level inference tuning.
+
+## Time-Series-Model Recommendation
+
+Do not prioritize time-series foundation models for directional options trading.
+
+If explored later:
+
+- Use them for volatility, volume, liquidity, or regime research rather than directional prediction.
+- Require naive baselines.
+- Require walk-forward validation.
+- Keep results paper-only.
+- Treat as experiment-tracking data, not production signal authority.
+
+## Vector-Search Recommendation
+
+Use CPU-served vector search first:
+
+- pgvector if the team wants Postgres semantics.
+- FAISS CPU if the team wants file-backed/local retrieval.
+- Mongo vector search only if it fits the existing Atlas posture and cost.
+
+GPU vector search should wait until:
+
+- Corpus grows toward very large scale.
+- Query volume becomes high.
+- CPU retrieval latency is proven to be a bottleneck.
+- A benchmark shows cuVS/CAGRA wins for the actual workload.
+
+## Model-Training Recommendation
+
+Do not start model training initiatives until labeled datasets exist.
+
+Allowed small experiment:
+
+- Fine-tune an embedding model on AI-Trader domain text after baseline RAG quality is measured.
+- Run as a short A6000 burst.
+- Record dataset version, parameters, metrics, and retrieval-quality changes.
+
+## Reinforcement-Learning Recommendation
+
+RL remains offline, paper-only research.
+
+Do not use RL for production execution because:
+
+- Reward hacking is likely.
+- Backtest overfitting can appear as alpha.
+- Trading environments are non-stationary.
+- Explainability and control are weaker than deterministic strategies.
+- The platform lacks reproducible datasets and experiment tracking today.
+
+If explored later, use FinRL-style or custom environments only for learning. Require walk-forward validation, naive baselines, and human review. Never promote RL output directly to live or paper execution without deterministic conversion and approval.
+
+## Current Architecture
+
+```mermaid
+flowchart TD
+  Client[React Trading Workstation] --> Backend[Node/Express API]
+  Backend --> Orchestrator[Assistant Orchestrator]
+  Orchestrator --> HostedAI[Hosted GPT / Whisper]
+  Backend --> Agent[FastAPI Agent]
+  Backend --> Mongo[(MongoDB)]
+  Backend --> Massive[Massive Options Data]
+  Backend --> Alpaca[Alpaca Paper]
+  Backend -. missing .-> Vector[(No Vector Store)]
+  Backend -. missing .-> RAG[No RAG Layer]
+```
+
+Current AI surface is hosted-API based. There is no repository evidence of embeddings, vector indexing, semantic retrieval, or RAG.
+
+## Recommended Architecture
+
+```mermaid
+flowchart TD
+  Client[React Trading Workstation] --> Backend[Node/Express API]
+  Backend --> Orchestrator[Assistant Orchestrator]
+  Orchestrator --> Retrieval[Retrieval Service]
+  Retrieval --> VectorStore[(CPU Vector Store)]
+  Orchestrator --> HostedAI[Hosted GPT / Existing AI]
+  Indexer[Batch Indexer] --> NIM[NVIDIA Embedding + Rerank NIM on Brev]
+  NIM --> Indexer
+  Indexer --> VectorStore
+  Backend --> Mongo[(MongoDB)]
+  Backend --> Massive[Massive Options Data]
+  Backend --> Alpaca[Alpaca Paper]
+```
+
+The GPU is in the indexing/validation path. The production hot path continues to work when Brev is unavailable.
+
+## Integration Seam
+
+The integration seam is an OpenAI-compatible embeddings endpoint:
+
+```text
+Indexer -> /v1/embeddings on NIM endpoint
+Indexer -> vector store write
+Orchestrator -> retrieval service -> CPU vector store
+Orchestrator -> hosted AI with cited context
+```
+
+Requirements:
+
+- No browser access to NVIDIA credentials.
+- No GPU dependency in execution path.
+- Retrieval responses include provenance and citations.
+- Index versions are recorded.
+- Nightly or scheduled delta indexing can run without requiring the GPU to stay online.
+
+## GPU Recommendations
+
+Primary: L4 24 GB at observed `$0.85/hr`.
+
+- Best fit for embedding and reranking NIM.
+- Compute capability 8.9.
+- Approximately 29 hours from `$25`.
+- Enough to validate RAG, index a meaningful corpus, and run reranking comparisons.
+
+Value: A6000 48 GB at observed `$0.60-$0.68/hr`.
+
+- Best value high-VRAM burst box.
+- Use for embedding fine-tune or broad benchmark if needed.
+- Not the first NIM pick if L4 is available.
+
+Headroom: L40S 48 GB at observed `$1.06/hr`.
+
+- Use for short LLM NIM learning.
+- Good for OpenAI-compatible endpoint validation.
+- Do not leave running.
+
+Avoid for NIM: T4 16 GB at observed `$0.48/hr`.
+
+- Cheapest GPU but NIM-incompatible due to compute capability 7.5.
+- Use only for generic CUDA/PyTorch experiments.
+
+## Credit-Utilization Plan
+
+| Step | GPU / Service | Hours | Estimated Cost | Outcome |
+| --- | --- | ---: | ---: | --- |
+| 1 | Hosted NVIDIA developer API credits where available | n/a | `$0` | Validate embedding/RAG design before Brev spend |
+| 2 | L4 24 GB | ~9 | ~$8 | Embedding + reranking validation, initial corpus index |
+| 3 | A6000 48 GB optional | ~7 | ~$4-$5 | Domain embedding fine-tune after baseline quality measured |
+| 4 | L40S 48 GB | ~3 | ~$3 | Learn LLM NIM deployment and base URL swap |
+| 5 | A6000/L4 benchmark spike | ~6 | ~$4-$6 | CPU vs GPU vector/search/feature benchmark and volatility probe |
+| 6 | Reserve | n/a | ~$5-$8 | Storage overhead, reruns, failed launches |
+
+## Cost Controls
+
+Hard requirements:
+
+- Check `brev ls` before and after every session.
+- Prefer short sessions with explicit stop/delete.
+- Do not leave GPUs running overnight.
+- Do not use GPU for production hot path.
+- Keep setup in a Launchable or script so instances can be deleted instead of preserved.
+- Track storage separately.
+- Record observed hourly price before creating an instance.
+- Do not create multiple instances without explicit approval.
+- Do not create expensive H100/multi-GPU instances without explicit approval.
+
+## Auto-Stop and Shutdown Requirements
+
+Every Brev GPU session should include:
+
+- Startup script that logs instance type, provider, GPU, and expected cost.
+- Auto-shutdown timer for the planned experiment window.
+- Final artifact copy or upload before shutdown.
+- `brev ls` verification after shutdown/delete.
+- Written experiment record with cost, runtime, model, corpus, metrics, and outcome.
+
+## Quick Wins
+
+1. Prototype embeddings against hosted NVIDIA developer credits before using Brev credits.
+2. Launch a RAG-with-local-NIM style environment on L4 for one indexing session.
+3. Batch index architecture docs, market-data docs, strategy docs, decision journal, and trade journal.
+4. Store vectors in a CPU-served vector store.
+5. Add retrieval to the AI orchestrator as advisory context only.
+6. Run a short L40S LLM NIM session to understand self-hosted inference economics.
+
+## Long-Term Roadmap
+
+### Phase 0: Prove It Free
+
+- Design retrieval service.
+- Prototype hosted NVIDIA embeddings with free developer credits where available.
+- Decide corpus scope.
+- Spend `$0` Brev credits.
+
+### Phase 1: Stand Up RAG on GPU
+
+- Launch L4.
+- Run embedding and reranking NIM.
+- Index corpus into CPU vector store.
+- Shut down GPU immediately after indexing.
+- Estimated cost: `$8-$12`.
+
+### Phase 2: Learn Self-Hosted LLM Path
+
+- Short L40S session.
+- Deploy an 8B LLM NIM.
+- Measure tokens/sec, latency, cost, and quality.
+- Compare against hosted OpenAI usage.
+- Estimated cost: about `$3`.
+
+### Phase 3: Scale Only on Evidence
+
+- Self-host LLM only when token volume clears measured crossover.
+- Move vector search to GPU only after corpus and QPS justify it.
+- Keep time-series and RL research offline and paper-only.
+- Require walk-forward validation and experiment tracking before any promotion.
+
+## Cost Forecast
+
+| Horizon | Expected NVIDIA Spend | Note |
+| --- | ---: | --- |
+| Phase 0 | `$0` | Hosted developer credits where available |
+| Phases 1-2 | `$15-$18` | Within supplied `$25` budget |
+| Steady-state RAG | Approximately `$0 GPU/month` | GPU off after indexing; CPU serves retrieval |
+| Self-hosted LLM | `$0.85-$1.06/hr` class | Only if token volume and utilization justify it |
+
+## Risk Register
+
+| Risk | Severity | Mitigation |
+| --- | --- | --- |
+| Runaway GPU bill | High | Auto-stop scripts, `brev ls`, no overnight GPU, explicit cost before create |
+| RL/time-series false alpha | High | Offline only, naive baselines, walk-forward validation, paper-only |
+| Provider capacity | Medium | Use Launchables/scripts to relaunch elsewhere |
+| Vendor lock-in | Low | NIM is OpenAI-compatible; vector store remains CPU-served |
+| Production dependency creep | High | GPU cannot be required for trading, health, or execution paths |
+| Data leakage into embeddings | High | Corpus allowlist, no secrets, no credentials, provenance and redaction |
+
+## Definition of Success
+
+The NVIDIA integration is successful only if:
+
+- The first proof of value uses embeddings/reranking/RAG, not local LLM migration.
+- GPU work is batchable and stoppable.
+- Vectors are persisted into a CPU-served store.
+- Production AI and trading workflows continue operating when Brev is unavailable.
+- Retrieval quality, latency, cost, and usefulness are measured.
+- No credentials, account cookies, or private session artifacts are committed.
+- RL remains offline/paper-only research.
+- Hosted AI remains in production until data proves self-hosting is better.
+
+## Final Recommendation
+
+Implementation priority in one line:
+
+```text
+Prototype RAG free -> index on L4 -> serve vectors on CPU -> run a short L40S self-hosted-LLM learning session -> expand only when measurements justify it.
+```
+
+The `$25` credits should buy capability and knowledge, not a production dependency.

--- a/docs/architecture/adr/001-strategy-engine-paper-only.md
+++ b/docs/architecture/adr/001-strategy-engine-paper-only.md
@@ -1,0 +1,19 @@
+# ADR 001: Strategy Engine Remains Paper-Only During v2 Foundation
+
+Date: 2026-07-25
+Status: Accepted
+
+## Context
+
+The certified `v1.1-enterprise-baseline` is an options-first paper-trading platform. The Enterprise Strategy Engine Readiness Audit found that the platform is stable for paper trading but lacks the identity, RBAC, durable eventing, feature provenance, backtesting reproducibility, and experiment tracking required for autonomous live-money execution.
+
+## Decision
+
+The Strategy Engine may be designed and implemented only for simulation and paper trading during the v2 foundation. It must not be connected to live-money execution paths.
+
+## Consequences
+
+- Strategy contracts, signal logic, feature-store design, backtests, experiments, and paper execution may proceed.
+- Live broker adapters, live order submission, and live-money automation remain prohibited.
+- Any future live-money program requires a separate architecture review, security review, compliance review, runbook, and certification cycle.
+

--- a/docs/architecture/adr/002-ai-has-no-direct-order-authority.md
+++ b/docs/architecture/adr/002-ai-has-no-direct-order-authority.md
@@ -1,0 +1,19 @@
+# ADR 002: AI Has No Direct Order-Execution Authority
+
+Date: 2026-07-25
+Status: Accepted
+
+## Context
+
+AI-Trader already uses advisory AI surfaces and an agent proxy. The audit found that AI should consume evidence and assist operators, but deterministic systems must retain execution authority.
+
+## Decision
+
+AI may summarize, retrieve, explain, draft, and recommend. AI may not submit orders, approve risk, promote strategies, clear emergency stops, modify execution rules, or bypass deterministic gates.
+
+## Consequences
+
+- AI output is advisory context only.
+- Order authority remains in deterministic execution gateways, broker adapters, risk gates, and human approvals.
+- RAG and future learning systems must not gain direct execution privileges.
+

--- a/docs/architecture/adr/003-mongo-durable-outbox-before-event-platform.md
+++ b/docs/architecture/adr/003-mongo-durable-outbox-before-event-platform.md
@@ -1,0 +1,19 @@
+# ADR 003: Mongo Durable Outbox Before Introducing Another Event Platform
+
+Date: 2026-07-25
+Status: Accepted
+
+## Context
+
+The current platform already uses MongoDB for application state and Socket.IO for UI fanout. The audit found that Socket.IO is not a durable system of record, but adding Kafka, NATS, or another event platform before contracts are proven would add operational complexity.
+
+## Decision
+
+AI-Trader v2 will begin with a Mongo-backed transactional outbox or equivalent durable event log. A larger event bus may be considered only after event schemas, replay semantics, and projector patterns are proven.
+
+## Consequences
+
+- Durable events can be introduced without new infrastructure.
+- Replays must be side-effect safe and must not call broker/provider APIs.
+- Socket.IO remains a projection/fanout layer, not the source of truth.
+

--- a/docs/architecture/adr/004-massive-advanced-options-initial-feature-boundary.md
+++ b/docs/architecture/adr/004-massive-advanced-options-initial-feature-boundary.md
@@ -1,0 +1,19 @@
+# ADR 004: Massive Advanced Options Data Is the Initial Feature Boundary
+
+Date: 2026-07-25
+Status: Accepted
+
+## Context
+
+The platform is entitlement-limited, not capability-limited. The certified baseline uses Massive Advanced Options Market Data and intentionally avoids dependence on unauthorized premium equity real-time feeds.
+
+## Decision
+
+AI-Trader v2 features must be designed around the current Massive options-market entitlement boundary: options chains, contracts, quotes, trades, snapshots, greeks, implied volatility, open interest, volume, spreads, authorized aggregates, and market status.
+
+## Consequences
+
+- No feature may assume premium real-time equity data.
+- Every feature must carry provider source, entitlement status, timestamp, freshness, calculation version, missing-data behavior, and quality status.
+- Equity-derived context must be labeled delayed, snapshot, unauthorized, or derived as appropriate.
+

--- a/docs/architecture/adr/005-gpu-services-optional-research-infrastructure.md
+++ b/docs/architecture/adr/005-gpu-services-optional-research-infrastructure.md
@@ -1,0 +1,19 @@
+# ADR 005: GPU Services Are Optional Research Infrastructure
+
+Date: 2026-07-25
+Status: Accepted
+
+## Context
+
+The NVIDIA Brev strategy found that the highest-value use of the owner's approximate `$25` credits is short-lived embedding, reranking, RAG, and benchmarking work. GPU infrastructure is not a cost-saver for the current hosted AI usage.
+
+## Decision
+
+NVIDIA Brev and other GPU services are optional research, indexing, training, and benchmarking infrastructure. They must not become required for production trading, health, execution, or operator workflows.
+
+## Consequences
+
+- GPU jobs must be measurable, stoppable, and documented.
+- Production must continue operating when Brev is unavailable.
+- Hosted AI remains in place until measurements justify migration.
+

--- a/docs/architecture/adr/006-cpu-served-retrieval-without-brev.md
+++ b/docs/architecture/adr/006-cpu-served-retrieval-without-brev.md
@@ -1,0 +1,19 @@
+# ADR 006: CPU-Served Retrieval Remains Available Without Brev
+
+Date: 2026-07-25
+Status: Accepted
+
+## Context
+
+The NVIDIA report recommends embeddings and reranking as the first useful GPU work, but only as an additive advisory capability. The GPU should index or validate, then shut down.
+
+## Decision
+
+AI-Trader retrieval must serve from a CPU-accessible vector store after indexing. Brev/NVIDIA GPU services may generate embeddings or rerank during batch jobs, but production retrieval must degrade gracefully when Brev is unavailable.
+
+## Consequences
+
+- Vector data is persisted outside the GPU instance.
+- The retrieval service includes fallback behavior.
+- GPU outages or shutdowns cannot break the production request path.
+

--- a/docs/architecture/adr/007-strategy-promotion-requires-evidence-and-human-approval.md
+++ b/docs/architecture/adr/007-strategy-promotion-requires-evidence-and-human-approval.md
@@ -1,0 +1,19 @@
+# ADR 007: Strategy Promotion Requires Deterministic Evidence and Human Approval
+
+Date: 2026-07-25
+Status: Accepted
+
+## Context
+
+The audit found partial strategy versioning and backtesting, but no complete promotion architecture. The v2 Strategy Engine requires deterministic governance before paper execution expansion.
+
+## Decision
+
+Strategy promotion requires deterministic evidence and human approval. Required evidence includes strategy version, feature versions, dataset versions, configuration snapshot, reproducible backtest, walk-forward validation, out-of-sample validation, naive baseline comparison, risk review, and reviewer attribution.
+
+## Consequences
+
+- AI and ML may propose changes but cannot promote them.
+- Backtest-only success is insufficient for promotion.
+- Promotion and rejection are durable events.
+

--- a/docs/architecture/adr/008-rl-offline-research-no-production-execution.md
+++ b/docs/architecture/adr/008-rl-offline-research-no-production-execution.md
@@ -1,0 +1,19 @@
+# ADR 008: Reinforcement Learning Remains Offline Research With No Production Execution Path
+
+Date: 2026-07-25
+Status: Accepted
+
+## Context
+
+Both the enterprise audit and NVIDIA strategy found that RL is high risk at this stage. The issue is not GPU cost; the issue is false alpha, reward hacking, overfit backtests, and weak explainability.
+
+## Decision
+
+Reinforcement learning remains offline, paper-only research. No RL policy may execute orders, promote strategies, alter risk rules, or participate in production execution.
+
+## Consequences
+
+- Learning work focuses on datasets, labels, reward candidates, experiment tracking, and human review.
+- RL experiments require naive baselines and walk-forward validation.
+- Any future RL-to-production discussion requires a separate ADR and certification cycle.
+

--- a/docs/audits/ENTERPRISE_STRATEGY_ENGINE_READINESS_AUDIT.md
+++ b/docs/audits/ENTERPRISE_STRATEGY_ENGINE_READINESS_AUDIT.md
@@ -1,0 +1,710 @@
+# AI-Trader Enterprise Strategy Engine Readiness Audit
+
+Date: 2026-07-25
+Baseline reviewed: `v1.1-enterprise-baseline`
+Baseline commit: `b31f6c83d1136d9c5093034ae0be50e6b8b2caf3`
+Scope: repository architecture audit only. No product features were implemented.
+
+## Executive Summary
+
+AI-Trader is production-stable for the certified v1.1 options-first paper-trading baseline. The platform has a coherent React/Vite client, Node/Express backend, MongoDB persistence layer, Massive market-data ownership, Alpaca paper broker integration, Socket.IO fanout, automation scheduler/monitor, portfolio command center, trading-intelligence records, and advisory FastAPI AI service.
+
+The platform is ready to begin Strategy Engine foundation work: strategy contracts, event contracts, feature-store design, backtesting hardening, experiment tracking, retrieval/RAG research, and paper-only strategy research.
+
+The platform is not yet architecturally ready for autonomous live-money execution, production reinforcement learning, direct AI execution authority, multi-account automation, unreviewed strategy self-modification, or GPU-required production execution.
+
+Primary finding: the current bottleneck is not compute. The bottleneck is enterprise control architecture: identity, RBAC, durable eventing, replayable feature provenance, strategy lifecycle governance, experiment tracking, and deterministic promotion gates.
+
+## Certification Baseline
+
+The audit starts from the certified v1.1 baseline:
+
+- Git branch: `main`
+- Git commit: `b31f6c83d1136d9c5093034ae0be50e6b8b2caf3`
+- Git tag: `v1.1-enterprise-baseline`
+- Baseline certification docs:
+  - `docs/release/PRODUCTION_CERTIFICATION.md`
+  - `docs/release/ENTERPRISE_BASELINE.md`
+  - `docs/architecture/ENTERPRISE_GROWTH_STRATEGY.md`
+
+Certification evidence preserved in the repository states:
+
+```text
+npm run lint                          PASS
+npm run build                         PASS
+npm --prefix server test              PASS, 425 passed
+npm --prefix client test              PASS, 138 passed
+npm --prefix client run test:e2e      PASS, 31 passed / 1 skipped
+npm --prefix client run test:e2e:prod PASS, 31 passed / 1 skipped
+npm audit                             PASS, 0 vulnerabilities
+npm --prefix client audit             PASS, 0 vulnerabilities
+npm --prefix server audit             PASS, 0 vulnerabilities
+Production aggregate health           GREEN
+```
+
+During this audit, `npm --prefix client test` passed on rerun but first surfaced an unhandled Vitest teardown/RPC error after all tests passed. That is classified as testing reliability debt, not evidence of a product regression.
+
+## Current Architecture
+
+AI-Trader v1.1 is an options-first, paper-trading platform with these runtime units:
+
+- `client/`: React/Vite trading workstation with charts, options matrix, order ticket, watchlist, portfolio, cockpit, automation command center, system operations, health surfaces, AI desk, and trading intelligence views.
+- `server/`: Node/Express API gateway and application core. Owns Massive credentials, market-data normalization, Socket.IO fanout, Mongo persistence, automation scheduling, broker adapter access, portfolio operations, health reporting, and AI proxying.
+- `agent/`: FastAPI advisory AI service for analysis, strategy extraction, transcription, SIFT extraction, chat-compatible completions, and basic backtest response surfaces.
+- `python-screener-service/`: FastAPI/Python screener and backtest service for 0DTE covered-call, iron-condor, lab backtest, screener backtest, and 0DTE universe scan endpoints.
+- MongoDB Atlas/local Mongo: durable state for watchlists, automation records, order intents, broker orders, positions, conversations, strategy/lab records, reports, journals, and operational history.
+- Massive: market-data provider under the current options-advanced entitlement boundary.
+- Alpaca: paper broker truth for account, clock, orders, positions, fills, and reconciliation.
+- Vercel: frontend hosting and same-origin rewrites.
+- Render: backend and agent hosting.
+
+## Current System Diagram
+
+```mermaid
+flowchart LR
+  User[Operator Browser] --> Client[React/Vite Client]
+  Client -->|same-origin /api| Vercel[Vercel Rewrites]
+  Client <-->|Socket.IO| Vercel
+  Vercel --> Backend[Node/Express Backend]
+  Backend <-->|Socket.IO rooms| Client
+  Backend --> Mongo[(MongoDB)]
+  Backend --> Massive[Massive REST + Options WS]
+  Backend --> Alpaca[Alpaca Paper REST]
+  Backend --> Agent[FastAPI Agent]
+  Backend --> Screener[Python Screener Service]
+  Agent --> OpenAI[Hosted AI APIs]
+  Screener --> Massive
+```
+
+## Data-Flow Diagram
+
+```mermaid
+flowchart TD
+  Massive[Massive Options Data] --> MQ[Backend Massive Queue]
+  MQ --> Cache[Response Cache + Chain Cache + Quote Cache]
+  Cache --> Charts[Chart Hub]
+  Cache --> Options[Options Matrix / Ladder / Tape]
+  Cache --> Automation[Automation Signal + Risk]
+  Cache --> AIContext[AI Context Builders]
+  Charts --> Socket[Socket.IO Fanout]
+  Socket --> Client[React Client]
+  Automation --> Intents[(Mongo Order Intents)]
+  Alpaca[Alpaca Paper Broker] --> Reconcile[Reconciliation Worker]
+  Reconcile --> Positions[(Mongo Positions + Broker Orders)]
+  Positions --> Portfolio[Portfolio Command Center]
+  Intents --> Portfolio
+  AIContext --> Agent[FastAPI Agent]
+  Agent --> Client
+```
+
+## Execution-Flow Diagram
+
+```mermaid
+sequenceDiagram
+  participant W as Watchlist
+  participant S as Signal Evaluator
+  participant R as Risk Engine
+  participant I as Order Intent Journal
+  participant B as Alpaca Paper Broker
+  participant P as Position Manager
+  participant M as Monitor Scheduler
+  W->>S: enabled automation universe
+  S->>S: evaluate options-native flow
+  S->>R: candidate + contract + feature snapshot
+  R->>I: approved/rejected durable decision
+  I->>B: submit only when gates allow
+  B->>P: order/fill truth via REST reconciliation
+  P->>M: open position lifecycle
+  M->>I: exit intent when stop/target/EOD/recovery
+  I->>B: idempotent paper exit order
+  B->>P: fill observed
+```
+
+## Current API Inventory
+
+Node/Express gateway mounts:
+
+| Mount | Responsibility |
+| --- | --- |
+| `/health`, `/api/health` | Basic backend health |
+| `/api/system/health` | Composite subsystem health |
+| `/api/market` | Aggregates, trades, quotes, option chains/contracts/selection, references, indicators, short-interest, short-volume |
+| `/api/market-data` | Options market-data health and status |
+| `/api/options` | Option selection persistence compatibility surface |
+| `/api/broker` | Alpaca account, clock, option positions, option orders |
+| `/api/trading/manual` | Manual intent create/confirm/submit boundary |
+| `/api/automation` | Automation health, scheduler, sessions, reconciliation, candidates, selections, risk decisions, universe evaluations |
+| `/api/portfolio` | Operations, positions, orders, automation visibility, timeline, trades, pause/resume/emergency stop, cancel/close |
+| `/api/watchlist` | Watchlist and automation-universe source of truth |
+| `/api/intelligence` | Trading sessions, trade reports, daily reports, decision journal, strategy analytics, admin-gated generation/backfills |
+| `/api/agent` | FastAPI agent proxy and health |
+| `/api/analyze` | Assistant analysis route |
+| `/api/chat` | AI chat route |
+| `/api/conversations` | Conversation persistence |
+| `/api/lab` | Strategy lab CRUD, versions, AI review, extraction notifications |
+| `/api/strategy` | Strategy parse, compile, extracted compile, backtest, versions |
+| `/api/engine` | Engine demo strategies, trigger/status, screener hook |
+| `/api/lab/futures`, `/api/engine/futures` | Futures contracts, backtest, stress test, paper runtime, promotion/deploy demo |
+| `/api/handoff` | Handoff requests and approval |
+| `/api/chart/health` | Chart health logs/stats |
+
+Python Agent endpoints:
+
+| Endpoint | Responsibility |
+| --- | --- |
+| `GET /health` | Agent health and commit |
+| `GET /data/capitol-trades` | External context stub/fetch surface |
+| `GET /data/fred-calendar` | Macro calendar context |
+| `GET /data/earnings` | Earnings context |
+| `POST /analyze` | Advisory analysis |
+| `POST /extract-strategy` | Strategy extraction |
+| `POST /extract-strategy-async` | Async strategy extraction |
+| `POST /transcribe-audio` | Audio transcription |
+| `POST /generate-strategy` | Code generation response |
+| `POST /interpret-rules` | Rule interpretation |
+| `POST /v1/chat/completions` | OpenAI-compatible chat surface |
+| `POST /backtest` | Agent backtest response |
+
+Python Screener endpoints:
+
+| Endpoint | Responsibility |
+| --- | --- |
+| `GET /health` | Screener service health |
+| `POST /api/screen/0dte-covered-calls` | 0DTE covered-call screen |
+| `POST /api/screen/iron-condor` | Iron-condor screen |
+| `POST /api/lab/backtest` | Lab backtest |
+| `POST /api/lab/screener/backtest` | Screener backtest |
+| `POST /api/scan/0dte-universe` | 0DTE universe scan |
+
+Socket.IO events observed:
+
+| Event family | Purpose |
+| --- | --- |
+| `live:subscribe`, `live:unsubscribe`, `live:quote`, `live:trade`, `live:trades`, `live:status`, `live:error` | Live market-data UI fanout |
+| `chart:focus`, `chart:snapshot`, `chart:update`, `chart:error`, `chart:cleared` | Chart hub and aggregate fanout |
+| `automation:visibility:subscribe`, `automation:visibility`, `automation:event`, `automation:visibility:error` | Automation command-center visibility |
+| `futures:*` | Futures paper runtime updates |
+| `strategy-extracted` | Lab extraction notifications |
+| `screener_signal` | Screener/engine notifications |
+
+Socket.IO is suitable for UI fanout. It is not a durable system of record and must not be treated as the canonical event architecture for Strategy Engine v2.
+
+## Validation Evidence
+
+Audit command evidence:
+
+```text
+git branch --show-current              main
+git rev-parse HEAD                     b31f6c83d1136d9c5093034ae0be50e6b8b2caf3
+git tag --points-at HEAD               v1.1-enterprise-baseline
+npm audit                              0 vulnerabilities
+npm --prefix client audit              0 vulnerabilities
+npm --prefix server audit              0 vulnerabilities
+npm run lint                           PASS
+npm --prefix server test               PASS, 425 tests
+npm --prefix client test               PASS on rerun, 138 tests
+npm run build                          PASS
+production /api/system/health          GREEN after agent health refresh
+production /api/agent/health           ok
+agent /health                          ok, final baseline commit
+```
+
+Production health sampled during the audit showed:
+
+- Aggregate status: `GREEN`.
+- Mongo, risk, automation, signalMode, submission, scheduler, monitor, heartbeat, broker, execution, Alpaca, Massive, queue, rateLimit, cache, watchlist, and websocket: `GREEN`.
+- Runtime AI moved from `unknown` to `ok` after refreshing `/api/agent/health`, indicating a cached probe timing behavior rather than an agent outage.
+- Broker runtime was `DEGRADED_REST` with `truthCurrent: true`, which is the certified paper REST fallback posture.
+
+## Testing Results
+
+Strengths:
+
+- Broad server coverage: automation gates, data gates, risk, selection, scheduler, submission, ownership, lifecycle, monitor, exit recovery, broker lifecycle, market sessions, Massive retry/rate-limit behavior, options WS, security headers, symbol translation, intelligence reports, AI health, and chart hub.
+- Broad client coverage: cockpit, command center, contracts, daily reports, decision journal, execution, market data UI/status, options math, order history, portfolio close, socket singleton, strategy analytics, trade reports, trading sessions, and watchlist hydration.
+- Production Playwright covers desktop, tablet, iPhone 13, and iPhone SE across app shell, watchlist, options matrix/depth/tape, portfolio, automation, AI desk, and mobile viewport overflow.
+
+Reliability risks:
+
+- A first `npm --prefix client test` audit run had all 138 tests pass but exited nonzero with `EnvironmentTeardownError: [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending`, attributed to `src/__tests__/commandCenter.test.tsx`. The rerun passed. Treat as high-priority test flake debt.
+- Production Playwright is serialized for live hosted verification. That is correct for current evidence collection but not a substitute for load/concurrency testing.
+- No dedicated production load/soak suite exists for Socket.IO fanout, Massive queue pressure, quote cache fanout, broker reconciliation, AI latency, or automation visibility.
+
+## Technical Debt
+
+Critical / High:
+
+- Global authentication and RBAC are not yet a universal backend request-boundary requirement.
+- Strategy concepts are fragmented across `automation`, `strategy`, `lab`, `engine`, `futures`, and Python screener services.
+- Event architecture is in-process Socket.IO plus Mongo domain records, not a durable event log or transactional outbox.
+- Automation is intentionally validated for exactly one concurrent autonomous position.
+- Backtesting does not yet have a unified reproducible dataset/version/artifact contract for Strategy Engine promotion.
+- Experiment tracking is not yet a first-class domain.
+- Learning/RL foundations are not yet isolated behind offline, paper-only research controls.
+
+Medium:
+
+- Broad `any` usage remains in market, portfolio, dashboard, lab, and aggregation code.
+- Mixed direct `console.*` logging and structured logging remain.
+- `referenceUI/` prototype code is tracked in the production repository.
+- `docs/reflection.md` contains raw working notes and confidential-looking transcript material; it should not be a canonical enterprise architecture source.
+- Some docs contain stale paths or stale local-development variables.
+- Docker-compose local client env uses `VITE_API_URL`, while the certified client standard is `VITE_API_BASE_URL` and production same-origin rewrites.
+
+Low:
+
+- UI polish and consistency can continue after core v2 controls are in place.
+- GPU experimentation should not distract from architecture work.
+
+## Code Smells
+
+- Route files often accept `any` request/response payloads without shared schema validation.
+- Some API surfaces are historical compatibility layers (`/api/options/selection` and `/api/market/options/selection`) and should eventually have canonical ownership.
+- Strategy and lab versioning are not unified into one promotion model.
+- Socket.IO events are useful but not traceable enough for replayable decision provenance.
+- Some operational status fields are cached snapshots and must be carefully labeled to avoid misleading health claims.
+
+## Security Assessment
+
+Strengths:
+
+- Production security middleware is configured with Helmet, CSP, frameguard, no `x-powered-by`, referrer policy, and HSTS in production.
+- CORS is origin allowlist based.
+- Safe structured logging redacts key/secret/token/password/authorization/credential/cookie fields.
+- Broker execution boundary is explicit and deterministic.
+- Manual trading uses durable confirmed intent, payload hashing, idempotency keys, and fail-closed infrastructure gates.
+- Production mock broker is rejected by automation configuration.
+- Admin-gated intelligence generation/backfills require `INTELLIGENCE_ADMIN_TOKEN`.
+- NPM audits are clean.
+- No tracked `.env` files or obvious high-entropy secret patterns were found in the working tree audit.
+
+## Authentication and RBAC Gaps
+
+Before Strategy Engine can govern production trading, the platform needs:
+
+- Global authentication middleware for backend routes.
+- Authenticated session identity on every request and state mutation.
+- Explicit roles: viewer, trader, operator, administrator.
+- Route-level authorization for watchlist writes, broker reads/writes, manual trading, automation controls, strategy/lab mutations, engine triggers, handoff approvals, and intelligence generation.
+- Actor attribution in every durable event and every audit record.
+- Account isolation for users, watchlists, strategy runs, order intents, positions, journals, and AI requests.
+- Replay prevention and consistent idempotency for all state-changing endpoints.
+- CSRF policy for browser-origin state changes if cookie/session auth is introduced.
+- Secret scanning in CI and documented credential rotation evidence.
+- Live-trading prohibition enforcement independent of UI controls.
+
+## Performance Assessment
+
+Strengths:
+
+- Massive request manager has priorities, cache, in-flight dedupe, rate-limit cooldown, entitlement blocks, retry/backoff, and metrics.
+- Options chain orchestrator narrows provider calls using expiration/type/strike windows.
+- Options live data is backend-owned and refcounted through a shared options subscription manager.
+- Production bundle size is acceptable for the current workstation. Largest observed raw JS chunk was the chart vendor chunk around 449 KB before compression.
+- AI calls have process-level rate limits, daily limits, and concurrency caps.
+
+Risks:
+
+- In-memory caches and queues are process-local.
+- Horizontal scale requires either sticky routing, shared cache, external queue, or explicit single-owner process roles.
+- Socket.IO through Vercel same-origin long polling is production-stable but not an enterprise load design.
+- No steady production resource budgets are enforced for memory, CPU, queue depth, AI latency, broker latency, or provider fanout.
+
+## Scalability Assessment
+
+The platform can scale carefully within the current single-backend baseline. It is not yet ready for multi-service, multi-account, multi-strategy, multi-position production automation.
+
+Required before scale-out:
+
+- Durable outbox/event log.
+- Shared event/feature contracts.
+- Account-scoped state.
+- Externalized queue or worker ownership model.
+- Feature-store and backtest dataset versioning.
+- Load tests around market data fanout and automation visibility.
+- Clear broker adapter interface and paper/live environment separation.
+
+## Documentation Drift
+
+Observed drift:
+
+- `docker-compose.yml` uses `VITE_API_URL`, but current certified client config uses `VITE_API_BASE_URL`.
+- `docs/api-reference.md` references `server/src/services/aggregatesWorker.ts`; implementation uses `server/src/features/market/services/aggregatesWorker.ts`.
+- `docs/AGENT_ARCHITECTURE.md` states the frontend handles user authentication; repository evidence does not show a global production auth/RBAC layer.
+- `docs/reflection.md` contains raw strategy/architecture notes and should not be treated as canonical.
+
+Recommendation: keep v1.1 certification docs unchanged, but create a canonical v2 architecture document with traceability and governance so future agents do not treat scattered notes as implementation authority.
+
+## Massive Entitlement Assumptions
+
+The audit assumes only current entitlements:
+
+- Massive Advanced Options Market Data.
+- Existing chart endpoints and APIs already integrated.
+- No premium real-time equity feed.
+- No required current-day stock intraday aggregates.
+- No direct browser access to Massive credentials.
+
+Currently implemented or verified Massive usage:
+
+- Options chains.
+- Options contracts/reference metadata.
+- Options snapshots.
+- Quotes.
+- Trades.
+- Greeks.
+- Implied volatility.
+- Open interest.
+- Volume.
+- Bid/ask spreads and day stats.
+- Market status.
+- Authorized aggregates where available.
+- News/sentiment/context where provider data is available.
+- Short-interest and short-volume context for equity risk framing.
+
+Every v2 feature must carry provider source, entitlement status, timestamp, freshness, calculation version, missing-data behavior, and quality status.
+
+## Strategy Engine Readiness Matrix
+
+| Capability | Readiness | Missing / Risk | Rank |
+| --- | --- | --- | --- |
+| Strategy Engine | Partial | Unified strategy contract, lifecycle, version promotion, feature dependencies, promotion gates | Critical |
+| Signal Engine | Partial | Signal registry, feature provenance, confidence calibration, multi-signal conflict handling | High |
+| Risk Engine | Good for single paper position | Multi-position, portfolio, correlation, assignment/exercise, account-level risk | High |
+| Position Manager | Partial | Multi-position, complex options, assignment/exercise, account isolation | High |
+| Order Manager | Partial | Paper only; live controls, broker streaming, order-state event contract incomplete | Critical |
+| Portfolio Manager | Partial | Account-scoped exposure, attribution, risk views, multi-strategy attribution | High |
+| Trade Journal | Partial | Intelligence records exist; needs complete automatic lifecycle and replayable links | Medium |
+| Learning Engine | Not ready | Feature history, labels, reward candidates, offline-only guardrails | Critical |
+| Backtesting | Partial | Dataset versions, slippage/commission models, walk-forward validation, artifacts | High |
+| Paper Trading | Ready baseline | Single-position only; expand carefully | Medium |
+| Live Trading | Not ready | Auth, RBAC, compliance, live broker certification, kill-switch drills | Critical |
+| Reinforcement Learning | Not ready | Offline sandbox, reward model, anti-overfit controls; no production path | Critical |
+| Strategy Versioning | Partial | Existing models fragmented; needs canonical lifecycle and rollback | High |
+| Experiment Tracking | Not ready | Run IDs, datasets, metrics, artifacts, lineage, promotion/rejection records | High |
+
+## Signal Engine Readiness
+
+Current options-native signal logic is a reasonable seed for v2 but should not become the final Strategy Engine contract unchanged. It needs:
+
+- Formal signal input schema.
+- Required feature declarations.
+- Signal output schema with confidence, direction, reason codes, and data-quality state.
+- Versioned calculation logic.
+- Support for multiple signals without implicit priority conflicts.
+- Replay behavior against historical feature windows.
+
+## Risk Engine Readiness
+
+Current risk gates are strong for the certified single-position paper baseline. They include deterministic sizing, max concurrent position guard, daily loss limits, market clock checks, stale-data rejection, and broker truth freshness.
+
+Missing for v2:
+
+- Portfolio-level risk.
+- Multi-position risk.
+- Correlation/exposure risk.
+- Per-strategy and aggregate daily risk.
+- Assignment/exercise risk for options.
+- Risk-decision event schema.
+- Human override governance.
+
+## Position and Order Manager Readiness
+
+Current position/order lifecycle supports paper entry, reconciliation, open position monitoring, exits, emergency stop, EOD flattening, and overnight recovery.
+
+Missing for v2:
+
+- Canonical order-state machine.
+- Durable order events.
+- Account isolation.
+- Multi-position lifecycle validation.
+- Partial-fill and complex-order lifecycle across strategies.
+- Broker adapter contracts for future brokers.
+- Live-money certification controls.
+
+## Portfolio Manager Readiness
+
+The portfolio command center aggregates useful operations state and broker/automation context. It is ready as an operator surface for paper trading.
+
+Missing for v2:
+
+- Strategy-level attribution.
+- Account-level exposure.
+- Risk-adjusted performance.
+- Full P&L lineage from fill to journal to analytics.
+- Multi-account isolation.
+
+## Trade Journal Readiness
+
+Trading intelligence records exist for sessions, trades, daily reports, decisions, and strategy analytics. This is a strong foundation.
+
+Missing for v2:
+
+- Automatic journal linkage to every durable event.
+- Required evidence snapshot for every decision.
+- Human feedback capture.
+- Strategy version and feature version lineage.
+- Complete outcome labeling for learning datasets.
+
+## Learning Engine Readiness
+
+Not production-ready. The platform should build the data foundation but not deploy adaptive learning into execution.
+
+Required first:
+
+- Historical features.
+- Signals.
+- Risk decisions.
+- Orders.
+- Fills.
+- Outcomes.
+- Human feedback.
+- Experiment runs.
+- Reproducible datasets.
+- Strict offline/paper-only controls.
+
+## Backtesting Readiness
+
+Partial. There are backtest surfaces and tests, but v2 needs reproducible, point-in-time-correct backtesting:
+
+- Dataset IDs and versions.
+- Feature versions.
+- Strategy versions.
+- Configuration snapshots.
+- Commission and slippage models.
+- Liquidity assumptions.
+- Walk-forward and out-of-sample validation.
+- Naive baseline comparisons.
+- Artifact persistence.
+- Promotion/rejection criteria.
+
+## Paper-Trading Readiness
+
+The certified baseline is ready for controlled paper-trading foundation work. v2 should remain paper-only while the Strategy Engine foundation is built.
+
+Allowed:
+
+- Paper-only Strategy Engine contracts.
+- Simulation.
+- Backtesting.
+- Experiment tracking.
+- RAG assistance.
+- Operator-reviewed strategy promotion.
+
+Not allowed:
+
+- Live-money automation.
+- Autonomous AI strategy mutation.
+- Production RL execution.
+
+## Live-Trading Blockers
+
+Live trading is blocked until:
+
+- Global auth and RBAC are implemented.
+- Account isolation exists.
+- Every state change is actor-attributed.
+- Live broker adapter certification is completed.
+- Compliance and operational review are completed.
+- Kill-switch drills are tested.
+- Production incident runbooks exist.
+- Load/soak tests pass.
+- Strategy promotion gates are deterministic and human-approved.
+- AI and RL are explicitly barred from direct execution authority.
+
+## Reinforcement-Learning Blockers
+
+RL must remain offline research because:
+
+- Reward design is not defined.
+- Dataset and environment versioning are not defined.
+- Backtest overfitting risk is high.
+- Walk-forward validation is not yet mandatory.
+- There is no paper-only RL sandbox with promotion prohibition.
+- RL can create hidden behavior that is difficult to explain and audit.
+
+## Strategy-Versioning Readiness
+
+Partial. Strategy/lab models exist, but v2 requires a canonical strategy lifecycle:
+
+- Draft.
+- Backtest.
+- Approved for simulation.
+- Approved for paper trading.
+- Paused.
+- Rejected.
+- Retired.
+- Rollback.
+
+Each strategy version must declare required features, signal logic, risk requirements, entry/exit rules, sizing policy, explainability output, performance attribution, and promotion gates.
+
+## Experiment-Tracking Readiness
+
+Not ready as a first-class domain. v2 needs:
+
+- Experiment run IDs.
+- Dataset versions.
+- Feature versions.
+- Strategy versions.
+- Configuration snapshots.
+- Random seeds.
+- Metrics.
+- Artifacts.
+- Baselines.
+- Promotion/rejection outcome.
+- Human reviewer.
+- Reproducibility status.
+
+## Recommended Module Architecture
+
+Recommended future structure:
+
+```text
+server/src/domains/
+  market-data/
+  feature-store/
+  strategy-engine/
+  signal-engine/
+  risk-engine/
+  execution/
+  broker-adapters/
+  portfolio/
+  position-manager/
+  order-manager/
+  trade-journal/
+  backtesting/
+  experiment-tracking/
+  learning-dataset/
+  ai-retrieval/
+  operations/
+  auth/
+  observability/
+  shared/
+```
+
+This is a target ownership model, not an instruction to refactor immediately.
+
+## Recommended Durable Event Architecture
+
+Begin with a Mongo-backed transactional outbox or equivalent durable event log before introducing Kafka, NATS, or another event platform.
+
+Minimum events:
+
+- `MarketSnapshotIngested`
+- `FeatureCalculated`
+- `StrategyEvaluationStarted`
+- `SignalGenerated`
+- `RiskDecisionMade`
+- `OrderIntentCreated`
+- `OrderIntentApproved`
+- `OrderSubmitted`
+- `FillObserved`
+- `PositionOpened`
+- `ExitTriggered`
+- `PositionClosed`
+- `JournalEntryCreated`
+- `BacktestStarted`
+- `BacktestCompleted`
+- `ExperimentCompleted`
+- `DatasetVersionCreated`
+- `StrategyPromoted`
+- `StrategyPaused`
+- `EmergencyStopActivated`
+
+Each event requires:
+
+- Event ID.
+- Event version.
+- Aggregate ID.
+- Correlation ID.
+- Causation ID.
+- Actor ID.
+- Strategy ID.
+- Strategy version.
+- Account ID.
+- Timestamp.
+- Payload schema.
+- Idempotency behavior.
+- Retention policy.
+- Replay behavior.
+
+## Recommended AI Authority Boundaries
+
+AI may:
+
+- Summarize evidence.
+- Retrieve relevant docs, news, filings, journal history, and strategy history.
+- Propose changes.
+- Explain signals, risk decisions, and outcomes.
+- Generate draft strategy definitions.
+- Assist with post-trade analysis.
+
+AI may not:
+
+- Submit orders.
+- Modify strategy/risk/execution rules directly.
+- Promote a strategy.
+- Override risk controls.
+- Clear emergency stops.
+- Operate live-money paths.
+- Execute reinforcement-learning policies in production.
+
+## 30-, 60-, and 90-Day Roadmap
+
+### Days 1-30
+
+- Preserve audit reports and canonicalize v2 architecture.
+- Add architecture decision records for paper-only strategy foundation, AI authority, outbox, Massive entitlement boundary, optional GPU, CPU-served retrieval, deterministic promotion, and offline RL.
+- Define global auth and RBAC plan.
+- Define durable event and strategy contracts.
+- Stabilize client Vitest teardown flake.
+- Correct documentation drift.
+
+### Days 31-60
+
+- Implement auth/RBAC foundation.
+- Implement Mongo durable outbox.
+- Define feature schema and provenance.
+- Build reproducible backtest dataset/version model.
+- Consolidate strategy/lab version model into canonical contract.
+- Add experiment-tracking domain design and initial records.
+- Add load/soak test plan for market-data and automation fanout.
+
+### Days 61-90
+
+- Integrate paper-only Strategy Engine behind gates.
+- Add feature-store ingestion for Massive options data.
+- Add paper-only experiment promotion workflow.
+- Add trade-journal event linkage and learning dataset snapshots.
+- Prototype RAG/semantic retrieval as optional advisory support.
+- Add multi-strategy simulation only after eventing and experiment tracking exist.
+
+## Priority Matrix
+
+| Priority | Work |
+| --- | --- |
+| Critical | Global auth/RBAC, durable events, unified strategy contract, live-trading prohibition, AI no-order-authority, offline-only RL boundary |
+| High | Feature store, backtest reproducibility, experiment tracking, strategy/version consolidation, test flake cleanup, multi-position design |
+| Medium | Docs drift cleanup, typed route schemas, console logging cleanup, load/soak suites, reference/prototype repository cleanup |
+| Low | GPU experimentation, UI polish beyond certified workflows, future local LLM research |
+
+## Definition of Architectural Readiness
+
+AI-Trader is architecturally ready for Strategy Engine implementation only when:
+
+- Every strategy has a versioned contract.
+- Every feature is versioned, timestamped, source-attributed, freshness-scored, and replayable.
+- Every strategy evaluation emits durable events.
+- Every signal, risk decision, order intent, order submission, fill, position transition, and journal entry is attributable and replayable.
+- Every state-changing request has authenticated actor identity and RBAC enforcement.
+- Backtests are reproducible with dataset IDs, feature versions, strategy versions, config snapshots, slippage, commission, and baseline comparisons.
+- Experiment tracking records metrics, artifacts, lineage, and promotion/rejection outcomes.
+- Strategy promotion requires deterministic evidence and human approval.
+- Paper trading remains the only allowed execution mode for v2 foundation.
+- Live-money automation remains explicitly prohibited.
+- AI and RL have no direct execution authority.
+- GPU services are optional research/indexing infrastructure and are not required for production operation.
+
+## Final Audit Conclusion
+
+The application is production-stable for the certified paper-trading baseline. It is ready for v2 architecture foundation work. It is not ready for autonomous live-money execution or production reinforcement learning.

--- a/docs/autonomous-trading/API.md
+++ b/docs/autonomous-trading/API.md
@@ -1,0 +1,161 @@
+# Autonomous Trading API
+
+Base path:
+
+```text
+/api/autonomous-trading
+```
+
+All endpoints are read-only.
+
+## GET `/status`
+
+Purpose: operator status summary.
+
+```bash
+curl http://localhost:4000/api/autonomous-trading/status
+```
+
+```json
+{
+  "status": {
+    "status": "Running",
+    "mode": "Shadow",
+    "market": "Closed",
+    "broker": "Alpaca Paper",
+    "modeBanner": "SHADOW MODE - No broker orders will be submitted."
+  }
+}
+```
+
+Failure cases: subsystem unavailable, Mongo unavailable. Required flags: none.
+
+## GET `/current`
+
+Purpose: current canonical pipeline record.
+
+```bash
+curl http://localhost:4000/api/autonomous-trading/current
+```
+
+```json
+{
+  "pipeline": {
+    "pipelineId": "atp_...",
+    "state": "RISK_REJECTED",
+    "symbol": "OXY",
+    "riskContext": { "approved": false, "reasonCodes": ["MAX_SECTOR_EXPOSURE"] }
+  }
+}
+```
+
+Failure cases: subsystem read failure. Required flags: none.
+
+## GET `/active`
+
+Purpose: active autonomous lifecycle records and automation positions.
+
+```bash
+curl http://localhost:4000/api/autonomous-trading/active
+```
+
+```json
+{ "trades": [], "positions": [] }
+```
+
+Failure cases: lifecycle unavailable. Required flags: none.
+
+## GET `/pending`
+
+Purpose: pending lifecycle records, order intents, and current opportunity.
+
+```bash
+curl http://localhost:4000/api/autonomous-trading/pending
+```
+
+```json
+{
+  "current": {
+    "symbol": "OXY",
+    "riskStatus": "APPROVED",
+    "entryStatus": "WAITING",
+    "blockingReason": "MARKET_NOT_OPEN"
+  }
+}
+```
+
+Failure cases: Mongo unavailable. Required flags: none.
+
+## GET `/recent-decisions`
+
+Purpose: concise decision feed.
+
+```bash
+curl 'http://localhost:4000/api/autonomous-trading/recent-decisions?limit=10'
+```
+
+```json
+{ "decisions": [{ "action": "REJECTED", "subsystem": "Risk Engine", "reason": "MAX_SECTOR_EXPOSURE" }] }
+```
+
+Failure cases: journal unavailable. Required flags: none.
+
+## GET `/timeline`
+
+Purpose: unified timeline across autonomous systems.
+
+```bash
+curl 'http://localhost:4000/api/autonomous-trading/timeline?limit=25'
+```
+
+```json
+{ "events": [{ "event": "Risk rejected", "actor": "risk-engine", "reason": "MAX_SECTOR_EXPOSURE" }] }
+```
+
+Failure cases: journal unavailable. Required flags: none.
+
+## GET `/metrics`
+
+Purpose: metrics grouped by `SHADOW_SIMULATION`, `AUTONOMOUS_PAPER`, and `MANUAL_PAPER`.
+
+```bash
+curl http://localhost:4000/api/autonomous-trading/metrics
+```
+
+```json
+{ "sources": [{ "source": "SHADOW_SIMULATION", "riskRejections": 1, "ordersSubmitted": 0 }] }
+```
+
+Failure cases: Mongo unavailable. Required flags: `AUTONOMOUS_METRICS_ENABLED=true` to surface in operations policy.
+
+## GET `/health`
+
+Purpose: single health and freshness model.
+
+```bash
+curl http://localhost:4000/api/autonomous-trading/health
+```
+
+```json
+{
+  "overall": "DEGRADED",
+  "services": [{ "name": "Risk Engine", "status": "HEALTHY", "stale": false }]
+}
+```
+
+Failure cases: subsystem health read failure. Required flags: none.
+
+## GET `/pipeline/:pipelineId`
+
+Purpose: fetch one persisted pipeline.
+
+```bash
+curl http://localhost:4000/api/autonomous-trading/pipeline/atp_abc123
+```
+
+```json
+{ "pipeline": { "pipelineId": "atp_abc123", "timeline": [] } }
+```
+
+Failure cases: `AUTONOMOUS_PIPELINE_NOT_FOUND`. Required flags: none.
+

--- a/docs/autonomous-trading/ARCHITECTURE.md
+++ b/docs/autonomous-trading/ARCHITECTURE.md
@@ -1,0 +1,48 @@
+# Autonomous Trading Architecture
+
+The coordinator is additive orchestration only. It preserves this authority chain:
+
+```text
+Massive Market Data
+  -> Event Intelligence
+  -> Decision Intelligence
+  -> Strategy Orchestrator
+  -> Enterprise Risk Engine
+  -> Trade Lifecycle Manager
+  -> Existing Execution Gateway
+  -> Alpaca Paper Trading
+  -> Existing Trade Evaluation
+  -> Journals and Reports
+```
+
+## Boundaries
+
+- Event Intelligence detects and explains market events.
+- Decision Intelligence identifies and ranks opportunities.
+- Strategy Orchestrator selects and compares strategies.
+- Risk Engine approves or rejects recommendations.
+- Trade Lifecycle Manager owns approved trades from entry through evaluation.
+- Execution Gateway submits and manages broker orders.
+- Alpaca Paper provides broker truth.
+- Trade Evaluation measures completed outcomes.
+
+No AI component calls Alpaca directly. No upstream intelligence component executes orders. No trade may reach the Execution Gateway without a current Risk Engine approval package.
+
+## New Additive Module
+
+Server location:
+
+```text
+server/src/features/autonomousTrading/
+```
+
+Important files:
+
+- `contracts/pipelineContract.ts`
+- `contracts/entryGate.ts`
+- `coordinator/autonomousCoordinator.service.ts`
+- `state/pipelineStateMachine.ts`
+- `shadow/shadowExecutionAdapter.ts`
+- `storage/autonomousPipeline.model.ts`
+- `routes/autonomousTrading.routes.ts`
+

--- a/docs/autonomous-trading/FAILURE_HANDLING.md
+++ b/docs/autonomous-trading/FAILURE_HANDLING.md
@@ -1,0 +1,37 @@
+# Failure Handling
+
+Every autonomous paper entry gate fails closed. A blocked entry is persisted and shown in the UI with a plain-language reason.
+
+## Entry Gate Conditions
+
+- `AUTONOMOUS_TRADING_ENABLED=true`
+- `AUTONOMOUS_ENTRY_ENABLED=true`
+- mode is `AUTONOMOUS_PAPER`
+- Alpaca environment is paper
+- market is open
+- automation is ready
+- MongoDB is connected
+- broker truth is current
+- execution lease is owned
+- Emergency Stop is inactive
+- Risk approval exists
+- Risk approval is approved
+- Risk approval is not expired
+- recommendation package matches approval package
+- lifecycle does not already exist
+- no duplicate order intent exists
+- position and order limits permit entry
+
+## Common Failure States
+
+| State | Reason Code | Operator Message |
+| --- | --- | --- |
+| Market closed | `MARKET_NOT_OPEN` | The market is not open for entries. |
+| Broker truth stale | `BROKER_TRUTH_STALE` | Broker truth is stale or unavailable. |
+| Lease not owned | `EXECUTION_LEASE_NOT_OWNED` | This process does not own the execution lease. |
+| Emergency stop | `EMERGENCY_STOP_ACTIVE` | Emergency Stop is active. |
+| Risk expired | `RISK_APPROVAL_EXPIRED` | The approval package is expired. |
+| Duplicate order | `DUPLICATE_ORDER_INTENT` | A duplicate order intent already exists. |
+
+Safe retry is allowed after the blocking condition is corrected.
+

--- a/docs/autonomous-trading/OPERATING_MODES.md
+++ b/docs/autonomous-trading/OPERATING_MODES.md
@@ -1,0 +1,48 @@
+# Operating Modes
+
+## Manual
+
+The operator selects and submits trades manually. Manual orders continue through the existing manual Execution Gateway path. Autonomous services may show information but do not initiate orders or claim manual trades.
+
+## Shadow
+
+The complete pipeline runs without broker order submission.
+
+Operator banner:
+
+```text
+SHADOW MODE - No broker orders will be submitted.
+```
+
+Shadow results use:
+
+```text
+SHADOW_SIMULATION
+```
+
+## Autonomous Paper
+
+Approved autonomous entries and exits may submit Alpaca Paper orders only after all gates pass.
+
+Operator banner:
+
+```text
+AUTONOMOUS PAPER MODE - Paper orders may be submitted.
+```
+
+Required flags:
+
+```bash
+AUTONOMOUS_TRADING_ENABLED=true
+AUTONOMOUS_TRADING_MODE=paper
+AUTONOMOUS_ENTRY_ENABLED=true
+```
+
+For exits:
+
+```bash
+AUTONOMOUS_EXIT_ENABLED=true
+```
+
+Live-money execution is not supported.
+

--- a/docs/autonomous-trading/OPERATOR_GUIDE.md
+++ b/docs/autonomous-trading/OPERATOR_GUIDE.md
@@ -1,0 +1,139 @@
+# Autonomous Trading Operator Guide
+
+## What It Does
+
+The autonomous trading system watches configured symbols, reads market events, ranks opportunities, compares strategies, asks the Risk Engine for approval, creates lifecycle records, and either simulates execution in Shadow Mode or delegates approved paper orders to the existing Execution Gateway.
+
+## What It Does Not Do
+
+- It does not submit live-money orders.
+- It does not let AI components call Alpaca directly.
+- It does not bypass Risk Engine approval.
+- It does not claim manual trades.
+
+## Modes
+
+Manual: the operator controls order submission.
+
+Shadow: the full AI pipeline runs, but no broker order is submitted.
+
+Autonomous Paper: approved entries and exits may submit Alpaca Paper orders when all gates pass.
+
+## How an Event Becomes a Recommendation
+
+1. Event Intelligence detects and explains a market event.
+2. Decision Intelligence ranks opportunities.
+3. Strategy Orchestrator compares strategy candidates.
+4. Risk Engine approves or rejects the recommendation.
+5. Trade Lifecycle Manager creates or monitors lifecycle records.
+6. Execution Gateway submits paper orders only when enabled and approved.
+7. Trade Evaluation measures completed outcomes.
+
+## Risk Approval
+
+Risk approval confirms that the trade fits portfolio limits, liquidity limits, Greeks limits, buying power, confidence thresholds, and open-position rules. A rejection is not an error; it is the Risk Engine doing its job.
+
+## Entries
+
+Shadow entries create simulated execution records. Autonomous Paper entries require all strict entry gates to pass.
+
+## Monitoring and Exits
+
+Open automation-owned positions are monitored by the existing Trade Lifecycle Manager. Lifecycle actions include `HOLD`, `TAKE_PROFIT`, `MOVE_STOP`, `EXIT`, and `WAIT`.
+
+## Pausing and Emergency Stop
+
+Use existing Automation controls for pause/resume and Emergency Stop. Emergency Stop blocks new autonomous execution and is displayed at the top of the Automation workspace.
+
+## Rejection Reason Codes
+
+Common codes:
+
+- `MAX_SECTOR_EXPOSURE`: portfolio exposure is above the configured limit.
+- `HIGH_SPREAD`: bid/ask spread is too wide.
+- `MARKET_NOT_OPEN`: entry gate blocked because the market is closed.
+- `BROKER_TRUTH_STALE`: broker state is not current.
+- `DUPLICATE_ORDER_INTENT`: duplicate execution was prevented.
+
+## Inspecting a Timeline
+
+Open the Automation workspace, review System Activity Timeline, then expand Intelligence Details for linked Event, Decision, Strategy, Risk, Lifecycle, Execution, and Evaluation IDs.
+
+## Daily Checklist
+
+### Before Market Open
+
+- Confirm Alpaca Paper mode.
+- Confirm Massive data health.
+- Confirm automation owner and leases.
+- Confirm broker truth is current.
+- Confirm risk limits.
+- Confirm Emergency Stop is inactive.
+- Confirm operating mode.
+- Review overnight events.
+
+### During Market Hours
+
+- Review current AI activity.
+- Review pending risk approvals.
+- Review active lifecycle actions.
+- Check stale-data warnings.
+- Review recent rejection reasons.
+- Confirm no execution contradictions.
+
+### After Market Close
+
+- Review completed trades.
+- Review open overnight positions.
+- Review strategy and risk performance.
+- Review failed or blocked pipelines.
+- Review daily report.
+- Confirm lifecycle and evaluation journals are complete.
+
+## Common Failure States
+
+- Market closed
+- Broker unavailable
+- Broker truth stale
+- MongoDB disconnected
+- Lease not owned
+- Emergency Stop active
+- Risk approval expired
+- Duplicate order intent
+- Execution timeout
+- Evaluation failure
+
+## Troubleshooting
+
+1. Check Autonomous Trader Status.
+2. Read Current AI Activity.
+3. Review Pending Trades blocking reason.
+4. Open System Activity Timeline.
+5. Expand Risk Review and Execution Details.
+6. Confirm feature flags.
+7. Retry only after the blocking condition is corrected.
+
+## Example UI State
+
+```text
+Autonomous Trader: Running
+Mode: Shadow
+Market: Closed
+Broker: Alpaca Paper
+Emergency Stop: Inactive
+SHADOW MODE - No broker orders will be submitted.
+```
+
+## Example API Response
+
+```json
+{
+  "status": {
+    "status": "Running",
+    "mode": "Shadow",
+    "market": "Closed",
+    "currentActivity": "The system is monitoring OXY, CVX, XLE, SPY, and QQQ."
+  }
+}
+```
+

--- a/docs/autonomous-trading/PIPELINE_CONTRACT.md
+++ b/docs/autonomous-trading/PIPELINE_CONTRACT.md
@@ -1,0 +1,61 @@
+# Pipeline Contract
+
+The canonical record is `AutonomousTradePipelineRecord`, schema version `1`.
+
+It traces one opportunity through:
+
+- event context
+- decision context
+- strategy context
+- risk context
+- lifecycle context
+- execution context
+- evaluation context
+- append-only timeline
+
+The coordinator stores identifiers and summaries. It does not copy full subsystem records unnecessarily.
+
+## Required Identity
+
+```json
+{
+  "pipelineId": "atp_...",
+  "schemaVersion": 1,
+  "mode": "SHADOW",
+  "state": "RISK_REJECTED",
+  "executionSource": "SHADOW_SIMULATION",
+  "symbol": "OXY",
+  "optionContract": "O:OXY260724C00060000",
+  "idempotencyKey": "atp_..."
+}
+```
+
+`pipelineId` is deterministic from mode, symbol, event IDs, decision scan ID, strategy run ID, and recommendation package ID. Reprocessing the same recommendation updates the same record.
+
+## Pipeline States
+
+```text
+OBSERVING
+EVENT_DETECTED
+OPPORTUNITY_IDENTIFIED
+STRATEGY_SELECTED
+RISK_REVIEW
+RISK_REJECTED
+RISK_APPROVED
+LIFECYCLE_CREATED
+ENTRY_BLOCKED
+ENTRY_REQUESTED
+ENTRY_SUBMITTED
+ENTRY_FILLED
+MONITORING
+EXIT_RECOMMENDED
+EXIT_REQUESTED
+EXIT_FILLED
+EVALUATING
+COMPLETED
+FAILED
+CANCELLED
+```
+
+Every transition is validated by `pipelineStateMachine.ts` and represented as a timestamped timeline event with actor, reason, reason code, and related record IDs.
+

--- a/docs/autonomous-trading/README.md
+++ b/docs/autonomous-trading/README.md
@@ -1,0 +1,29 @@
+# Autonomous Trading Integration
+
+This package connects the existing Event Intelligence, Decision Intelligence, Strategy Orchestrator, Risk Engine, Trade Lifecycle Manager, Execution Gateway, Alpaca Paper integration, and Trade Evaluation systems into one traceable paper-trading workflow.
+
+It does not replace any underlying subsystem. The autonomous coordinator stores references to existing records and presents one operator view in the existing Automation/Cockpit workspace.
+
+## Documentation
+
+- `ARCHITECTURE.md` - subsystem boundaries and data flow
+- `PIPELINE_CONTRACT.md` - canonical pipeline record
+- `OPERATING_MODES.md` - Manual, Shadow, and Autonomous Paper modes
+- `OPERATOR_GUIDE.md` - daily operator guide and checklist
+- `SHADOW_MODE.md` - simulated execution behavior
+- `FAILURE_HANDLING.md` - fail-closed behavior and reason codes
+- `API.md` - `/api/autonomous-trading/*` read APIs
+- `VALIDATION.md` - tests and validation commands
+
+## Default Safety
+
+Autonomous paper entry and exit are disabled by default. Shadow mode is the safe default.
+
+```bash
+AUTONOMOUS_TRADING_ENABLED=false
+AUTONOMOUS_TRADING_MODE=shadow
+AUTONOMOUS_ENTRY_ENABLED=false
+AUTONOMOUS_EXIT_ENABLED=false
+AUTONOMOUS_SHADOW_EXECUTION_ENABLED=true
+```
+

--- a/docs/autonomous-trading/SHADOW_MODE.md
+++ b/docs/autonomous-trading/SHADOW_MODE.md
@@ -1,0 +1,39 @@
+# Shadow Mode
+
+Shadow mode mirrors execution intent without submitting to Alpaca.
+
+The shadow adapter records:
+
+- intended entry price
+- contract
+- intended quantity
+- stop and target
+- bid, ask, and mid
+- configured slippage
+- timestamps
+- simulated fill status
+- hypothetical P/L fields
+
+Records are labeled:
+
+```text
+SHADOW_SIMULATION
+```
+
+Shadow results must never be combined with paper results unless grouped by `executionSource`.
+
+## Example
+
+```json
+{
+  "source": "SHADOW_SIMULATION",
+  "symbol": "OXY",
+  "optionContract": "O:OXY260724C00060000",
+  "quantity": 1,
+  "mid": 1.1,
+  "slippagePct": 0.02,
+  "simulatedFillPrice": 1.12,
+  "status": "SIMULATED_FILLED"
+}
+```
+

--- a/docs/autonomous-trading/VALIDATION.md
+++ b/docs/autonomous-trading/VALIDATION.md
@@ -1,0 +1,31 @@
+# Validation
+
+Required commands:
+
+```bash
+npm run lint
+npm run build
+npm --prefix server test
+npm --prefix client test
+git diff --check
+```
+
+Focused tests added:
+
+- `server/tests/autonomousTrading.test.mjs`
+- `client/src/__tests__/autonomousTraderPanel.test.tsx`
+
+Covered scenarios:
+
+- strict autonomous entry gate
+- invalid state transition rejection
+- shadow execution creates simulated fills without broker orders
+- pipeline persistence is idempotent
+- Automation workspace renders unified autonomous status
+- Shadow mode label is visible
+- pending blocking reasons are visible
+- timeline ordering surface renders
+- advanced details are collapsed by default
+
+Manual regression remains covered by existing manual trading and execution boundary tests.
+

--- a/docs/decision-engine/README.md
+++ b/docs/decision-engine/README.md
@@ -1,0 +1,144 @@
+# Decision Intelligence Engine
+
+## Architecture
+
+The Decision Intelligence Engine is an additive intelligence layer between the
+existing market-data/watchlist systems and execution. It does not submit orders,
+route broker calls, or mutate automation execution state.
+
+```mermaid
+flowchart TD
+  Massive[Massive Market Data] --> MarketData[Existing Market Data Layer]
+  MarketData --> Watchlist[Existing Watchlist]
+  Watchlist --> Scanner[Decision Opportunity Scanner]
+  MarketData --> Scanner
+  Scanner --> Scoring[Explainable Scores]
+  Scoring --> Research[Structured AI Research JSON]
+  Research --> Ranking[Decision Ranking]
+  Ranking --> Journal[Append-only Decision Journal]
+  Journal --> Cockpit[Read-only Operator Cockpit Panel]
+```
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+  participant UI as Operator Cockpit
+  participant API as Decision Engine API
+  participant WL as Watchlist Service
+  participant MD as Options Market Data Orchestrator
+  participant J as Decision Scan Journal
+
+  API->>WL: read enabled watchlist
+  API->>MD: read option-chain windows
+  API->>API: score candidates
+  API->>API: rank accepted/rejected candidates
+  API->>J: append scan
+  UI->>API: GET /api/decision-engine/latest
+  API->>J: read latest scan
+  API-->>UI: read-only decision intelligence
+```
+
+## Data Flow
+
+Inputs:
+
+- Existing watchlist symbols and thresholds
+- Option-chain contracts
+- Bid, ask, spread, volume, open interest, IV, and Greeks when supplied
+- Market status and delayed underlying context labels
+- Optional news, sector, and market breadth context
+
+Outputs:
+
+- Candidate opportunities
+- Explainable scores
+- Structured research JSON
+- Top 10 ranking
+- Rejected candidates with machine reason codes and human explanations
+- Append-only scan journal records
+
+## JSON Schemas
+
+Candidate score:
+
+```json
+{
+  "key": "liquidity",
+  "score": 86.2,
+  "maxScore": 100,
+  "grade": "STRONG",
+  "explanation": "Higher volume and open interest improve fills.",
+  "inputs": {
+    "volume": 1200,
+    "openInterest": 2500
+  }
+}
+```
+
+Research output:
+
+```json
+{
+  "symbol": "SPY",
+  "contract": "O:SPY260821C00500000",
+  "confidence": 0.82,
+  "bullishReasons": [
+    "Candidate is a call contract, so its payoff direction is bullish."
+  ],
+  "bearishReasons": [],
+  "risks": [],
+  "marketContext": {
+    "marketStatus": "open",
+    "underlyingPrice": 501.25,
+    "underlyingTimeframe": "DELAYED",
+    "sector": null,
+    "marketBreadth": null,
+    "news": [],
+    "trend": "UNKNOWN",
+    "momentum": "UNKNOWN"
+  },
+  "expectedMove": {
+    "source": "SUPPLIED_IV",
+    "value": 0.0514,
+    "explanation": "Uses supplied IV and DTE only."
+  },
+  "recommendation": "BUY_CALL",
+  "explanation": "The contract clears explainable gates."
+}
+```
+
+## Reason Codes
+
+- `LOW_VOLUME`: supplied contract volume is below threshold.
+- `HIGH_SPREAD`: bid/ask spread is too wide.
+- `LOW_CONFIDENCE`: explainable confidence is below threshold.
+- `POOR_RISK_REWARD`: risk/reward does not justify the setup.
+- `HIGH_IV`: supplied IV is above threshold.
+- `LOW_OPEN_INTEREST`: open interest is below threshold.
+- `MARKET_CLOSED`: market status is not open.
+- `BUYING_POWER`: position-size policy cannot be satisfied.
+- `DATA_UNAVAILABLE`: required data is missing.
+- `INCOMPLETE_CHAIN`: option-chain pagination was incomplete.
+- `STALE_QUOTE`: quote freshness failed.
+- `NO_BID_ASK`: bid or ask was not supplied.
+- `LOW_LIQUIDITY`: liquidity score is weak.
+- `WEAK_TREND`: trend context does not support the contract.
+- `WEAK_MOMENTUM`: momentum evidence is weak.
+- `ELEVATED_RISK`: risk score failed after spread, IV, delta, and theta
+  checks.
+
+## API
+
+- `GET /api/decision-engine/latest`: latest journaled scan.
+- `GET /api/decision-engine/scans?limit=50`: scan history.
+- `GET /api/decision-engine/scans/:scanId`: replay a scan.
+- `POST /api/decision-engine/scan`: run and append a live scan. No execution.
+- `POST /api/decision-engine/validate`: validate supplied scan input without
+  persisting.
+
+## Operation
+
+Set `DECISION_ENGINE_AUTO_START=true` to run the scanner continuously on the
+server interval. The default is off to avoid unexpected provider load during
+local development.

--- a/docs/event-intelligence/README.md
+++ b/docs/event-intelligence/README.md
@@ -1,0 +1,161 @@
+# Event Intelligence Engine
+
+## Architecture
+
+The Event Intelligence Engine is an additive market-awareness layer. It reads
+market events, classifies them, estimates impact, stores replayable context, and
+notifies the Decision Intelligence Engine when reevaluation is justified.
+
+It never places orders and never calls the execution gateway.
+
+```mermaid
+flowchart TD
+  Massive[Massive REST and Macro Data] --> Providers[Event Providers]
+  Providers --> Normalize[Normalize Events]
+  Normalize --> Classify[Classification]
+  Classify --> Impact[Market Impact Engine]
+  Impact --> History[Historical Similarity]
+  History --> Score[Importance Score]
+  Score --> Journal[Event Intelligence Journal]
+  Score --> Trigger[Decision Reevaluation Notice]
+  Trigger --> Decision[Decision Intelligence Engine]
+  Journal --> Cockpit[Read-only Event Panel]
+```
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+  participant P as Massive Providers
+  participant E as Event Engine
+  participant H as Decision Journal
+  participant D as Decision Engine
+  participant J as Event Journal
+  participant UI as Cockpit
+
+  E->>P: fetch news, sentiment, macro, status, actions
+  E->>E: normalize and classify
+  E->>E: estimate affected assets and sectors
+  E->>H: read similar decisions and outcomes
+  E->>E: score importance
+  E->>D: notify high-importance context
+  E->>J: persist replayable event record
+  UI->>J: read latest context
+```
+
+## Provider Documentation
+
+Local Massive references reviewed:
+
+- `docs/massive/README.md`
+- `docs/market-data/options-advanced-alignment-audit.md`
+- `docs/ai-features.md`
+- `server/src/shared/data/massiveMacro.ts`
+- `server/src/features/options/services/optionsChecklist.ts`
+
+Integrated through existing infrastructure:
+
+- News and company news: `/v2/reference/news`
+- Market news: `/v2/reference/news` without a ticker filter
+- Sentiment: `/v1/sentiment/{symbol}`
+- Market status: existing `getMarketStatusSnapshot`
+- Economic events: `/fed/v1/treasury-yields`, `/fed/v1/inflation`,
+  `/fed/v1/labor-market`
+- Earnings-style records: best-effort `/vX/reference/financials`
+- Corporate actions: best-effort `/v3/reference/dividends` and
+  `/v3/reference/splits`
+
+All calls reuse `massiveGet`, existing API key handling, rate limiting,
+request priority, cache, retry, and entitlement cooldown behavior.
+
+## JSON Schemas
+
+Normalized event:
+
+```json
+{
+  "id": "massive-market-news:abc123",
+  "provider": "massive-market-news",
+  "timestamp": "2026-07-25T14:00:00.000Z",
+  "title": "Iran ceasefire sends crude oil lower",
+  "summary": "Energy markets react.",
+  "category": "Oil",
+  "sentiment": {
+    "label": "bullish",
+    "score": 0.91,
+    "explanation": "Provider or keyword sentiment."
+  },
+  "symbols": ["OXY"],
+  "sectors": ["Energy"],
+  "confidence": 0.85,
+  "importance": 95,
+  "importanceExplanation": "Component scoring explanation.",
+  "source": "Massive",
+  "url": null,
+  "raw": {}
+}
+```
+
+Impact estimate:
+
+```json
+{
+  "affectedSymbols": ["CVX", "OXY", "USO", "XLE", "XOM"],
+  "affectedEtfs": ["USO", "XLE"],
+  "affectedSectors": ["Energy"],
+  "affectedCommodities": ["Oil"],
+  "confidence": 0.91,
+  "importance": 95
+}
+```
+
+## Classification Rules
+
+Classification is deterministic and keyword based. Examples:
+
+- Federal Reserve: `fed`, `fomc`, `powell`
+- Economic: `inflation`, `cpi`, `payroll`, `treasury yield`
+- Oil: `oil`, `crude`, `opec`, `ceasefire`
+- AI and Technology: `ai`, `gpu`, `semiconductor`, `cloud`
+- Corporate actions: dividends, splits, and financial reference records
+- Analyst events: upgrade, downgrade, price target changes
+
+## Scoring
+
+Importance is 0-100 and explained from:
+
+- Recency
+- Provider source
+- Sentiment magnitude
+- Market impact breadth
+- Historical similarity
+- Sector breadth
+- Affected symbols, ETFs, and commodities
+- Event category
+- Confidence
+
+High-importance events notify the Decision Intelligence Engine with event
+context only. The Decision Engine may rescore opportunities; no order is passed.
+
+## API
+
+Read-only endpoints:
+
+- `GET /api/event-intelligence/events`
+- `GET /api/event-intelligence/latest`
+- `GET /api/event-intelligence/history`
+- `GET /api/event-intelligence/symbol/:ticker`
+- `GET /api/event-intelligence/sector/:sector`
+- `GET /api/event-intelligence/context`
+
+## Example
+
+Iran ceasefire:
+
+- Category: `Oil`
+- Affected commodity: `Oil`
+- Affected ETFs: `USO`, `XLE`
+- Affected symbols: `CVX`, `OXY`, `XOM`
+- Affected sector: `Energy`
+- Decision trigger: high-importance reevaluation notice
+- Execution: none

--- a/docs/hardening/AUTHENTICATION_FOUNDATION.md
+++ b/docs/hardening/AUTHENTICATION_FOUNDATION.md
@@ -1,0 +1,144 @@
+# Authentication Foundation
+
+Status: implemented as the v2 staged backend identity foundation.
+
+Authority:
+
+- `docs/architecture/AI_TRADER_V2_MASTER_ARCHITECTURE.md`
+- `docs/roadmaps/AI_TRADER_V2_IMPLEMENTATION_BACKLOG.md`
+- `docs/architecture/adr/001-strategy-engine-paper-only.md`
+- `docs/architecture/adr/002-ai-has-no-direct-order-authority.md`
+
+## Scope
+
+The backend now attaches request identity context to incoming Express requests.
+This is the first implementation step for actor attribution, account isolation,
+and future RBAC. It is not a complete authentication product and does not add
+live trading, autonomous trading, production reinforcement learning, or AI order
+authority.
+
+## Runtime Modes
+
+Default mode is observe/compatible mode.
+
+- Unauthenticated requests continue to work.
+- `req.auth` is still populated with a legacy-compatible actor context.
+- Existing production browser flows remain backward compatible.
+
+Required mode is opt-in.
+
+- Set `AI_TRADER_AUTH_ENFORCEMENT=required` or `AI_TRADER_AUTH_MODE=required`.
+- Unsafe `/api` methods require a valid bearer token.
+- Unsafe means `POST`, `PUT`, `PATCH`, or `DELETE`.
+- `GET`, `HEAD`, and `OPTIONS` requests remain readable during the staged rollout.
+
+If required mode is enabled without a configured token, unsafe `/api` requests
+fail closed with `AUTH_CONFIGURATION_REQUIRED`.
+
+## Bootstrap Token
+
+The current bootstrap authenticator accepts:
+
+```text
+Authorization: Bearer <configured token>
+```
+
+Configuration:
+
+| Variable | Purpose |
+| --- | --- |
+| `AI_TRADER_AUTH_TOKEN` | Preferred bootstrap bearer token |
+| `AI_TRADER_OPERATOR_TOKEN` | Compatibility fallback token |
+| `AI_TRADER_DEFAULT_ACTOR_ID` | Legacy fallback actor ID |
+| `AI_TRADER_DEFAULT_ACCOUNT_ID` | Legacy fallback paper account ID |
+| `AI_TRADER_DEFAULT_ROLES` | Comma-separated fallback roles |
+
+Do not commit the actual token value.
+
+## Actor Headers
+
+When the bearer token is valid, these optional headers can identify the request
+actor and paper account:
+
+| Header | Purpose |
+| --- | --- |
+| `X-AI-Trader-Actor-Id` | Actor identifier for attribution |
+| `X-AI-Trader-Account-Id` | Paper account identifier |
+| `X-AI-Trader-Roles` | Comma-separated role names for future RBAC |
+
+Current recognized roles are:
+
+- `viewer`
+- `trader`
+- `operator`
+- `administrator`
+
+RBAC enforcement is intentionally deferred to `V2-BL-004`.
+
+## Request Context
+
+Routes can read:
+
+```ts
+req.auth
+```
+
+The context contains:
+
+- `authenticated`
+- `actorId`
+- `accountId`
+- `roles`
+- `authMethod`
+- `enforcementMode`
+
+This context is the starting point for durable event actor attribution in later
+v2 foundation work.
+
+## Current Protections
+
+- Required mode blocks unauthenticated unsafe `/api` requests.
+- Missing auth configuration fails closed in required mode.
+- Token comparison uses constant-time comparison for equal-length candidates.
+- Logs record rejection reason, actor ID, and account ID without logging token
+  values.
+- CORS allows the auth and actor-attribution headers needed for staged rollout.
+
+## Explicit Non-Goals
+
+This implementation does not provide:
+
+- User registration or user management.
+- OAuth or SSO.
+- Session cookies.
+- CSRF policy.
+- RBAC enforcement.
+- Route-level role matrix.
+- Multi-account automation.
+- Live-money execution.
+
+Those belong to later approved backlog items.
+
+## Rollback
+
+Operational rollback:
+
+1. Remove or unset `AI_TRADER_AUTH_ENFORCEMENT=required`.
+2. Leave default observe mode active while investigating.
+
+Code rollback:
+
+1. Remove the request identity middleware wiring from `server/src/index.ts`.
+2. Remove `server/src/shared/auth/requestIdentity.ts`.
+3. Remove `server/tests/auth.foundation.test.mjs`.
+
+## Verification
+
+Required tests:
+
+- Unauthenticated unsafe `/api` request rejects in required mode.
+- Missing configured token fails closed in required mode.
+- Valid bearer token propagates actor/account identity.
+- Read-only `/api` requests remain compatible.
+- Observe mode does not block legacy state-changing requests.
+- Enforcement is scoped to `/api` routes.

--- a/docs/learning/README.md
+++ b/docs/learning/README.md
@@ -1,0 +1,304 @@
+# Enterprise Learning Intelligence
+
+Learning Intelligence is the evidence layer that turns completed paper-trade history into reusable insights.
+
+It never executes trades, never calls Alpaca, never bypasses Risk or Lifecycle, and never mutates trade reports. It reads completed Trade Evaluation reports and creates append-only learning artifacts.
+
+## Architecture
+
+Source flow:
+
+```text
+Completed Trade Evaluation
+        ↓
+Learning Artifact Synchronizer
+        ↓
+Append-only Trade Reviews
+        ↓
+Versioned Learning Datasets
+        ↓
+Calibration, Scorecards, Regime Analytics, Event Analytics
+        ↓
+Operator Cockpit + read-only APIs
+```
+
+Code lives under:
+
+```text
+server/src/features/learning/
+```
+
+The module contains controllers, analytics, scorecards, calibration, datasets, journal, routes, storage, types, tests, docs, and a safe scheduler.
+
+## Trade Review
+
+Each completed trade report can produce one append-only learning review.
+
+Captured fields include:
+
+- Entry and exit timestamps
+- Entry strategy and winning strategy
+- Market regime, Fed event, news event, sector, symbol, direction
+- Confidence, evidence score, risk score
+- Entry reason and exit reason
+- Maximum favorable/adverse excursion
+- Holding time
+- Expected and actual return
+- Win/loss/partial-win classification
+- Why the trade succeeded
+- Why the trade failed
+- What could improve
+- Evidence references back to trade report, position, risk decision, candidate, contract selection, universe evaluation, and event IDs
+
+Collection:
+
+```text
+learning_trade_reviews
+```
+
+Review records are append-only. Update operations are blocked by the model.
+
+## Calibration
+
+Confidence calibration compares predicted confidence with realized success rate.
+
+Example:
+
+```json
+{
+  "confidenceBand": "90-100%",
+  "predictedConfidence": 0.95,
+  "actualSuccessRate": 0.61,
+  "calibrationError": 0.34,
+  "verdict": "Overconfident"
+}
+```
+
+Verdicts:
+
+- Overconfident
+- Underconfident
+- Well calibrated
+- Insufficient data
+
+## Scorecards
+
+Strategy scorecards are generated for:
+
+- Last 30 days
+- Last 90 days
+- Lifetime
+
+Metrics include:
+
+- Total trades
+- Wins and losses
+- Win rate
+- Average return
+- Median return
+- Average hold time
+- Average risk
+- Largest winner
+- Largest loser
+- Sharpe, when enough returns exist
+- Max drawdown
+
+## Market Regime Analytics
+
+Regime analytics group learning reviews by market regime and derived tags such as:
+
+- Trending
+- Range
+- High volatility
+- Low volatility
+- Risk on
+- Risk off
+- News driven
+- Fed
+- Energy rotation
+- Sector rotation
+
+Each group reports trades, win rate, and average return.
+
+## Event Analytics
+
+Event analytics classify reviews into event families:
+
+- Fed
+- CPI
+- PPI
+- Jobs
+- Oil
+- Earnings
+- Breaking News
+- Sentiment
+- Options Flow
+
+The response also lists the most common strategies used for each event group.
+
+## Dataset Design
+
+Each completed trade can produce one versioned dataset row.
+
+Collection:
+
+```text
+learning_datasets
+```
+
+Dataset records include:
+
+- Market snapshot
+- Technical indicators
+- Massive-derived data references
+- News and sentiment context
+- Event Intelligence references
+- Decision Intelligence reference
+- Strategy ranking context
+- Risk package summary
+- Lifecycle evidence
+- Execution result
+- Trade Evaluation outcome
+
+Historical datasets are never mutated. New schema versions should create new dataset IDs.
+
+## JSON Schemas
+
+Trade review identity:
+
+```json
+{
+  "reviewId": "learning-review:report:trade-1:v1",
+  "schemaVersion": 1,
+  "sourceReportId": "report:trade-1",
+  "sourceTradeId": "trade-1"
+}
+```
+
+Dataset identity:
+
+```json
+{
+  "datasetId": "learning-dataset:report:trade-1:v1",
+  "schemaVersion": 1,
+  "version": "learning-dataset-v1",
+  "sourceReportId": "report:trade-1",
+  "sourceTradeId": "trade-1"
+}
+```
+
+## API
+
+All endpoints are read-only.
+
+### GET `/api/learning/status`
+
+Purpose: Show whether learning artifacts are current with completed trade reports.
+
+```bash
+curl -s https://example.com/api/learning/status
+```
+
+Example:
+
+```json
+{
+  "status": "CURRENT",
+  "completedTrades": 12,
+  "tradeReviews": 12,
+  "datasets": 12,
+  "pendingReviews": 0,
+  "pendingDatasets": 0
+}
+```
+
+### GET `/api/learning/trades`
+
+Purpose: List append-only trade reviews.
+
+```bash
+curl -s "https://example.com/api/learning/trades?limit=20"
+```
+
+### GET `/api/learning/scorecards`
+
+Purpose: Strategy performance by window.
+
+```bash
+curl -s https://example.com/api/learning/scorecards
+```
+
+### GET `/api/learning/calibration`
+
+Purpose: Confidence calibration buckets.
+
+```bash
+curl -s https://example.com/api/learning/calibration
+```
+
+### GET `/api/learning/regimes`
+
+Purpose: Performance by market regime.
+
+```bash
+curl -s https://example.com/api/learning/regimes
+```
+
+### GET `/api/learning/events`
+
+Purpose: Event-family performance and strategy usage.
+
+```bash
+curl -s https://example.com/api/learning/events
+```
+
+### GET `/api/learning/datasets`
+
+Purpose: Versioned reusable learning dataset rows.
+
+```bash
+curl -s "https://example.com/api/learning/datasets?limit=20"
+```
+
+## Examples
+
+Question: Which strategy performs best after Fed announcements?
+
+Use:
+
+```bash
+curl -s https://example.com/api/learning/events | jq '.events[] | select(.event=="Fed")'
+```
+
+Question: What confidence values are reliable?
+
+Use:
+
+```bash
+curl -s https://example.com/api/learning/calibration
+```
+
+Question: Why did this trade fail?
+
+Use:
+
+```bash
+curl -s "https://example.com/api/learning/trades?limit=100" | jq '.reviews[] | select(.sourceTradeId=="trade-id")'
+```
+
+## Scheduler
+
+The server starts a learning synchronizer after startup. It scans completed generated trade reports and inserts missing learning reviews/datasets.
+
+Environment:
+
+- `LEARNING_SYNC_ENABLED=false` disables the synchronizer.
+- `LEARNING_SYNC_INTERVAL_MS` sets the interval, minimum 60 seconds.
+
+The synchronizer does not execute trades and does not call broker or market-data providers.
+
+## Privacy and Safety
+
+Learning artifacts store evidence references and summarized performance. They must not store credentials, API keys, JWTs, tokens, sensitive headers, or raw provider payloads.
+
+Learning Intelligence is an advisory layer. Future strategy changes must still pass through Decision Intelligence, Strategy Orchestrator, Risk, Lifecycle, Execution Gateway, and Paper Trading controls.

--- a/docs/production-readiness/V1_0_ENTERPRISE_STABILIZATION_REPORT.md
+++ b/docs/production-readiness/V1_0_ENTERPRISE_STABILIZATION_REPORT.md
@@ -1,0 +1,133 @@
+# V1.0 Enterprise Stabilization Report
+
+Date: 2026-07-26
+Branch: `v2/autonomous-system-integration`
+
+## Repository Audit
+
+Safe findings addressed:
+
+- Missing read-only `/api/system/status` and `/api/system/metrics` endpoints.
+- System status paths could wait on Mongo-backed autonomous readers while MongoDB was disconnected.
+- Automation workspace needed a single operations summary without new navigation.
+- Learning and performance views existed as underlying reports but did not expose focused read models for calibration and scorecards.
+
+Findings intentionally not changed in this sprint:
+
+- Historical TODOs in older handoff/engine experimental surfaces.
+- Reference/build artifacts outside the active deployment path.
+- Existing Massive and Alpaca clients, to avoid creating duplicated provider ownership.
+
+## Integration Summary
+
+The stabilized V1.0 flow preserves:
+
+```text
+Massive -> Event -> Decision -> Strategy -> Risk -> Lifecycle -> Execution Gateway -> Alpaca Paper -> Evaluation -> Learning
+```
+
+The autonomous coordinator is read/orchestration only. It stores references to existing journal records and does not bypass Risk, Lifecycle, or the Execution Gateway.
+
+## Operator Experience
+
+The existing Cockpit/Automation workspace now surfaces:
+
+- Autonomous Trader status
+- Current AI activity
+- Active and pending trades
+- Recent decisions
+- Unified activity timeline
+- Collapsed intelligence details
+- System Operations summary
+
+Detailed subsystem evidence remains collapsed by default.
+
+## System Operations
+
+Added:
+
+- `GET /api/system/status`
+- `GET /api/system/metrics`
+
+Both are read-only and safe during degraded infrastructure. When MongoDB is disconnected, status and metrics return promptly with blocked/unavailable state instead of waiting on journal queries.
+
+## Trading Quality Read Models
+
+Added read-only learning/performance endpoints:
+
+- `/api/intelligence/learning/trade-review`
+- `/api/intelligence/learning/confidence-calibration`
+- `/api/intelligence/learning/strategy-scorecards`
+- `/api/intelligence/learning/dataset`
+- `/api/intelligence/performance/historical`
+- `/api/intelligence/performance/market-regime`
+- `/api/intelligence/performance/event`
+- `/api/intelligence/performance/sector`
+- `/api/intelligence/performance/fed`
+- `/api/intelligence/performance/options-flow`
+
+These use persisted Trade Evaluation and Decision Journal records.
+
+## Deployment Readiness Checklist
+
+Render backend:
+
+- Build command: `npm install && npm run build`
+- Start command: `npm start`
+- Health check: `/health`
+- Readiness checks: `/api/system/status`, `/api/system/health`, `/api/autonomous-trading/health`
+
+Vercel frontend:
+
+- Build command: `cd client && npm install && npm run build`
+- Output directory: `client/dist`
+- Same-origin `/api/*` rewrites remain expected for hosted production.
+
+Required backend environment:
+
+- `NODE_ENV=production`
+- `PORT`
+- `CORS_ORIGINS`
+- `FRONTEND_ORIGIN`
+- `MONGO_URI` or `MONGODB_URI`
+- `MASSIVE_API_KEY`
+- `MASSIVE_BASE_URL`
+- `MASSIVE_SUBSCRIPTION_PROFILE`
+- `MASSIVE_OPTIONS_WS_URL`
+- `MASSIVE_OPTIONS_WS_ENABLED`
+- `MASSIVE_STOCKS_WS_ENABLED`
+- `APCA_API_KEY_ID`
+- `APCA_API_SECRET_KEY`
+- `APCA_API_BASE_URL`
+- `APCA_DATA_BASE_URL`
+- `ALPACA_PAPER=true`
+- `ALPACA_DATA_FEED`
+- `ALPACA_OPTION_FEED`
+- `OPENAI_API_KEY`
+- `OPENAI_MODEL`
+- `AUTH_JWT_SECRET`
+
+Safe autonomous defaults:
+
+```bash
+AUTONOMOUS_TRADING_ENABLED=false
+AUTONOMOUS_TRADING_MODE=shadow
+AUTONOMOUS_COORDINATOR_AUTO_START=false
+AUTONOMOUS_ENTRY_ENABLED=false
+AUTONOMOUS_EXIT_ENABLED=false
+AUTONOMOUS_SHADOW_EXECUTION_ENABLED=true
+AUTONOMOUS_UI_ENABLED=true
+AUTONOMOUS_METRICS_ENABLED=true
+```
+
+## Remaining Risks
+
+- Shadow validation still needs real market-session observation.
+- Live-money execution remains unsupported and must stay impossible.
+- Learning read models need more completed paper trades before calibration has statistical value.
+- Full external observability, alerting, and incident runbooks remain follow-up work.
+
+## Recommended Next Sprint
+
+Run controlled Shadow Mode during live market hours, review decision quality and rejection patterns, then tune confidence calibration and strategy scorecards before enabling autonomous paper entries.
+

--- a/docs/production-readiness/V1_0_ENTERPRISE_STABILIZATION_REPORT.md
+++ b/docs/production-readiness/V1_0_ENTERPRISE_STABILIZATION_REPORT.md
@@ -105,7 +105,9 @@ Required backend environment:
 - `ALPACA_OPTION_FEED`
 - `OPENAI_API_KEY`
 - `OPENAI_MODEL`
-- `AUTH_JWT_SECRET`
+- `AI_TRADER_AUTH_ENFORCEMENT` (staged auth foundation; defaults to `observe`. The
+  earlier `AUTH_JWT_SECRET` name was never read in code and has been removed —
+  see `docs/release/AI_TRADER_ENTERPRISE_RC1.md` and `server/.env.example`.)
 
 Safe autonomous defaults:
 

--- a/docs/release/AI_TRADER_ENTERPRISE_RC1.md
+++ b/docs/release/AI_TRADER_ENTERPRISE_RC1.md
@@ -1,0 +1,257 @@
+# AI-Trader Enterprise — Release Candidate 1 (v2.0.0-enterprise)
+
+Release engineering report for PR #59 (`v2/autonomous-system-integration` → `main`).
+
+- Status legend: ✅ verified · ⚠️ known limitation · ⏳ pending post-merge fill-in
+- Report generated during release execution; the "Production verification" and
+  "Release artifacts" sections are completed after merge + deployment.
+
+---
+
+## 1. Executive summary
+
+This release promotes the AI-Trader Enterprise stack to its first production
+release candidate. It layers a full enterprise intelligence pipeline —
+Authentication foundation, Decision Intelligence, Event Intelligence, Strategy
+Orchestrator, Enterprise Risk Engine, Trade Lifecycle Manager, Autonomous
+Trading Coordinator, Learning Intelligence, System status/metrics — plus Vercel
+Analytics + Speed Insights and an operator Cockpit, on top of the existing
+Massive market-data and Alpaca **paper** execution platform.
+
+The release is **additive and inert by default**: every new scheduler defaults
+to auto-start OFF, autonomous trading defaults to `shadow` (submits no broker
+orders), and live-money execution is structurally impossible. All new
+intelligence engines are advisory/read-model layers that delegate any execution
+to the single existing Execution Gateway.
+
+Validation: `lint` ✅ · `build` ✅ · server tests **460/460** ✅ · client tests
+**144/144** ✅ · CI (Vercel + build-test) ✅.
+
+Recommendation: **READY TO MERGE** for a controlled paper/shadow production
+release, contingent on the documented deployment configuration.
+
+## 2. Architecture summary
+
+Central wiring: `server/src/index.ts` — one Express app, one Socket.IO server,
+each feature router mounted once, each scheduler with a matched start/stop pair
+wired into both `start()` and `gracefulShutdown()`.
+
+Enterprise pipeline (advisory → single execution owner):
+
+```text
+Massive → Event → Decision → Strategy → Risk → Lifecycle
+        → Autonomous Coordinator → Shadow Execution or Block
+        → Execution Gateway → Alpaca Paper → Evaluation → Learning
+```
+
+Ownership boundaries (verified):
+
+- **One** Socket.IO server (`index.ts:236`); **one** Massive options-WS owner
+  (`optionsSubscriptionManager.service.ts`); stocks-WS is a distinct stream,
+  gated off by default. Two `MassiveWsClient` instances total, no overlap.
+- **One** broker submission function, reached only via two risk-gated lanes
+  (automation engine + manual gateway). Autonomous/Shadow/AI are read-models
+  with no broker access. Legacy direct broker route is fail-closed (HTTP 410).
+- 30 route base paths mounted once; `/api/automation` intentionally split across
+  two disjoint routers; `futuresRouter` intentionally aliased (lab + engine).
+
+## 3. Modules included
+
+| Module | Surface | Scheduler default | Execution authority |
+|---|---|---|---|
+| Authentication foundation | `/api/*` identity middleware | observe mode | none |
+| Decision Intelligence | `/api/decision-engine` | auto-start OFF | none (advisory) |
+| Event Intelligence | `/api/event-intelligence` | auto-start OFF | none (advisory) |
+| Strategy Orchestrator | `/api/strategy-orchestrator` | auto-start OFF | none (advisory) |
+| Enterprise Risk Engine | `/api/risk-engine` | auto-start OFF | approve/reject only |
+| Trade Lifecycle Manager | `/api/trade-lifecycle` | autostart OFF | delegates to gateway |
+| Autonomous Coordinator | `/api/autonomous-trading` | coordinator OFF, mode shadow | none (read-model + shadow sim) |
+| Learning Intelligence | `/api/learning` | sync OFF | none (read-only, append-only) |
+| System status/metrics | `/api/system/status`, `/metrics` | n/a | none |
+| Vercel Analytics + Speed Insights | React root | n/a | none |
+
+## 4. Validation evidence
+
+- `npm run lint` → exit 0, 0 warnings.
+- `npm run build` (server `tsc` + client `vite`) → exit 0. Postbuild guard:
+  "single HTTP client, single socket client, no backend/loopback origin in the
+  bundle."
+- `npm --prefix server test` → **460 passed / 0 failed** (includes auth,
+  decision, event, strategy, risk, lifecycle, autonomous, learning suites).
+- `npm --prefix client test` → **144 passed / 0 failed** (includes cockpit +
+  Vercel observability suites).
+- Hygiene: no conflict markers, no secrets in tracked files, no duplicate
+  routes/schedulers/WS owners/HTTP clients (guards enforce singletons).
+
+## 5. Security boundaries
+
+- **Authentication (staged, observe mode).** `AI_TRADER_AUTH_ENFORCEMENT`
+  defaults to `observe` — identity is stamped and logged, nothing is rejected.
+  The production frontend does not send a bearer token, so `required` mode is
+  intentionally **not** enabled for this single-operator release (enabling it
+  would break the UI). Unsafe actions remain constrained by the execution
+  gateway, paper-only guard, ownership leases, Risk Engine, and Emergency Stop.
+  Full multi-user auth (Google/JWT sessions) is explicitly out of scope here.
+- **AI has no direct order authority** (ADR-002). The coordinator only reads
+  journals and summarizes; deterministic gateways are the sole submitters.
+- **No live-money path.** `assertPaperConfiguration()` throws if `ALPACA_PAPER`
+  is false or the live host is configured; runs at adapter construction and
+  before every submit/close.
+
+## 6. Paper-trading guarantees
+
+- Single paper-only Alpaca client; live URL structurally blocked.
+- Risk/approval gating precedes every submission on both lanes; persist-then-act
+  with deterministic `client_order_id` idempotency prevents double submission.
+- Autonomous entry and exit remain disabled unless explicitly enabled; shadow
+  mode simulates fills and submits nothing.
+- Emergency Stop blocks applicable automated actions; broker-truth freshness is
+  enforced; manual trades are separate from autonomous ownership.
+
+## 7. Deployment configuration (required)
+
+Backend (Render) required env — canonical names (see `server/.env.example`):
+
+```bash
+NODE_ENV=production
+PORT=<render-provides>
+CORS_ORIGINS=https://polygonio-mcp-beryl.vercel.app
+FRONTEND_ORIGIN=https://polygonio-mcp-beryl.vercel.app
+MONGO_URI=<atlas-uri>            # MONGODB_URI is the compatibility fallback
+MONGO_OPTIONAL=false             # fail closed on the durable-state backend
+MASSIVE_API_KEY=<key>
+MASSIVE_BASE_URL=https://api.massive.com
+MASSIVE_SUBSCRIPTION_PROFILE=options-advanced
+MASSIVE_OPTIONS_WS_ENABLED=true
+MASSIVE_STOCKS_WS_ENABLED=<per-entitlement>
+# Alpaca PAPER (first non-empty of each family wins):
+APCA_API_KEY_ID=<paper-key>
+APCA_API_SECRET_KEY=<paper-secret>
+APCA_API_BASE_URL=https://paper-api.alpaca.markets
+ALPACA_PAPER=true
+OPENAI_API_KEY=<key>
+# Enterprise engines — safe production defaults (inert):
+AUTONOMOUS_TRADING_ENABLED=false
+AUTONOMOUS_TRADING_MODE=shadow
+AUTONOMOUS_COORDINATOR_AUTO_START=false
+AUTONOMOUS_ENTRY_ENABLED=false
+AUTONOMOUS_EXIT_ENABLED=false
+DECISION_ENGINE_AUTO_START=false
+EVENT_INTELLIGENCE_AUTO_START=false
+STRATEGY_ORCHESTRATOR_AUTO_START=false
+RISK_ENGINE_AUTO_START=false
+TRADE_LIFECYCLE_AUTOSTART=false
+LEARNING_SYNC_ENABLED=false
+```
+
+> Phantom variables removed from the examples in this release (were documented
+> but never read in code): `AUTH_JWT_*`, `AUTH_DEV_*`, `MONGO_LOCAL_*`,
+> `MONGO_FORCE_IPV4`, `MASSIVE_WS_EAGER_CONNECT`, `APCA_DATA_BASE_URL`,
+> `ALPACA_DATA_FEED`, `ALPACA_OPTION_FEED`, `VITE_AUTH_TOKEN`, `VITE_AUTH_ROLE`.
+
+### Render deployment checklist
+
+- Build: `npm install && npm run build` · Start: `npm start` · Health: `/health`.
+- Readiness probes: `/api/system/status`, `/api/autonomous-trading/health`.
+- Graceful shutdown on SIGTERM/SIGINT (releases scheduler leases).
+- Options WS start deferred 30s in production for zero-downtime rollout overlap.
+- Agent service: `uvicorn api:app` (`/health` on its port).
+
+### Vercel deployment checklist
+
+- Framework `vite`, build `npm run build`, output `client/dist`.
+- Same-origin `/api/*` + `/socket.io*` rewrites → Render backend (`vercel.json`).
+- `VITE_API_BASE_URL` / `VITE_SOCKET_URL` set to the frontend's own origin (the
+  build guard rejects a Render/loopback origin in the bundle).
+- Analytics + Speed Insights mount exactly once at the React root.
+
+## 8. Provider verification
+
+### Massive
+| Source | Status | Notes |
+|---|---|---|
+| Market status | ✅ VERIFIED_REST | `/v1/marketstatus/now`, 30s TTL |
+| News / company news | ✅ VERIFIED_REST | `/v2/reference/news` w/ `insights` |
+| Fed / treasury / inflation / labor | ✅ VERIFIED_REST | Massive economy endpoints |
+| Options chains / snapshots / aggregates | ✅ VERIFIED_REST | via wrapper; `adjusted:true`; paginated |
+| Options WebSocket | ✅ single owner | refcounted, 1000-contract cap, reconnect+backoff |
+| Rate limit / cache / retry | ✅ | unified `massiveRetry`, TTL caches |
+| Sentiment (`/v1/sentiment/{ticker}`) | ⚠️ BEST_EFFORT | undocumented endpoint; `.catch()`→empty (silent). Should derive from news `insights`. |
+| Earnings via `/vX/reference/financials` | ⚠️ BEST_EFFORT | legacy Polygon path absent from Massive; `.catch()`→empty. Should use `/rest/stocks/fundamentals/*`. |
+
+No duplicate Massive clients. The two BEST_EFFORT sources degrade to empty
+without error and do not affect execution safety.
+
+### Alpaca Paper — ✅ SAFE
+Single paper-only client; hard paper guard; single submission owner via two
+risk-gated lanes; AI/autonomous/shadow have no broker access; legacy direct
+route fail-closed (410); duplicate-order protection + broker-truth freshness
+enforced; manual and autonomous ownership separated.
+
+### MongoDB — ⏳ verified in production post-deploy
+`MONGO_OPTIONAL=false` on the durable-state backend so a DB outage fails health
+loudly. Startup drops a stale `strategyversions` index and ensures market-cache
+indexes.
+
+## 9. Shadow Mode readiness — ✅
+
+Coordinator is a read-model; shadow adapter simulates a midpoint fill with
+slippage and submits no broker order. Default mode is shadow with entries/exits
+disabled. Safe to observe-and-simulate during live sessions.
+
+## 10. Manual Trading regression status
+
+Manual trading path is independent of autonomous ownership, gated by the
+execution gateway (`authorizeManualSubmission`) with fail-closed checks and an
+operational kill switch (`MANUAL_TRADING_ENABLED`). Covered by broker/execution
+regression suites within the 460 server tests. ⏳ Production read-path smoke
+recorded post-deploy.
+
+## 11. Rollback plan
+
+- Pre-merge: draft PR; nothing to roll back.
+- Post-merge: revert the merge commit (`git revert -m 1 <merge-sha>`) and push;
+  Render + Vercel redeploy the prior build. Learning data is append-only /
+  versioned (no destructive migration).
+- Instant kill without revert: set `AUTONOMOUS_TRADING_MODE=off`, keep all
+  `*_AUTO_START=false`, or trigger Emergency Stop in Mission Control.
+
+## 12. Known limitations
+
+- Massive sentiment + earnings-financials sources are BEST_EFFORT (silent empty)
+  pending re-pointing to documented endpoints.
+- Auth runs in observe mode for this single-operator release (documented, by
+  design); full multi-user auth is future work.
+- Pre-existing cross-feature circular-import web (market/automation centered) is
+  tracked tech debt; not introduced or worsened by this PR; out of RC scope.
+- `aggregatesWorker` interval lacks a shutdown stop (default-off worker).
+- No committed `render.yaml` (infra dashboard-managed).
+
+## 13. Production verification  ⏳ (completed post-deploy)
+
+| Check | Result |
+|---|---|
+| Backend `/health`, `/api/health` | ⏳ |
+| `/api/system/status`, `/api/system/metrics` | ⏳ |
+| Autonomous / decision / event / strategy / risk / lifecycle / learning status | ⏳ |
+| Frontend loads; Analytics + Speed Insights present | ⏳ |
+| Same-origin `/api` routing; no backend URL in bundle | ⏳ |
+| Massive market-status reachable in prod | ⏳ |
+| Alpaca paper account reachable; live mode impossible | ⏳ |
+| MongoDB connected; automation reconciliation clean | ⏳ |
+| Stability window (no crash loop / rate-limit loop / restart) | ⏳ |
+
+## 14. Release artifacts  ⏳
+
+- Final merge SHA: ⏳
+- Release tag: `v2.0.0-enterprise` ⏳
+- Render backend deployment: ⏳ (no authenticated Render tooling in CI env)
+- Render agent deployment: ⏳
+- Vercel deployment: ⏳ (no authenticated Vercel tooling in CI env)
+- Production URLs: frontend `https://polygonio-mcp-beryl.vercel.app` · backend
+  `https://polygonio-backend.onrender.com`
+
+## 15. Final recommendation  ⏳
+
+To be finalized after production verification: **READY TO MERGE** →
+**PRODUCTION STABLE** upon green post-deploy checks, else rollback per §11.

--- a/docs/risk-engine/README.md
+++ b/docs/risk-engine/README.md
@@ -1,0 +1,277 @@
+# Enterprise Risk Intelligence Engine
+
+V2-BL-007 adds the read-side risk approval authority for AI-Trader Enterprise.
+It answers "can we safely take this trade?" after upstream systems have already
+answered "should we consider this trade?"
+
+The engine never executes trades, never submits broker orders, and never bypasses
+Manual Trading or the Execution Gateway. It returns immutable approval packages
+with either `APPROVE` or `REJECT`.
+
+## Architecture
+
+```text
+Massive
+  |
+Event Intelligence
+  |
+Decision Intelligence
+  |
+Strategy Orchestrator
+  |
+Enterprise Risk Intelligence Engine
+  |
+Execution Gateway
+  |
+Alpaca Paper
+```
+
+The Risk Engine is additive under `server/src/features/riskEngine/`:
+
+- `controllers/`: builds risk inputs from Strategy Orchestrator recommendations
+- `portfolio/`: reads persisted portfolio and session state
+- `approval/`: deterministic approval pipeline
+- `limits/`: configurable enterprise rules and reason text
+- `greeks/`: portfolio Greeks aggregation
+- `correlation/`: correlated-position detection
+- `positionSizing/`: contracts, dollar risk, and allocation math
+- `journal/` and `storage/`: append-only approval history
+- `routes/`: read-only HTTP API
+- `scheduler/`: optional gated background review
+- `types/`: approval package and portfolio schemas
+
+## Approval Flow
+
+```text
+Recommendation Package
+  |
+Validate Portfolio
+  |
+Validate Buying Power
+  |
+Validate Exposure
+  |
+Validate Greeks
+  |
+Validate Liquidity
+  |
+Validate Correlation
+  |
+Validate Daily Loss
+  |
+Validate Risk Budget
+  |
+APPROVE or REJECT
+```
+
+Every failed check becomes a reason code with supporting metrics and a suggested
+improvement. The approval output is safe for the Execution Gateway to consume,
+but this PR does not modify that gateway.
+
+## Portfolio Model
+
+The portfolio snapshot stores:
+
+- Current positions
+- Buying power when available from persisted state
+- Sector, ticker, strategy, and macro exposure
+- Long versus short exposure
+- Open trade count and maximum concurrent trades
+- Daily realized and unrealized loss
+- Risk consumed and remaining risk budget
+- Portfolio Greeks: delta, gamma, theta, vega, rho
+
+The engine reads persisted automation positions and sessions. It does not query
+broker order submission paths.
+
+## Risk Rules
+
+Rules are configurable through environment variables with conservative defaults:
+
+| Rule | Environment variable | Default |
+| --- | --- | --- |
+| Maximum contracts | `RISK_MAX_CONTRACTS` | `10` |
+| Maximum dollar risk | `RISK_MAX_DOLLAR_RISK` | `750` |
+| Maximum daily loss | `RISK_MAX_DAILY_LOSS` | `1500` |
+| Maximum position size | `RISK_MAX_POSITION_SIZE_PCT` | `0.05` |
+| Maximum sector exposure | `RISK_MAX_SECTOR_EXPOSURE_PCT` | `0.35` |
+| Maximum correlation | `RISK_MAX_CORRELATION` | `0.75` |
+| Maximum gamma | `RISK_MAX_GAMMA` | `0.35` |
+| Maximum theta | `RISK_MAX_THETA_ABS` | `300` |
+| Maximum delta | `RISK_MAX_DELTA_ABS` | `300` |
+| Maximum vega | `RISK_MAX_VEGA_ABS` | `500` |
+| Maximum open trades | `RISK_MAX_OPEN_TRADES` | `8` |
+| Minimum confidence | `RISK_MIN_CONFIDENCE` | `0.6` |
+| Maximum spread | `RISK_MAX_SPREAD_PCT` | `0.18` |
+| Minimum volume | `RISK_MIN_VOLUME` | `100` |
+| Minimum open interest | `RISK_MIN_OPEN_INTEREST` | `250` |
+| Maximum IV | `RISK_MAX_IV` | `1.2` |
+
+Feature flags:
+
+```text
+RISK_ENGINE_ENABLED=true
+RISK_ENGINE_APPROVAL_REQUIRED=true
+RISK_ENGINE_AUTO_START=false
+PORTFOLIO_RISK_TRACKING=true
+CORRELATION_ENGINE=true
+GREEKS_AGGREGATION=true
+```
+
+`RISK_ENGINE_AUTO_START` defaults to `false`; scheduled reviews must be enabled
+explicitly.
+
+## Position Sizing
+
+Position sizing uses:
+
+- Portfolio size
+- Confidence
+- Expected return
+- Maximum dollar risk
+- Maximum position size
+- Unit contract risk
+- Current portfolio heat
+- Market regime
+
+High-volatility, risk-off, macro-driven, news-driven, and sector-rotation
+regimes reduce size before approval.
+
+## JSON Schemas
+
+Approval package:
+
+```json
+{
+  "approved": false,
+  "approvalId": "uuid",
+  "recommendationId": "strategy-risk-package-id",
+  "suggestedPositionSize": {
+    "suggestedContracts": 2,
+    "dollarRisk": 350,
+    "capitalAllocation": 350,
+    "expectedPortfolioImpact": 0.0035,
+    "explanation": "Sized by confidence, return, heat, regime, and unit risk."
+  },
+  "portfolioRisk": {
+    "dailyRealizedLoss": 0,
+    "dailyUnrealizedLoss": 0,
+    "riskConsumed": 0,
+    "remainingRiskBudget": 1150,
+    "maximumConsecutiveLosses": 3,
+    "consecutiveLosses": 0,
+    "maximumOpenRisk": 6000,
+    "openRisk": 1200
+  },
+  "sectorExposure": {
+    "Energy": 1200
+  },
+  "correlationRisk": {
+    "score": 0.44,
+    "correlatedSymbols": ["XLE"],
+    "explanation": "OXY overlaps with Energy exposure."
+  },
+  "liquidityRisk": {
+    "code": "PASSED",
+    "passed": true,
+    "explanation": "Liquidity metrics satisfy limits.",
+    "supportingMetrics": {},
+    "suggestedImprovement": null
+  },
+  "greekRisk": {},
+  "buyingPowerRisk": {},
+  "remainingRiskBudget": 1150,
+  "reasons": [],
+  "warnings": [],
+  "timestamp": "2026-07-25T14:00:00.000Z"
+}
+```
+
+Journal record:
+
+```json
+{
+  "approvalId": "uuid",
+  "timestamp": "2026-07-25T14:00:00.000Z",
+  "recommendation": {},
+  "approval": {},
+  "rejection": [],
+  "reasonCodes": [],
+  "portfolioSnapshot": {},
+  "exposure": {},
+  "greeks": {},
+  "buyingPower": null,
+  "riskBudget": {},
+  "ruleVersion": "risk-v1",
+  "schemaVersion": 1
+}
+```
+
+## API
+
+All endpoints are read-only:
+
+- `GET /api/risk-engine/status`
+- `GET /api/risk-engine/portfolio`
+- `GET /api/risk-engine/exposure`
+- `GET /api/risk-engine/greeks`
+- `GET /api/risk-engine/risk-budget`
+- `GET /api/risk-engine/rules`
+- `GET /api/risk-engine/history`
+- `GET /api/risk-engine/approval-queue`
+
+`approval-queue?preview=true` computes a non-persisted preview of the latest
+pending Strategy Orchestrator recommendation. It does not create journal records.
+
+## Reason Codes
+
+- `MAX_SECTOR_EXPOSURE`
+- `MAX_POSITION_SIZE`
+- `LOW_LIQUIDITY`
+- `HIGH_SPREAD`
+- `HIGH_IV`
+- `LOW_CONFIDENCE`
+- `MAX_DAILY_LOSS`
+- `INSUFFICIENT_BUYING_POWER`
+- `HIGH_CORRELATION`
+- `MAX_GAMMA`
+- `MAX_DELTA`
+- `MAX_THETA`
+- `MAX_VEGA`
+- `MARKET_CLOSED`
+- `NEWS_LOCKOUT`
+- `MAX_OPEN_TRADES`
+- `MAX_DOLLAR_RISK`
+- `NO_ACTIONABLE_RECOMMENDATION`
+- `MISSING_LIQUIDITY_DATA`
+
+## Examples
+
+High spread rejection:
+
+```json
+{
+  "approved": false,
+  "status": "REJECT",
+  "reasons": [
+    {
+      "code": "HIGH_SPREAD",
+      "explanation": "The bid/ask spread is too wide for controlled execution risk.",
+      "supportingMetrics": {
+        "spreadPct": 0.4,
+        "maximumSpreadPct": 0.18
+      },
+      "suggestedImprovement": "Use a tighter contract or wait for a narrower spread."
+    }
+  ]
+}
+```
+
+Energy correlation:
+
+```text
+Existing: XLE, CVX
+Incoming: OXY
+Result: HIGH_CORRELATION when score exceeds configured limit
+Action: reduce size or reject
+```

--- a/docs/roadmaps/AI_TRADER_V2_IMPLEMENTATION_BACKLOG.md
+++ b/docs/roadmaps/AI_TRADER_V2_IMPLEMENTATION_BACKLOG.md
@@ -1,0 +1,275 @@
+# AI-Trader v2 Implementation Backlog
+
+Date: 2026-07-25
+Authority: `docs/architecture/AI_TRADER_V2_MASTER_ARCHITECTURE.md`
+Scope: v2 foundation only. Do not implement live trading or production reinforcement learning tickets from this backlog.
+
+## Backlog Governance
+
+Every item must preserve the certified `v1.1-enterprise-baseline` unless explicitly approved in a future implementation sprint. Every item is paper-trading-only unless it is documentation-only. GPU services are optional research infrastructure and must not become production dependencies.
+
+## V2-BL-001: Preserve Architecture Reports
+
+Description: Preserve the Enterprise Strategy Engine Readiness Audit and NVIDIA Brev Enterprise Integration Strategy as local Markdown documents.
+
+- Source requirement IDs: V2-001, V2-052
+- Priority: Critical
+- Dependencies: none
+- Security impact: ensures recommendations are not lost; no secrets may be added
+- Data impact: none
+- Expected files/modules: `docs/audits/`, `docs/architecture/`
+- Tests required: docs path/link validation, secret scan, `git diff --check`
+- Documentation required: source report docs
+- Rollback plan: revert documentation-only files
+- Definition of done: both reports exist and preserve all major findings
+- Allowed production behavior: none changed
+- Prohibited production behavior: any runtime code/config change
+
+## V2-BL-002: Create Architecture Decision Records
+
+Description: Record v2 foundation decisions as ADRs, including paper-only Strategy Engine, AI authority limits, Mongo outbox, Massive entitlement boundary, optional GPU, CPU-served retrieval, human promotion, and offline-only RL.
+
+- Source requirement IDs: V2-002, V2-004, V2-012, V2-013, V2-035, V2-036, V2-041
+- Priority: Critical
+- Dependencies: V2-BL-001
+- Security impact: formalizes safety boundaries
+- Data impact: none
+- Expected files/modules: `docs/architecture/adr/`
+- Tests required: docs link validation
+- Documentation required: ADR index and docs README update
+- Rollback plan: revert ADR docs
+- Definition of done: ADRs exist and are linked from docs index
+- Allowed production behavior: none changed
+- Prohibited production behavior: changing execution paths
+
+## V2-BL-003: Global Authentication Foundation
+
+Description: Add authenticated request identity to backend routes, with staged rollout and compatibility plan.
+
+- Source requirement IDs: V2-010, V2-021, V2-023, V2-024
+- Priority: Critical
+- Dependencies: V2-BL-002
+- Security impact: high; establishes actor identity and account isolation
+- Data impact: future records gain `actorId` and `accountId`
+- Expected files/modules: future auth domain module, `server/src/index.ts`, route middleware, tests
+- Tests required: unauthenticated rejection, authenticated success, identity propagation, audit attribution
+- Documentation required: auth architecture, setup instructions, operator runbook
+- Rollback plan: feature-flag enforcement; retain read-only access while resolving rollout issues
+- Definition of done: protected state-changing routes receive actor identity
+- Allowed production behavior: staged auth enforcement
+- Prohibited production behavior: enabling live trading
+
+## V2-BL-004: RBAC and Route Authorization
+
+Description: Implement viewer, trader, operator, and administrator roles with route-level authorization.
+
+- Source requirement IDs: V2-022, V2-023, V2-025
+- Priority: Critical
+- Dependencies: V2-BL-003
+- Security impact: high; restricts state-changing operations
+- Data impact: audit records include role and actor
+- Expected files/modules: auth domain, route middleware, watchlist, broker, automation, portfolio, lab, strategy, intelligence routes
+- Tests required: role matrix tests for protected routes
+- Documentation required: RBAC matrix and route inventory update
+- Rollback plan: feature flag per route class; no bypass for broker submissions
+- Definition of done: route-level authorization enforced and tested
+- Allowed production behavior: paper controls only by authorized roles
+- Prohibited production behavior: granting AI or unauthenticated actors execution authority
+
+## V2-BL-005: Durable Mongo Event Outbox
+
+Description: Add a Mongo-backed transactional outbox/event log as the v2 system of record for strategy, signal, risk, order, position, journal, backtest, experiment, and emergency events.
+
+- Source requirement IDs: V2-008, V2-011, V2-012
+- Priority: Critical
+- Dependencies: V2-BL-003
+- Security impact: actor attribution and replay safety
+- Data impact: new durable event collection and projector model
+- Expected files/modules: future events domain module, Mongo models, projector utilities
+- Tests required: event schema, idempotency, transaction/outbox writes, projector replay without external side effects
+- Documentation required: event schema reference
+- Rollback plan: write outbox in observe-only mode before making projections authoritative
+- Definition of done: events are durable, versioned, idempotent, and replay-safe
+- Allowed production behavior: event capture for paper baseline
+- Prohibited production behavior: replay causing broker/API side effects
+
+## V2-BL-006: Unified Strategy Contract
+
+Description: Define canonical strategy contract and lifecycle across lab, strategy, automation, and future engine domains.
+
+- Source requirement IDs: V2-002, V2-007, V2-028, V2-055
+- Priority: Critical
+- Dependencies: V2-BL-005
+- Security impact: promotion gates and actor approval
+- Data impact: strategy records gain canonical IDs, versions, lifecycle, feature requirements
+- Expected files/modules: future strategy-engine domain module, existing strategy/lab models, docs
+- Tests required: schema validation, lifecycle transition tests, rollback tests
+- Documentation required: strategy contract reference
+- Rollback plan: compatibility adapter from existing strategy/lab records
+- Definition of done: new strategies can be represented without altering execution behavior
+- Allowed production behavior: paper-only strategy definitions
+- Prohibited production behavior: automatic live or paper execution from draft strategies
+
+## V2-BL-007: Feature Schema and Provenance
+
+Description: Define feature schema, versioning, data quality, provenance, freshness, entitlement status, and missing-data behavior.
+
+- Source requirement IDs: V2-013, V2-015, V2-016, V2-017, V2-018, V2-019, V2-020
+- Priority: High
+- Dependencies: V2-BL-005
+- Security impact: prevents misleading data claims
+- Data impact: new feature definitions and feature windows
+- Expected files/modules: future feature-store domain module, market-data integration docs
+- Tests required: feature validation, staleness rejection, entitlement status propagation, point-in-time reads
+- Documentation required: feature catalog
+- Rollback plan: read-only feature projection first
+- Definition of done: features can be replayed with source/timestamp/version/quality
+- Allowed production behavior: paper/advisory feature recording
+- Prohibited production behavior: using unauthorized equity data as live feature input
+
+## V2-BL-008: Backtesting Reproducibility
+
+Description: Harden backtesting around immutable datasets, feature versions, strategy versions, config snapshots, slippage/commission models, and baseline comparisons.
+
+- Source requirement IDs: V2-026, V2-027, V2-030, V2-031, V2-032
+- Priority: High
+- Dependencies: V2-BL-006, V2-BL-007
+- Security impact: reduces false promotion risk
+- Data impact: dataset and artifact records
+- Expected files/modules: future backtesting domain module, strategy backtest services, Python screener compatibility
+- Tests required: deterministic replay, no look-ahead bias, dataset immutability, baseline comparison
+- Documentation required: backtest methodology
+- Rollback plan: run new backtesting in parallel with existing routes
+- Definition of done: a backtest can be reproduced from IDs alone
+- Allowed production behavior: research and paper-only evidence
+- Prohibited production behavior: live promotion from backtest alone
+
+## V2-BL-009: Experiment Tracking
+
+Description: Add first-class experiment records with run IDs, metrics, artifacts, dataset versions, feature versions, strategy versions, seeds, and review decisions.
+
+- Source requirement IDs: V2-029, V2-033, V2-034
+- Priority: High
+- Dependencies: V2-BL-008
+- Security impact: promotion audit trail
+- Data impact: experiment collections and artifact metadata
+- Expected files/modules: future experiment-tracking domain module
+- Tests required: run creation/completion, artifact references, promotion/rejection linkage
+- Documentation required: experiment tracking reference
+- Rollback plan: observe-only experiment capture
+- Definition of done: every strategy experiment has lineage and review outcome
+- Allowed production behavior: paper-only experiment recording
+- Prohibited production behavior: automated promotion without human approval
+
+## V2-BL-010: Paper-Only Execution Gates
+
+Description: Extend explicit paper-only guards for v2 Strategy Engine integration and ensure live broker paths cannot be activated accidentally.
+
+- Source requirement IDs: V2-002, V2-003, V2-004, V2-025
+- Priority: Critical
+- Dependencies: V2-BL-004, V2-BL-006
+- Security impact: blocks live-money execution
+- Data impact: execution events include paper/live prohibition state
+- Expected files/modules: automation config, execution gateway, broker adapters, strategy engine gates
+- Tests required: live config rejection, AI order rejection, strategy direct submit rejection, paper-only submission tests
+- Documentation required: paper-only execution runbook
+- Rollback plan: default all new v2 execution paths disabled
+- Definition of done: v2 engine cannot route to live broker
+- Allowed production behavior: paper-only controlled execution
+- Prohibited production behavior: live-money trading
+
+## V2-BL-011: RAG Proof of Concept
+
+Description: Build optional advisory RAG prototype using embeddings/reranking and CPU-served vector storage, with GPU only for indexing/validation.
+
+- Source requirement IDs: V2-036, V2-037, V2-038, V2-039, V2-040, V2-041, V2-042
+- Priority: Medium
+- Dependencies: V2-BL-001, V2-BL-003 for production exposure; can prototype offline earlier
+- Security impact: corpus redaction and no-secret indexing required
+- Data impact: vector index and corpus/index version records
+- Expected files/modules: future ai-retrieval domain module, agent/orchestrator integration, docs corpus config
+- Tests required: no secrets in corpus, retrieval fallback, citation/provenance, Brev-unavailable behavior
+- Documentation required: retrieval architecture and operating runbook
+- Rollback plan: retrieval disabled flag; hosted AI remains unchanged
+- Definition of done: advisory answer can cite retrieved context and still works without Brev
+- Allowed production behavior: advisory retrieval only
+- Prohibited production behavior: GPU-required trading path or AI execution authority
+
+## V2-BL-012: GPU Cost Controls
+
+Description: Add operating runbooks/scripts/checklists for Brev GPU sessions, including price confirmation, auto-stop, shutdown verification, and experiment records.
+
+- Source requirement IDs: V2-040, V2-042, V2-043, V2-044, V2-045, V2-046, V2-047, V2-048, V2-049, V2-050
+- Priority: Medium
+- Dependencies: V2-BL-011
+- Security impact: prevents credential/corpus leakage and runaway spend
+- Data impact: experiment cost records
+- Expected files/modules: future runbook docs or scripts only unless approved
+- Tests required: docs validation; optional dry-run script test
+- Documentation required: Brev GPU operating procedure
+- Rollback plan: delete runbook/script docs
+- Definition of done: no GPU session can be run without cost and shutdown checklist
+- Allowed production behavior: none
+- Prohibited production behavior: persistent GPU dependency
+
+## V2-BL-013: Test Reliability Cleanup
+
+Description: Investigate and fix the Vitest teardown/RPC flake observed after `commandCenter.test.tsx`.
+
+- Source requirement IDs: V2-051
+- Priority: High
+- Dependencies: none
+- Security impact: none
+- Data impact: none
+- Expected files/modules: client tests/setup or affected test file
+- Tests required: repeat `npm --prefix client test` multiple times
+- Documentation required: test reliability note if root cause is non-obvious
+- Rollback plan: revert isolated test harness change
+- Definition of done: repeated client test runs exit 0 without teardown errors
+- Allowed production behavior: none
+- Prohibited production behavior: changing app runtime logic unless root cause requires it and is separately approved
+
+## V2-BL-014: Documentation Drift Cleanup
+
+Description: Correct stale references such as `VITE_API_URL`, old aggregate worker paths, and unsupported auth claims.
+
+- Source requirement IDs: V2-052, V2-053
+- Priority: Medium
+- Dependencies: V2-BL-001
+- Security impact: reduces operational mistakes
+- Data impact: none
+- Expected files/modules: `docs/`, `docker-compose.yml` if explicitly approved
+- Tests required: docs link validation and config review
+- Documentation required: changelog note
+- Rollback plan: revert docs/config changes
+- Definition of done: docs match implementation
+- Allowed production behavior: docs-only unless config change is separately scoped
+- Prohibited production behavior: silently changing production deployment config
+
+## V2-BL-015: Load and Soak Test Plan
+
+Description: Design load/soak suites for Socket.IO fanout, Massive queues, options subscriptions, automation visibility, broker reconciliation, and AI latency.
+
+- Source requirement IDs: V2-054
+- Priority: Medium
+- Dependencies: V2-BL-005
+- Security impact: protects availability
+- Data impact: benchmark artifacts
+- Expected files/modules: future test-plan docs, future test harness
+- Tests required: synthetic load plan, acceptance thresholds
+- Documentation required: load test plan and runbook
+- Rollback plan: docs-only initial phase
+- Definition of done: production-like load scenarios and metrics are defined
+- Allowed production behavior: none
+- Prohibited production behavior: load testing production without explicit maintenance approval
+
+## Prohibited Backlog Categories
+
+Do not create implementation tickets for:
+
+- Live-money autonomous trading.
+- Production RL execution.
+- AI direct order submission.
+- GPU-required production execution.
+- Multi-account automation before identity isolation.
+- Multi-position autonomous automation before explicit future design and certification.

--- a/docs/strategy-orchestrator/README.md
+++ b/docs/strategy-orchestrator/README.md
@@ -1,0 +1,121 @@
+# Strategy Orchestrator
+
+## Architecture
+
+The Strategy Orchestrator is the central recommendation layer between Decision
+Intelligence and the Risk Engine. It selects relevant strategies, evaluates
+evidence, resolves disagreement, and emits a recommendation package.
+
+It does not approve trades and does not execute orders.
+
+```mermaid
+flowchart TD
+  Massive[Massive] --> Event[Event Intelligence]
+  Event --> Decision[Decision Intelligence]
+  Decision --> Orchestrator[Strategy Orchestrator]
+  Orchestrator --> Journal[Strategy Journal]
+  Orchestrator --> Risk[Risk Engine Handoff Package]
+  Journal --> Cockpit[Read-only Strategy Panel]
+```
+
+## Strategy Lifecycle
+
+1. Build context from event intelligence, decision intelligence, watchlist,
+   persisted portfolio state, news, sentiment, technical scores, and regime.
+2. Detect market regime.
+3. Schedule only strategies relevant to current events/regime.
+4. Evaluate independent strategy modules.
+5. Aggregate evidence into a 0-100 evidence score.
+6. Rank all strategies.
+7. Resolve conflicts.
+8. Produce recommendation: `BUY`, `WATCH`, `WAIT`, `SKIP`, or `NO_TRADE`.
+9. Append the run to the strategy journal.
+
+## Evidence Model
+
+Evidence combines:
+
+- Event Intelligence
+- Decision Intelligence
+- Market data context
+- Persisted portfolio context
+- Watchlists
+- News
+- Sentiment
+- Technical analysis
+- Market regime
+
+Every evidence score includes component values and an explanation.
+
+## Conflict Resolution
+
+Strategies may disagree. The orchestrator keeps the disagreement visible:
+
+- Bullish strategies
+- Bearish strategies
+- Neutral strategies
+- Confidence adjustment
+- Recommended action
+- Human-readable explanation
+
+Conflicts usually downgrade `BUY`/`WATCH` to `WAIT`.
+
+## JSON Schemas
+
+Strategy evaluation:
+
+```json
+{
+  "strategyId": "oil-commodity",
+  "name": "Oil / Commodity",
+  "direction": "BULLISH",
+  "confidence": 0.82,
+  "risk": 0.31,
+  "expectedReturn": 0.58,
+  "positionSize": 0.07,
+  "evidenceScore": 88,
+  "reasoning": ["Oil event fit is 90.0%."],
+  "rejected": false,
+  "rejectionReason": null
+}
+```
+
+Recommendation package:
+
+```json
+{
+  "action": "WATCH",
+  "confidence": 0.74,
+  "supportingStrategies": [],
+  "rejectedStrategies": [],
+  "riskHandoff": {
+    "allowedForRiskReview": true,
+    "message": "Risk Engine must independently approve.",
+    "packageId": "uuid"
+  }
+}
+```
+
+## API
+
+Read-only endpoints:
+
+- `GET /api/strategy-orchestrator/status`
+- `GET /api/strategy-orchestrator/recommendations`
+- `GET /api/strategy-orchestrator/strategies`
+- `GET /api/strategy-orchestrator/history`
+- `GET /api/strategy-orchestrator/evidence`
+
+## Examples
+
+Fed event:
+
+- Scheduled: Fed Reaction, Macro Rotation, AI Consensus
+- Skipped: Oil / Commodity
+- Recommendation: watch or wait for Risk Engine review
+
+Oil event:
+
+- Scheduled: Oil / Commodity, Sector Rotation, News Momentum
+- Portfolio adjustment: reduce confidence if Energy exposure is already high
+- Recommendation package only; no execution path is called

--- a/docs/trade-lifecycle/API.md
+++ b/docs/trade-lifecycle/API.md
@@ -1,0 +1,31 @@
+# Trade Lifecycle API
+
+All endpoints are read-only.
+
+## `GET /api/trade-lifecycle/status`
+
+Returns feature flags, AI status, paper-trading status, market state, current
+strategy/regime, next evaluation, latest AI decision, lifecycle counts, and
+scheduler status.
+
+## `GET /api/trade-lifecycle/active`
+
+Returns lifecycle records in active states from entry through pending exit.
+
+## `GET /api/trade-lifecycle/pending`
+
+Returns lifecycle records waiting for risk, entry, or execution progress.
+
+## `GET /api/trade-lifecycle/history`
+
+Returns archived or post-exit lifecycle records.
+
+## `GET /api/trade-lifecycle/timeline`
+
+Returns lifecycle journal events and automation audit context. Use `tradeId` to
+filter to one trade.
+
+## `GET /api/trade-lifecycle/evaluations`
+
+Returns lifecycle records with stored evaluation summaries and matching trade
+reports when available.

--- a/docs/trade-lifecycle/README.md
+++ b/docs/trade-lifecycle/README.md
@@ -1,0 +1,94 @@
+# Enterprise Trade Lifecycle Manager
+
+The Trade Lifecycle Manager is an additive owner layer for autonomous paper
+trades. It does not decide entries, duplicate execution, or call Alpaca
+directly. It reads the existing automation position, order intent, risk,
+strategy, event, and evaluation records, then persists a richer lifecycle state
+and append-only journal.
+
+## Architecture
+
+Approved autonomous trade evidence flows through the existing platform.
+
+Massive Data -> Event Intelligence -> Decision Intelligence -> Strategy
+Orchestrator -> Enterprise Risk Engine -> Trade Lifecycle Manager -> existing
+automation order-intent execution path -> Alpaca Paper -> Trade Evaluation ->
+Learning Journals.
+
+The lifecycle service owns monitoring records and recommendations. Broker order
+submission remains delegated to the existing durable order-intent services.
+
+## Lifecycle States
+
+Trades move through explicit states:
+
+`NEW -> PENDING_ENTRY -> ENTRY_SUBMITTED -> ENTRY_FILLED -> MONITORING`
+
+`PARTIAL_EXIT -> EXIT_PENDING -> EXIT_FILLED -> EVALUATION -> ARCHIVED`
+
+Transitions are monotonic. When an existing automation position is already
+farther along, the lifecycle service records each intermediate state in order so
+the journal never has a gap.
+
+## Timeline
+
+Every lifecycle transition, monitoring decision, confidence change, and
+evaluation result is appended to `trade_lifecycle_journal`. Existing automation
+audit events remain unchanged and are included in timeline reads for operator
+context.
+
+## Journal
+
+The lifecycle journal stores:
+
+- Trade ID and automation position link
+- State and previous state
+- Recommendation/action
+- Risk, entry, execution, confidence, and evaluation payloads
+- Human-readable reasoning
+
+The journal model rejects update and delete query mutations.
+
+## API
+
+Read-only endpoints:
+
+- `GET /api/trade-lifecycle/status`
+- `GET /api/trade-lifecycle/active`
+- `GET /api/trade-lifecycle/pending`
+- `GET /api/trade-lifecycle/history`
+- `GET /api/trade-lifecycle/timeline?tradeId=<id>`
+- `GET /api/trade-lifecycle/evaluations`
+
+## Feature Flags
+
+Safe defaults:
+
+- `TRADE_LIFECYCLE_ENABLED=true`
+- `TRADE_LIFECYCLE_AUTOSTART=false`
+- `AUTONOMOUS_MONITORING=true`
+- `AUTONOMOUS_ENTRY_ENABLED=false`
+- `AUTONOMOUS_EXIT_ENABLED=false`
+
+Autonomous order placement is disabled unless explicitly enabled. Even then,
+lifecycle requests route through existing order-intent execution services.
+
+## Operator Guide
+
+Open the existing Automation page. The Trade Lifecycle panel shows AI status,
+paper trading mode, market state, strategy, regime, next evaluation, current
+recommendation, open trades, pending trades, rejected items, timeline events,
+and latest evaluations.
+
+Expand an open trade to inspect entry, confidence, risk decision, exit
+recommendation, and journal reasoning.
+
+## Example
+
+An active trade can show:
+
+`PENDING_ENTRY -> ENTRY_SUBMITTED -> ENTRY_FILLED -> MONITORING`
+
+Monitoring may recommend `HOLD`, `MOVE_STOP`, `TAKE_PROFIT`, `SCALE_OUT`,
+`EXIT`, `WAIT`, or `NO_ACTION`. Exit recommendations require multi-factor
+reasoning and never rely only on P/L.

--- a/docs/trade-lifecycle/STATE_DIAGRAM.md
+++ b/docs/trade-lifecycle/STATE_DIAGRAM.md
@@ -1,0 +1,25 @@
+# State Diagram
+
+```text
+NEW
+  |
+PENDING_ENTRY
+  |
+ENTRY_SUBMITTED
+  |
+ENTRY_FILLED
+  |
+MONITORING
+  |
+PARTIAL_EXIT
+  |
+EXIT_PENDING
+  |
+EXIT_FILLED
+  |
+EVALUATION
+  |
+ARCHIVED
+```
+
+State transitions are persisted one at a time in `trade_lifecycle_journal`.

--- a/docs/vercel/README.md
+++ b/docs/vercel/README.md
@@ -1,0 +1,174 @@
+# Vercel Frontend Observability
+
+AI-Trader Enterprise uses Vercel native frontend observability for the Vite React client in `client/`.
+
+This setup is additive. It does not change trading logic, execution ownership, broker integrations, market-data integrations, or autonomous system behavior.
+
+## Architecture
+
+The React application root is `client/src/main.tsx`.
+
+The root mounts exactly one Vercel Web Analytics component and exactly one Speed Insights component:
+
+```tsx
+<Analytics />
+<SpeedInsights />
+```
+
+The application also uses `client/src/lib/operatorAnalytics.ts` for anonymous custom events. That utility wraps Vercel Analytics `track()` and exposes an allowlisted event catalog.
+
+## Analytics
+
+Package:
+
+```bash
+npm --prefix client install @vercel/analytics
+```
+
+Root integration:
+
+```tsx
+import { Analytics } from '@vercel/analytics/react';
+```
+
+Vercel Web Analytics automatically tracks page views after the project is deployed and Web Analytics is enabled in the Vercel dashboard.
+
+## Speed Insights
+
+Package:
+
+```bash
+npm --prefix client install @vercel/speed-insights
+```
+
+Root integration:
+
+```tsx
+import { SpeedInsights } from '@vercel/speed-insights/react';
+```
+
+Speed Insights reports Core Web Vitals and route-level frontend performance after production traffic reaches the deployed Vercel project.
+
+## Observability
+
+Native Vercel Observability is used for frontend deployments:
+
+- Deployments and build logs
+- Runtime logs for Vercel-handled routes and functions
+- Request and routing telemetry
+- Web Analytics page views and custom events
+- Speed Insights performance metrics
+- Vercel traces where supported by the project plan and runtime
+
+The AI-Trader backend remains on Render. Backend runtime logs, schedulers, workers, MongoDB connectivity, Massive connectivity, Alpaca connectivity, and execution traces are monitored through the backend health/status APIs and Render logs.
+
+No third-party monitoring service is required for this task.
+
+## Tracked Events
+
+Custom events are intentionally anonymous and operator-workflow focused:
+
+- Application Loaded
+- Automation Viewed
+- Automation Started
+- Automation Stopped
+- Cockpit Viewed
+- AI Desk Viewed
+- Strategy Viewed
+- Risk Viewed
+- Trade Lifecycle Viewed
+- Reports Viewed
+- Operator Expanded Advanced Details
+- Shadow Mode Enabled
+- Paper Mode Enabled
+
+These events may include only coarse UI properties such as:
+
+- `surface`: `desktop` or `mobile`
+- `control`: `pause`, `resume`, or `emergency-stop`
+- `section`: the UI section label
+
+## Privacy
+
+Never send these values to Vercel Analytics custom events:
+
+- Broker account IDs
+- User emails
+- API keys
+- JWTs
+- Tokens
+- Secrets
+- Personally identifiable information
+- Trade prices
+- Order IDs
+- Contract IDs
+- Raw provider payloads
+
+The analytics utility only exists for UI workflow events. Do not use it from trading, broker, market-data, risk, lifecycle, or execution logic.
+
+## Deployment
+
+No deployment is performed by this setup.
+
+Before deployment:
+
+```bash
+npm run lint
+npm run build
+npm --prefix client test
+```
+
+Vercel project settings to confirm:
+
+- Framework preset: Vite
+- Build command: `npm run build`
+- Output directory: `dist`
+- Web Analytics: enabled
+- Speed Insights: enabled
+- Observability: enabled for the project/team plan
+
+The repository `client/vercel.json` keeps same-origin rewrites for `/api/*`, `/health`, and `/socket.io/*`.
+
+## Verification
+
+After production deployment and real traffic:
+
+1. Open the Vercel project dashboard.
+2. Confirm Web Analytics is detected.
+3. Confirm Speed Insights is detected.
+4. Confirm page views start populating.
+5. Confirm route views appear for the deployed Vite app.
+6. Confirm Speed Insights begins reporting Core Web Vitals.
+7. Confirm Observability shows deployment logs and request telemetry.
+8. Exercise the Automation workspace and confirm custom events begin appearing.
+
+Expected delay: analytics and performance dashboards may need production traffic and processing time before data appears.
+
+## Troubleshooting
+
+If Web Analytics is not detected:
+
+- Confirm `@vercel/analytics` is installed in `client/package.json`.
+- Confirm exactly one `<Analytics />` is mounted in `client/src/main.tsx`.
+- Confirm Web Analytics is enabled in the Vercel dashboard.
+- Confirm the deployed build is the latest commit.
+
+If Speed Insights is not detected:
+
+- Confirm `@vercel/speed-insights` is installed in `client/package.json`.
+- Confirm exactly one `<SpeedInsights />` is mounted in `client/src/main.tsx`.
+- Confirm Speed Insights is enabled in the Vercel dashboard.
+- Confirm production traffic has reached the site.
+
+If custom events do not appear:
+
+- Confirm events are emitted from `client/src/lib/operatorAnalytics.ts`.
+- Confirm the event name is in `OPERATOR_ANALYTICS_EVENTS`.
+- Confirm the interaction occurred in a production deployment.
+- Confirm no browser extension is blocking analytics scripts.
+
+If runtime logs or traces are missing:
+
+- Confirm the project has Vercel Observability enabled.
+- Confirm the route is handled by Vercel rather than the Render backend rewrite.
+- Use Render logs and `/api/system/status` for backend runtime observability.

--- a/server/.env.example
+++ b/server/.env.example
@@ -10,31 +10,50 @@ AGENT_API_URL=http://localhost:5001
 FASTAPI_URL=http://localhost:5001
 SCREENER_URL=http://localhost:8001
 
-# Authentication / RBAC
-AUTH_JWT_SECRET=<replace-with-local-jwt-secret>
-AUTH_JWT_ISSUER=<optional-issuer>
-AUTH_JWT_AUDIENCE=<optional-audience>
-AUTH_ALLOW_DEV_TOKENS=false
-AUTH_DEV_VIEWER_TOKEN=<dev-viewer-token>
-AUTH_DEV_TRADER_TOKEN=<dev-trader-token>
-AUTH_DEV_ADMIN_TOKEN=<dev-admin-token>
+# Authentication (staged foundation — see server/src/shared/auth/requestIdentity.ts)
+#
+# This release ships a STAGED, backward-compatible identity layer. It is NOT a
+# full multi-user login system (no Google/JWT session flows are wired). The
+# production frontend does not send an Authorization header, so this release
+# runs in "observe" mode: every request is stamped with a default identity and
+# nothing is rejected. Unsafe actions remain constrained by the existing
+# execution gateway, paper-only guard, ownership leases, Risk Engine, and
+# Emergency Stop — not by this layer.
+#
+# enforcementMode: 'observe' (default) logs identity but never blocks;
+#   'required' rejects unauthenticated POST/PUT/PATCH/DELETE to /api/* with 401
+#   (or 503 if no token is configured). Do NOT set 'required' until the frontend
+#   is updated to send a bearer token, or the UI will break.
+AI_TRADER_AUTH_ENFORCEMENT=observe        # observe | required  (alias: AI_TRADER_AUTH_MODE)
+# AI_TRADER_AUTH_TOKEN=<static-bearer-token>   # required only when enforcement=required (alias: AI_TRADER_OPERATOR_TOKEN)
+AI_TRADER_DEFAULT_ACTOR_ID=legacy-operator
+AI_TRADER_DEFAULT_ACCOUNT_ID=paper-default
+AI_TRADER_DEFAULT_ROLES=administrator     # comma list: viewer,trader,operator,administrator
+# Separate admin token gating the intelligence admin routes (independent of the above).
+# INTELLIGENCE_ADMIN_TOKEN=<intelligence-admin-token>
 
 # MongoDB
+# MONGO_URI is preferred; MONGODB_URI is the compatibility fallback (either works).
 MONGO_URI=mongodb://127.0.0.1:27017/market-copilot
 MONGODB_URI=mongodb://127.0.0.1:27017/market-copilot
+# MONGO_OPTIONAL=true lets the server boot and serve WITHOUT MongoDB (features
+# that need durable state stay unavailable). This is convenient for local dev.
+# PRODUCTION: set MONGO_OPTIONAL=false on any backend that owns durable trading
+# or autonomous state, so a DB outage fails the health check loudly instead of
+# serving a silently DB-less instance.
 MONGO_OPTIONAL=true
-MONGO_LOCAL_FALLBACK=true
-MONGO_LOCAL_URI=mongodb://127.0.0.1:27017/market-copilot
-MONGO_FORCE_IPV4=true
 
 # Massive / Polygon market data
 MASSIVE_API_KEY=<massive-or-polygon-api-key>
 MASSIVE_BASE_URL=https://api.massive.com
+MASSIVE_SUBSCRIPTION_PROFILE=options-advanced
 MASSIVE_STOCKS_WS_ENABLED=true
 MASSIVE_OPTIONS_WS_ENABLED=true
-MASSIVE_WS_EAGER_CONNECT=false
 MASSIVE_STOCKS_WS_URL=wss://socket.massive.com/stocks
 MASSIVE_OPTIONS_WS_URL=wss://socket.massive.com/options
+# Production-only: delay options WS startup so a zero-downtime Render rollout does
+# not briefly run two owners of the same stream (defaults to 30000 in production).
+# MASSIVE_OPTIONS_WS_STARTUP_DELAY_MS=30000
 MASSIVE_CACHE_TTL_MS=10000
 MASSIVE_TIMEOUT_MS=10000
 
@@ -54,14 +73,17 @@ SIFT_PROVIDER=openai
 SIFT_MODEL=gpt-4o
 OPTION_ASSISTANT_ID=<optional-assistant-id>
 
-# Alpaca paper trading
+# Alpaca PAPER trading (broker adapter reads the first non-empty of each family:
+#   key    : ALPACA_API_KEY | ALPACA_KEY_ID | APCA_API_KEY_ID
+#   secret : ALPACA_API_SECRET | ALPACA_SECRET_KEY | APCA_API_SECRET_KEY
+#   baseURL: ALPACA_API_BASE | ALPACA_BASE_URL | APCA_API_BASE_URL)
+# A hard runtime guard (assertPaperConfiguration) throws if ALPACA_PAPER=false or
+# the base URL is the live host — live-money submission is structurally blocked.
 APCA_API_KEY_ID=<alpaca-key-id>
 APCA_API_SECRET_KEY=<alpaca-secret-key>
 APCA_API_BASE_URL=https://paper-api.alpaca.markets
-APCA_DATA_BASE_URL=https://data.alpaca.markets
 ALPACA_PAPER=true
-ALPACA_DATA_FEED=iex
-ALPACA_OPTION_FEED=opra
+# ALPACA_HTTP_TIMEOUT_MS=15000
 # Manual paper trading (user-driven, explicit-confirmation surface). Operational
 # kill switch: set to false to fail-closed reject all manual submissions at the
 # execution gateway. Automation is unaffected (separate governed path).
@@ -142,3 +164,50 @@ AI_RATE_LIMIT_MAX=20
 AI_DAILY_CALL_LIMIT=200
 AI_MAX_CONCURRENT=2
 AI_MAX_CONCURRENT_PER_USER=1
+
+# ---------------------------------------------------------------------------
+# Enterprise intelligence modules (v2). All schedulers default OFF (auto-start
+# false) so the enterprise stack is inert unless explicitly enabled. Read models
+# and routes are always available; only the background scanners are gated.
+# ---------------------------------------------------------------------------
+
+# Autonomous Trading Coordinator — advisory/read-model + shadow simulation only.
+# It NEVER submits broker orders; entries/exits stay disabled unless turned on.
+AUTONOMOUS_TRADING_ENABLED=false
+AUTONOMOUS_TRADING_MODE=shadow            # shadow | live-paper (shadow submits nothing)
+AUTONOMOUS_COORDINATOR_AUTO_START=false
+AUTONOMOUS_ENTRY_ENABLED=false
+AUTONOMOUS_EXIT_ENABLED=false
+AUTONOMOUS_SHADOW_EXECUTION_ENABLED=true
+AUTONOMOUS_MONITORING=true
+AUTONOMOUS_UI_ENABLED=true
+AUTONOMOUS_METRICS_ENABLED=true
+# AUTONOMOUS_SHADOW_SLIPPAGE_PCT=0.01
+
+# Decision Intelligence scanner
+DECISION_ENGINE_AUTO_START=false
+DECISION_ENGINE_SCAN_INTERVAL_MS=120000   # min 30000
+
+# Event Intelligence scanner
+EVENT_INTELLIGENCE_AUTO_START=false
+EVENT_INTELLIGENCE_SCAN_INTERVAL_MS=120000
+# EVENT_INTELLIGENCE_TRIGGER_THRESHOLD=70
+
+# Strategy Orchestrator scheduler
+STRATEGY_ORCHESTRATOR_AUTO_START=false
+# STRATEGY_ORCHESTRATOR_INTERVAL_MS=120000
+
+# Enterprise Risk Engine (approval required by default; cannot execute orders)
+RISK_ENGINE_ENABLED=true
+RISK_ENGINE_AUTO_START=false
+RISK_ENGINE_APPROVAL_REQUIRED=true
+# RISK_ENGINE_INTERVAL_MS=60000
+
+# Trade Lifecycle Manager (delegates execution to the gateway; never submits)
+TRADE_LIFECYCLE_ENABLED=true
+TRADE_LIFECYCLE_AUTOSTART=false           # note: AUTOSTART (one word), not AUTO_START
+# TRADE_LIFECYCLE_EVALUATION_INTERVAL_MS=30000
+
+# Learning Intelligence (read-only, append-only artifacts from Trade Evaluations)
+LEARNING_SYNC_ENABLED=false
+# LEARNING_SYNC_INTERVAL_MS=300000

--- a/server/src/features/autonomousTrading/contracts/entryGate.ts
+++ b/server/src/features/autonomousTrading/contracts/entryGate.ts
@@ -1,0 +1,76 @@
+import type { AutonomousTradingMode } from '../types/pipelineTypes';
+
+export type AutonomousEntryGateInput = {
+  autonomousTradingEnabled: boolean;
+  autonomousEntryEnabled: boolean;
+  mode: AutonomousTradingMode;
+  alpacaPaperConfirmed: boolean;
+  marketOpen: boolean;
+  automationReady: boolean;
+  mongoConnected: boolean;
+  brokerTruthCurrent: boolean;
+  executionLeaseOwned: boolean;
+  emergencyStopActive: boolean;
+  riskApprovalExists: boolean;
+  riskApproved: boolean;
+  riskApprovalExpired: boolean;
+  recommendationMatchesApproval: boolean;
+  lifecycleAlreadyExists: boolean;
+  duplicateOrderIntentExists: boolean;
+  positionAndOrderLimitsPermitEntry: boolean;
+};
+
+export type AutonomousEntryGateResult =
+  | { allowed: true; reasonCodes: []; explanation: string }
+  | { allowed: false; reasonCodes: string[]; explanation: string };
+
+const REASON_TEXT: Record<string, string> = {
+  AUTONOMOUS_TRADING_DISABLED: 'Autonomous trading is disabled.',
+  AUTONOMOUS_ENTRY_DISABLED: 'Autonomous paper entries are disabled.',
+  MODE_NOT_AUTONOMOUS_PAPER: 'The system is not in Autonomous Paper mode.',
+  ALPACA_NOT_CONFIRMED_PAPER: 'Alpaca is not confirmed as paper trading.',
+  MARKET_NOT_OPEN: 'The market is not open for entries.',
+  AUTOMATION_NOT_READY: 'Automation readiness checks have not passed.',
+  MONGO_DISCONNECTED: 'MongoDB is disconnected.',
+  BROKER_TRUTH_STALE: 'Broker truth is stale or unavailable.',
+  EXECUTION_LEASE_NOT_OWNED: 'This process does not own the execution lease.',
+  EMERGENCY_STOP_ACTIVE: 'Emergency Stop is active.',
+  RISK_APPROVAL_MISSING: 'No Risk Engine approval package is available.',
+  RISK_APPROVAL_REJECTED: 'The Risk Engine rejected this recommendation.',
+  RISK_APPROVAL_EXPIRED: 'The Risk Engine approval package is expired.',
+  RECOMMENDATION_APPROVAL_MISMATCH: 'The recommendation no longer matches the approval package.',
+  LIFECYCLE_ALREADY_EXISTS: 'A lifecycle record already exists for this recommendation.',
+  DUPLICATE_ORDER_INTENT: 'A duplicate order intent already exists.',
+  POSITION_OR_ORDER_LIMIT_BLOCK: 'Position or order limits block a new entry.',
+};
+
+export function evaluateAutonomousEntryGate(input: AutonomousEntryGateInput): AutonomousEntryGateResult {
+  const reasonCodes: string[] = [];
+  if (!input.autonomousTradingEnabled) reasonCodes.push('AUTONOMOUS_TRADING_DISABLED');
+  if (!input.autonomousEntryEnabled) reasonCodes.push('AUTONOMOUS_ENTRY_DISABLED');
+  if (input.mode !== 'AUTONOMOUS_PAPER') reasonCodes.push('MODE_NOT_AUTONOMOUS_PAPER');
+  if (!input.alpacaPaperConfirmed) reasonCodes.push('ALPACA_NOT_CONFIRMED_PAPER');
+  if (!input.marketOpen) reasonCodes.push('MARKET_NOT_OPEN');
+  if (!input.automationReady) reasonCodes.push('AUTOMATION_NOT_READY');
+  if (!input.mongoConnected) reasonCodes.push('MONGO_DISCONNECTED');
+  if (!input.brokerTruthCurrent) reasonCodes.push('BROKER_TRUTH_STALE');
+  if (!input.executionLeaseOwned) reasonCodes.push('EXECUTION_LEASE_NOT_OWNED');
+  if (input.emergencyStopActive) reasonCodes.push('EMERGENCY_STOP_ACTIVE');
+  if (!input.riskApprovalExists) reasonCodes.push('RISK_APPROVAL_MISSING');
+  if (input.riskApprovalExists && !input.riskApproved) reasonCodes.push('RISK_APPROVAL_REJECTED');
+  if (input.riskApprovalExpired) reasonCodes.push('RISK_APPROVAL_EXPIRED');
+  if (!input.recommendationMatchesApproval) reasonCodes.push('RECOMMENDATION_APPROVAL_MISMATCH');
+  if (input.lifecycleAlreadyExists) reasonCodes.push('LIFECYCLE_ALREADY_EXISTS');
+  if (input.duplicateOrderIntentExists) reasonCodes.push('DUPLICATE_ORDER_INTENT');
+  if (!input.positionAndOrderLimitsPermitEntry) reasonCodes.push('POSITION_OR_ORDER_LIMIT_BLOCK');
+
+  if (reasonCodes.length === 0) {
+    return { allowed: true, reasonCodes: [], explanation: 'All autonomous paper entry gates passed.' };
+  }
+  return {
+    allowed: false,
+    reasonCodes,
+    explanation: reasonCodes.map(code => REASON_TEXT[code] ?? code).join(' '),
+  };
+}
+

--- a/server/src/features/autonomousTrading/contracts/pipelineContract.ts
+++ b/server/src/features/autonomousTrading/contracts/pipelineContract.ts
@@ -1,0 +1,117 @@
+import { createHash } from 'crypto';
+import type { AutonomousTradePipelineRecord, AutonomousTradingMode } from '../types/pipelineTypes';
+
+export const AUTONOMOUS_PIPELINE_SCHEMA_VERSION = 1;
+
+export function normalizeAutonomousMode(raw = process.env.AUTONOMOUS_TRADING_MODE): AutonomousTradingMode {
+  const value = String(raw ?? 'shadow').trim().toLowerCase();
+  if (value === 'paper' || value === 'autonomous_paper') return 'AUTONOMOUS_PAPER';
+  if (value === 'manual') return 'MANUAL';
+  return 'SHADOW';
+}
+
+export function autonomousModeLabel(mode: AutonomousTradingMode): 'Manual' | 'Shadow' | 'Autonomous Paper' {
+  if (mode === 'AUTONOMOUS_PAPER') return 'Autonomous Paper';
+  if (mode === 'MANUAL') return 'Manual';
+  return 'Shadow';
+}
+
+export function executionSourceForMode(mode: AutonomousTradingMode) {
+  if (mode === 'AUTONOMOUS_PAPER') return 'AUTONOMOUS_PAPER' as const;
+  if (mode === 'MANUAL') return 'MANUAL_PAPER' as const;
+  return 'SHADOW_SIMULATION' as const;
+}
+
+export function stablePipelineId(input: {
+  mode: AutonomousTradingMode;
+  symbol: string | null;
+  eventIds: string[];
+  scanId: string | null;
+  strategyRunId: string | null;
+  recommendationId: string | null;
+}): string {
+  const hash = createHash('sha256')
+    .update(JSON.stringify({
+      mode: input.mode,
+      symbol: input.symbol,
+      eventIds: input.eventIds.slice().sort(),
+      scanId: input.scanId,
+      strategyRunId: input.strategyRunId,
+      recommendationId: input.recommendationId,
+    }))
+    .digest('hex')
+    .slice(0, 32);
+  return `atp_${hash}`;
+}
+
+export function emptyPipelineRecord(args: {
+  pipelineId: string;
+  mode: AutonomousTradingMode;
+  symbol: string | null;
+  optionContract: string | null;
+  idempotencyKey: string;
+  now: string;
+}): AutonomousTradePipelineRecord {
+  const source = executionSourceForMode(args.mode);
+  return {
+    pipelineId: args.pipelineId,
+    schemaVersion: AUTONOMOUS_PIPELINE_SCHEMA_VERSION,
+    createdAt: args.now,
+    updatedAt: args.now,
+    mode: args.mode,
+    state: 'OBSERVING',
+    executionSource: source,
+    symbol: args.symbol,
+    optionContract: args.optionContract,
+    idempotencyKey: args.idempotencyKey,
+    eventContext: { eventIds: [], importance: null, sentiment: null, summary: null },
+    decisionContext: {
+      scanId: null,
+      opportunityScore: null,
+      rank: null,
+      recommendation: null,
+      explanation: null,
+    },
+    strategyContext: {
+      runId: null,
+      winningStrategy: null,
+      confidence: null,
+      evidenceScore: null,
+      conflicts: [],
+    },
+    riskContext: {
+      approvalId: null,
+      approved: null,
+      suggestedContracts: null,
+      dollarRisk: null,
+      reasonCodes: [],
+      warnings: [],
+      expiresAt: null,
+    },
+    lifecycleContext: {
+      lifecycleId: null,
+      state: null,
+      currentAction: null,
+      currentConfidence: null,
+      nextEvaluationAt: null,
+    },
+    executionContext: {
+      requested: false,
+      executionIntentId: null,
+      brokerOrderId: null,
+      status: null,
+      paper: args.mode !== 'SHADOW',
+      source,
+    },
+    evaluationContext: {
+      evaluationId: null,
+      status: null,
+      outcome: null,
+      returnPct: null,
+    },
+    blockingReasons: [],
+    plainLanguageStatus: 'The autonomous trader is observing and waiting for current subsystem data.',
+    timeline: [],
+  };
+}
+

--- a/server/src/features/autonomousTrading/coordinator/autonomousCoordinator.service.ts
+++ b/server/src/features/autonomousTrading/coordinator/autonomousCoordinator.service.ts
@@ -1,0 +1,806 @@
+import mongoose from 'mongoose';
+import { getMarketStatusSnapshot } from '../../market/services/marketStatus';
+import { listWatchlist } from '../../watchlist/watchlist.service';
+import { getLatestEventRecord, listEventRecords } from '../../eventIntelligence/storage/eventJournal.service';
+import { getLatestDecisionScan, listDecisionScans } from '../../decisionEngine/journal.service';
+import { getLatestStrategyRun, runStrategyOrchestrator } from '../../strategyOrchestrator/controllers/orchestrator.service';
+import { buildRiskRecommendationFromStrategyRun, getLatestRiskApproval, runRiskReview } from '../../riskEngine/controllers/riskEngine.service';
+import { AutomationPositionModel } from '../../automation/models/automationPosition.model';
+import { OrderIntentModel } from '../../automation/models/orderIntent.model';
+import { BrokerOrderModel } from '../../automation/models/brokerOrder.model';
+import { AutomationSessionModel } from '../../automation/models/automationSession.model';
+import { AutomationEventModel } from '../../automation/models/automationEvent.model';
+import { getAutomationHealth } from '../../automation/services/automationHealth.service';
+import { getSchedulerStatus } from '../../automation/services/schedulerController.service';
+import { getMonitorStatus } from '../../automation/services/monitorController.service';
+import { getBrokerStreamHealth, isBrokerTruthCurrent } from '../../automation/services/orderReconciliation.service';
+import { getAutomationRuntime } from '../../automation/services/sessionRecovery.service';
+import {
+  listLifecycleActive,
+  listLifecyclePending,
+  listLifecycleTimeline,
+} from '../../tradeLifecycle/positionManager/lifecycleOwner.service';
+import { buildPipelineTransition } from '../state/pipelineStateMachine';
+import {
+  emptyPipelineRecord,
+  executionSourceForMode,
+  normalizeAutonomousMode,
+  stablePipelineId,
+} from '../contracts/pipelineContract';
+import { evaluateAutonomousEntryGate } from '../contracts/entryGate';
+import {
+  getAutonomousPipeline,
+  listAutonomousPipelines,
+  upsertAutonomousPipeline,
+} from '../storage/autonomousPipelineJournal.service';
+import type {
+  AutonomousMetricsSource,
+  AutonomousOperatorStatus,
+  AutonomousOverallHealth,
+  AutonomousPipelineTimelineEvent,
+  AutonomousServiceHealth,
+  AutonomousTradePipelineRecord,
+} from '../types/pipelineTypes';
+
+function envBool(name: string, fallback: boolean): boolean {
+  const raw = process.env[name];
+  if (raw == null || raw.trim() === '') return fallback;
+  return ['1', 'true', 'yes', 'on'].includes(raw.trim().toLowerCase());
+}
+
+function iso(value: unknown): string | null {
+  if (!value) return null;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? new Date(parsed).toISOString() : value;
+  }
+  if (typeof (value as any)?.toISOString === 'function') return (value as any).toISOString();
+  return null;
+}
+
+function finite(value: unknown): number | null {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function modeBanner(mode: ReturnType<typeof normalizeAutonomousMode>): string {
+  if (mode === 'AUTONOMOUS_PAPER') return 'AUTONOMOUS PAPER MODE - Paper orders may be submitted.';
+  if (mode === 'MANUAL') return 'MANUAL MODE - Autonomous intelligence may inform but may not initiate orders.';
+  return 'SHADOW MODE - No broker orders will be submitted.';
+}
+
+function displayMode(mode: ReturnType<typeof normalizeAutonomousMode>): AutonomousOperatorStatus['mode'] {
+  if (mode === 'AUTONOMOUS_PAPER') return 'Autonomous Paper';
+  if (mode === 'MANUAL') return 'Manual';
+  return 'Shadow';
+}
+
+function statusFromSession(session: any | null, automationReady: boolean): AutonomousOperatorStatus['status'] {
+  if (!session) return automationReady ? 'Running' : 'Stopped';
+  if (session.status === 'READY') return automationReady ? 'Running' : 'Degraded';
+  if (session.status === 'PAUSED') return 'Paused';
+  if (session.status === 'STOPPED' || session.status === 'EMERGENCY_STOPPED') return 'Stopped';
+  return automationReady ? 'Degraded' : 'Stopped';
+}
+
+function marketLabel(raw: unknown): string {
+  const value = String(raw ?? 'UNKNOWN').toUpperCase();
+  if (value === 'OPEN' || value === 'REGULAR') return 'Open';
+  if (value === 'PRE_MARKET') return 'Pre-market';
+  if (value === 'AFTER_HOURS') return 'After-hours';
+  if (value === 'CLOSED') return 'Closed';
+  return value === 'UNKNOWN' ? 'Unknown' : value;
+}
+
+function eventSummary(event: any | null): string | null {
+  return event?.event?.title ?? event?.event?.summary ?? event?.category ?? null;
+}
+
+function decisionExplanation(scan: any | null): string | null {
+  return scan?.winner?.thesis ?? scan?.winner?.aiResearch?.explanation ?? scan?.noTradeReason ?? null;
+}
+
+function rankOfWinner(scan: any | null): number | null {
+  if (!scan?.winner?.id || !Array.isArray(scan?.ranking?.top10)) return scan?.winner ? 1 : null;
+  const index = scan.ranking.top10.findIndex((candidate: any) => candidate?.id === scan.winner.id);
+  return index >= 0 ? index + 1 : 1;
+}
+
+function strategyConflicts(run: any | null): string[] {
+  if (!run?.conflicts) return [];
+  const conflicts: string[] = [];
+  if (run.conflicts.hasConflict) conflicts.push(run.conflicts.explanation ?? 'Strategy conflict detected.');
+  if (Array.isArray(run.conflicts.bullishStrategies) && run.conflicts.bullishStrategies.length > 0) {
+    conflicts.push(`Bullish: ${run.conflicts.bullishStrategies.join(', ')}`);
+  }
+  if (Array.isArray(run.conflicts.bearishStrategies) && run.conflicts.bearishStrategies.length > 0) {
+    conflicts.push(`Bearish: ${run.conflicts.bearishStrategies.join(', ')}`);
+  }
+  return conflicts;
+}
+
+function latestPipelineState(record: AutonomousTradePipelineRecord): AutonomousTradePipelineRecord['state'] {
+  if (record.evaluationContext.evaluationId) return 'COMPLETED';
+  if (record.lifecycleContext.state === 'MONITORING') return 'MONITORING';
+  if (record.executionContext.brokerOrderId) return 'ENTRY_SUBMITTED';
+  if (record.executionContext.requested) return 'ENTRY_REQUESTED';
+  if (record.lifecycleContext.lifecycleId) return 'LIFECYCLE_CREATED';
+  if (record.riskContext.approved === false) return 'RISK_REJECTED';
+  if (record.riskContext.approved === true) return 'RISK_APPROVED';
+  if (record.strategyContext.runId) return 'STRATEGY_SELECTED';
+  if (record.decisionContext.scanId) return 'OPPORTUNITY_IDENTIFIED';
+  if (record.eventContext.eventIds.length > 0) return 'EVENT_DETECTED';
+  return 'OBSERVING';
+}
+
+function buildPlainLanguageStatus(record: AutonomousTradePipelineRecord): string {
+  if (record.blockingReasons.length > 0) {
+    return `The system is blocked: ${record.blockingReasons.join(', ')}.`;
+  }
+  if (record.riskContext.approved === false) {
+    return `Risk review rejected ${record.symbol ?? 'the current opportunity'}${
+      record.riskContext.reasonCodes.length ? ` because ${record.riskContext.reasonCodes.join(', ')}` : ''
+    }.`;
+  }
+  if (record.lifecycleContext.currentAction) {
+    return `The lifecycle manager recommends ${record.lifecycleContext.currentAction} for ${record.optionContract ?? record.symbol ?? 'the current position'}.`;
+  }
+  if (record.strategyContext.winningStrategy) {
+    return `${record.strategyContext.winningStrategy} is leading with ${Math.round((record.strategyContext.confidence ?? 0) * 100)}% confidence.`;
+  }
+  if (record.decisionContext.recommendation) {
+    return `Decision Intelligence recommends ${record.decisionContext.recommendation} for ${record.symbol ?? 'the current opportunity'}.`;
+  }
+  return 'The autonomous trader is observing and waiting for current subsystem data.';
+}
+
+function buildTimeline(record: AutonomousTradePipelineRecord): AutonomousPipelineTimelineEvent[] {
+  const events: AutonomousPipelineTimelineEvent[] = [];
+  let state: AutonomousTradePipelineRecord['state'] = 'OBSERVING';
+  const push = (
+    to: AutonomousTradePipelineRecord['state'],
+    actor: string,
+    event: string,
+    reason: string,
+    relatedRecords: AutonomousPipelineTimelineEvent['relatedRecords'],
+    reasonCode?: string | null
+  ) => {
+    if (state === to) return;
+    events.push(buildPipelineTransition({ from: state, to, actor, event, reason, relatedRecords, reasonCode }));
+    state = to;
+  };
+
+  if (record.eventContext.eventIds.length > 0) {
+    push(
+      'EVENT_DETECTED',
+      'event-intelligence',
+      'Event detected',
+      record.eventContext.summary ?? 'Event Intelligence found a market event.',
+      record.eventContext.eventIds.map(recordId => ({ subsystem: 'event-intelligence', recordId, collection: 'event_intelligence_events' }))
+    );
+  }
+  if (record.decisionContext.scanId) {
+    push(
+      'OPPORTUNITY_IDENTIFIED',
+      'decision-intelligence',
+      'Decision scan completed',
+      record.decisionContext.explanation ?? 'Decision Intelligence ranked an opportunity.',
+      [{ subsystem: 'decision-intelligence', recordId: record.decisionContext.scanId, collection: 'decision_engine_scans' }]
+    );
+  }
+  if (record.strategyContext.runId) {
+    push(
+      'STRATEGY_SELECTED',
+      'strategy-orchestrator',
+      'Strategy selected',
+      record.strategyContext.winningStrategy
+        ? `${record.strategyContext.winningStrategy} is leading.`
+        : 'Strategy Orchestrator completed without a leading strategy.',
+      [{ subsystem: 'strategy-orchestrator', recordId: record.strategyContext.runId, collection: 'strategy_orchestrator_runs' }]
+    );
+  }
+  if (record.riskContext.approvalId) {
+    push(
+      'RISK_REVIEW',
+      'risk-engine',
+      'Risk review completed',
+      record.riskContext.approved ? 'Risk Engine approved the recommendation.' : 'Risk Engine rejected the recommendation.',
+      [{ subsystem: 'risk-engine', recordId: record.riskContext.approvalId, collection: 'risk_engine_approvals' }]
+    );
+    push(
+      record.riskContext.approved ? 'RISK_APPROVED' : 'RISK_REJECTED',
+      'risk-engine',
+      record.riskContext.approved ? 'Risk approved' : 'Risk rejected',
+      record.riskContext.reasonCodes.join(', ') || (record.riskContext.approved ? 'Approved by Risk Engine.' : 'Rejected by Risk Engine.'),
+      [{ subsystem: 'risk-engine', recordId: record.riskContext.approvalId, collection: 'risk_engine_approvals' }],
+      record.riskContext.reasonCodes[0] ?? null
+    );
+  }
+  if (record.lifecycleContext.lifecycleId) {
+    push(
+      'LIFECYCLE_CREATED',
+      'trade-lifecycle',
+      'Lifecycle created',
+      `Lifecycle state is ${record.lifecycleContext.state ?? 'unknown'}.`,
+      [{ subsystem: 'trade-lifecycle', recordId: record.lifecycleContext.lifecycleId, collection: 'trade_lifecycle_records' }]
+    );
+  }
+  if (record.executionContext.requested && record.executionContext.executionIntentId) {
+    push(
+      record.executionContext.brokerOrderId ? 'ENTRY_SUBMITTED' : 'ENTRY_REQUESTED',
+      'execution-gateway',
+      record.executionContext.brokerOrderId ? 'Entry submitted' : 'Entry requested',
+      record.executionContext.brokerOrderId
+        ? 'Existing Execution Gateway submitted a paper order.'
+        : 'Execution intent exists; broker order has not been submitted.',
+      [{ subsystem: 'execution-gateway', recordId: record.executionContext.executionIntentId, collection: 'automation_order_intents' }]
+    );
+  }
+  if (record.lifecycleContext.state === 'MONITORING') {
+    push('MONITORING', 'trade-lifecycle', 'Position monitoring', buildPlainLanguageStatus(record), []);
+  }
+  if (record.evaluationContext.evaluationId) {
+    push(
+      'EVALUATING',
+      'trade-evaluation',
+      'Evaluation started',
+      'Existing Trade Evaluation measured the completed outcome.',
+      [{ subsystem: 'trade-evaluation', recordId: record.evaluationContext.evaluationId }]
+    );
+    push('COMPLETED', 'autonomous-coordinator', 'Pipeline completed', 'The opportunity lifecycle is complete.', []);
+  } else if (record.state === 'RISK_REJECTED') {
+    push('COMPLETED', 'autonomous-coordinator', 'Pipeline completed', 'No trade was submitted.', []);
+  }
+  return events;
+}
+
+export async function buildCurrentAutonomousPipeline(options: {
+  persist?: boolean;
+  runStrategy?: boolean;
+  runRisk?: boolean;
+} = {}): Promise<AutonomousTradePipelineRecord> {
+  const mode = normalizeAutonomousMode();
+  const now = new Date().toISOString();
+  if (mongoose.connection?.readyState !== 1) {
+    const pipelineId = stablePipelineId({
+      mode,
+      symbol: null,
+      eventIds: [],
+      scanId: null,
+      strategyRunId: null,
+      recommendationId: null,
+    });
+    const record = emptyPipelineRecord({ pipelineId, mode, symbol: null, optionContract: null, idempotencyKey: pipelineId, now });
+    record.state = 'FAILED';
+    record.blockingReasons = ['MONGO_DISCONNECTED'];
+    record.plainLanguageStatus = 'MongoDB is disconnected, so persisted autonomous pipeline data is unavailable.';
+    return record;
+  }
+  const [event, decision, existingStrategy] = await Promise.all([
+    getLatestEventRecord().catch(() => null),
+    getLatestDecisionScan().catch(() => null),
+    getLatestStrategyRun().catch(() => null),
+  ]);
+  const strategy = options.runStrategy ? await runStrategyOrchestrator({ persist: options.persist !== false }).catch(() => existingStrategy) : existingStrategy;
+  const riskRecommendation = strategy ? buildRiskRecommendationFromStrategyRun(strategy as any) : null;
+  const riskReview =
+    options.runRisk && riskRecommendation
+      ? await runRiskReview({ recommendation: riskRecommendation, persist: options.persist !== false }).catch(() => null)
+      : null;
+  const latestRisk = riskReview?.record ?? (await getLatestRiskApproval().catch(() => null));
+  const eventAny = event as any;
+  const decisionAny = decision as any;
+  const strategyAny = strategy as any;
+  const latestRiskAny = latestRisk as any;
+  const symbol = decisionAny?.winner?.symbol ?? strategyAny?.decisionEngineContext?.bestOpportunity?.symbol ?? latestRiskAny?.recommendation?.symbol ?? null;
+  const optionContract = decisionAny?.winner?.contract?.symbol ?? latestRiskAny?.recommendation?.contract?.symbol ?? null;
+  const eventIds = eventAny ? [eventAny.eventId ?? eventAny.event?.id].filter(Boolean) : [];
+  const recommendationId = strategyAny?.recommendation?.riskHandoff?.packageId ?? latestRiskAny?.recommendation?.recommendationId ?? null;
+  const pipelineId = stablePipelineId({
+    mode,
+    symbol,
+    eventIds,
+    scanId: decisionAny?.scanId ?? null,
+    strategyRunId: strategyAny?.runId ?? null,
+    recommendationId,
+  });
+  const existing = await getAutonomousPipeline(pipelineId).catch(() => null);
+  const record = existing ?? emptyPipelineRecord({ pipelineId, mode, symbol, optionContract, idempotencyKey: pipelineId, now });
+  record.updatedAt = now;
+  record.mode = mode;
+  record.executionSource = executionSourceForMode(mode);
+  record.symbol = symbol;
+  record.optionContract = optionContract;
+  record.eventContext = {
+    eventIds,
+    importance: finite(eventAny?.importance ?? eventAny?.event?.importance),
+    sentiment: eventAny?.event?.sentiment?.score ?? eventAny?.event?.sentiment?.label ?? null,
+    summary: eventSummary(event),
+  };
+  record.decisionContext = {
+    scanId: decisionAny?.scanId ?? null,
+    opportunityScore: finite(decisionAny?.winner?.overallScore),
+    rank: rankOfWinner(decision),
+    recommendation: decisionAny?.winner?.recommendation ?? null,
+    explanation: decisionExplanation(decision),
+  };
+  record.strategyContext = {
+    runId: strategyAny?.runId ?? null,
+    winningStrategy: strategyAny?.winner?.name ?? null,
+    confidence: finite(strategyAny?.recommendation?.confidence ?? strategyAny?.winner?.confidence),
+    evidenceScore: finite(strategyAny?.evidence?.score ?? strategyAny?.winner?.evidenceScore),
+    conflicts: strategyConflicts(strategy),
+  };
+  record.riskContext = {
+    approvalId: latestRiskAny?.approvalId ?? null,
+    approved: latestRiskAny?.approval?.approved ?? null,
+    suggestedContracts: finite(latestRiskAny?.approval?.suggestedPositionSize?.suggestedContracts),
+    dollarRisk: finite(latestRiskAny?.approval?.suggestedPositionSize?.dollarRisk),
+    reasonCodes: latestRiskAny?.reasonCodes ?? latestRiskAny?.approval?.reasons?.map((reason: any) => reason.code) ?? [],
+    warnings: latestRiskAny?.approval?.warnings ?? [],
+    expiresAt: latestRiskAny?.timestamp ? new Date(Date.parse(latestRiskAny.timestamp) + 5 * 60_000).toISOString() : null,
+  };
+
+  const [lifecycle, intent] = await Promise.all([
+    optionContract
+      ? listLifecycleActive().then(items => items.find((item: any) => item.optionSymbol === optionContract) ?? null).catch(() => null)
+      : Promise.resolve(null),
+    recommendationId
+      ? OrderIntentModel.findOne({ idempotencyKey: recommendationId }).sort({ createdAt: -1 }).lean().catch(() => null)
+      : Promise.resolve(null),
+  ]);
+  const brokerOrder =
+    intent?.brokerOrderId
+      ? await BrokerOrderModel.findOne({ brokerOrderId: intent.brokerOrderId }).lean().catch(() => null)
+      : null;
+
+  record.lifecycleContext = {
+    lifecycleId: lifecycle?.tradeId ?? lifecycle?._id?.toString?.() ?? null,
+    state: lifecycle?.state ?? null,
+    currentAction: lifecycle?.currentAction ?? null,
+    currentConfidence: finite(lifecycle?.confidence?.current),
+    nextEvaluationAt: iso(lifecycle?.nextEvaluationAt),
+  };
+  record.executionContext = {
+    requested: Boolean(intent),
+    executionIntentId: intent?._id ? String(intent._id) : null,
+    brokerOrderId: intent?.brokerOrderId ?? brokerOrder?.brokerOrderId ?? null,
+    status: intent?.status ?? brokerOrder?.status ?? null,
+    paper: mode !== 'SHADOW',
+    source: executionSourceForMode(mode),
+  };
+  record.evaluationContext = {
+    evaluationId: lifecycle?.evaluationReportId ?? null,
+    status: lifecycle?.evaluationSummary ? 'COMPLETED' : null,
+    outcome: (lifecycle?.evaluationSummary as any)?.winLoss ?? null,
+    returnPct: finite((lifecycle?.evaluationSummary as any)?.return),
+  };
+
+  const health = await getAutomationHealth().catch(() => null);
+  const gate = evaluateAutonomousEntryGate({
+    autonomousTradingEnabled: envBool('AUTONOMOUS_TRADING_ENABLED', false),
+    autonomousEntryEnabled: envBool('AUTONOMOUS_ENTRY_ENABLED', false),
+    mode,
+    alpacaPaperConfirmed: health?.gates?.brokerMode?.status === 'pass',
+    marketOpen: health?.gates?.marketClock?.state === 'OPEN',
+    automationReady: Boolean(health?.automationReady),
+    mongoConnected: mongoose.connection?.readyState === 1,
+    brokerTruthCurrent: isBrokerTruthCurrent(),
+    executionLeaseOwned: getSchedulerStatus().lastTick?.ownsLease === true,
+    emergencyStopActive: Boolean((await latestSession().catch(() => null))?.emergencyStop?.active),
+    riskApprovalExists: Boolean(record.riskContext.approvalId),
+    riskApproved: record.riskContext.approved === true,
+    riskApprovalExpired: record.riskContext.expiresAt ? Date.parse(record.riskContext.expiresAt) < Date.now() : false,
+    recommendationMatchesApproval: !recommendationId || latestRiskAny?.recommendation?.recommendationId === recommendationId,
+    lifecycleAlreadyExists: Boolean(record.lifecycleContext.lifecycleId),
+    duplicateOrderIntentExists: Boolean(record.executionContext.executionIntentId),
+    positionAndOrderLimitsPermitEntry: !(await hasOpenAutomationPosition().catch(() => true)),
+  });
+  record.blockingReasons = gate.allowed || mode !== 'AUTONOMOUS_PAPER' ? [] : gate.reasonCodes;
+  record.state = record.blockingReasons.length > 0 && record.riskContext.approved ? 'ENTRY_BLOCKED' : latestPipelineState(record);
+  record.plainLanguageStatus = buildPlainLanguageStatus(record);
+  record.timeline = buildTimeline(record);
+
+  if (options.persist !== false && mongoose.connection?.readyState === 1) {
+    return upsertAutonomousPipeline(record);
+  }
+  return record;
+}
+
+async function latestSession() {
+  return AutomationSessionModel.findOne({}).sort({ updatedAt: -1 }).lean();
+}
+
+async function hasOpenAutomationPosition(): Promise<boolean> {
+  const count = await AutomationPositionModel.countDocuments({ status: { $in: ['PENDING_ENTRY', 'OPEN', 'EXITING'] } });
+  return count > 0;
+}
+
+export async function getAutonomousStatus(): Promise<AutonomousOperatorStatus> {
+  if (mongoose.connection?.readyState !== 1) {
+    const mode = normalizeAutonomousMode();
+    return {
+      generatedAt: new Date().toISOString(),
+      status: 'Stopped',
+      mode: displayMode(mode),
+      modeBanner: modeBanner(mode),
+      market: 'Unknown',
+      broker: 'Alpaca Paper',
+      automationOwner: 'Unknown',
+      marketData: 'Unavailable',
+      nextEvaluationAt: null,
+      emergencyStop: 'Unknown',
+      watching: [],
+      currentActivity: 'MongoDB is disconnected, so autonomous trading status is unavailable.',
+      latestPipelineId: null,
+      featureFlags: getAutonomousFeatureFlags(),
+    };
+  }
+  const [pipeline, health, scheduler, session, watchlist, market] = await Promise.all([
+    buildCurrentAutonomousPipeline({ persist: false }).catch(() => null),
+    getAutomationHealth().catch(() => null),
+    Promise.resolve(getSchedulerStatus()),
+    latestSession().catch(() => null),
+    listWatchlist().catch(() => []),
+    getMarketStatusSnapshot().catch(() => null),
+  ]);
+  const mode = normalizeAutonomousMode();
+  const watching = watchlist.filter((item: any) => item.enabled !== false).map((item: any) => item.symbol).filter(Boolean);
+  const marketClock = health?.gates?.marketClock?.state ?? market?.market ?? 'UNKNOWN';
+  const massiveGate = health?.gates?.massiveMarketData;
+  return {
+    generatedAt: new Date().toISOString(),
+    status: statusFromSession(session, Boolean(health?.automationReady)),
+    mode: displayMode(mode),
+    modeBanner: modeBanner(mode),
+    market: marketLabel(marketClock),
+    broker: 'Alpaca Paper',
+    automationOwner: scheduler.state === 'ACTIVE' ? 'Owned' : scheduler.state === 'STOPPED' ? 'Not Owned' : 'Unknown',
+    marketData: massiveGate?.status === 'pass' ? 'Live' : massiveGate?.status === 'degraded' ? 'Stale' : 'Unavailable',
+    nextEvaluationAt: scheduler.nextWindow ?? pipeline?.lifecycleContext.nextEvaluationAt ?? null,
+    emergencyStop: session?.emergencyStop?.active === true ? 'Active' : session?.emergencyStop?.active === false ? 'Inactive' : 'Unknown',
+    watching,
+    currentActivity: buildCurrentActivityNarrative(pipeline, watching, scheduler.nextWindow),
+    latestPipelineId: pipeline?.pipelineId ?? null,
+    featureFlags: getAutonomousFeatureFlags(),
+  };
+}
+
+function buildCurrentActivityNarrative(
+  pipeline: AutonomousTradePipelineRecord | null,
+  watching: string[],
+  nextEvaluationAt: string | null
+): string {
+  const sentences: string[] = [];
+  if (watching.length > 0) sentences.push(`The system is monitoring ${watching.join(', ')}.`);
+  else sentences.push('No watchlist symbols are currently configured for autonomous monitoring.');
+  if (!pipeline) {
+    sentences.push('No current autonomous pipeline record is available.');
+  } else {
+    if (pipeline.eventContext.summary) sentences.push(`${pipeline.eventContext.summary} was detected by Event Intelligence.`);
+    else sentences.push('No current Event Intelligence context is available.');
+    if (pipeline.strategyContext.winningStrategy) {
+      sentences.push(`${pipeline.strategyContext.winningStrategy} is leading with ${Math.round((pipeline.strategyContext.confidence ?? 0) * 100)}% confidence.`);
+    } else {
+      sentences.push('No current strategy recommendation is available.');
+    }
+    if (pipeline.riskContext.approved === true) sentences.push('Risk Engine approved the current recommendation.');
+    else if (pipeline.riskContext.approved === false) sentences.push(`Risk Engine rejected the current recommendation because ${pipeline.riskContext.reasonCodes.join(', ') || 'risk checks did not pass'}.`);
+    else sentences.push('The system is waiting for Risk Engine review.');
+    sentences.push(pipeline.plainLanguageStatus);
+  }
+  if (nextEvaluationAt) sentences.push(`The next evaluation is scheduled for ${nextEvaluationAt}.`);
+  return sentences.join(' ');
+}
+
+export function getAutonomousFeatureFlags(): Record<string, boolean | string> {
+  return {
+    AUTONOMOUS_TRADING_ENABLED: envBool('AUTONOMOUS_TRADING_ENABLED', false),
+    AUTONOMOUS_TRADING_MODE: String(process.env.AUTONOMOUS_TRADING_MODE ?? 'shadow'),
+    AUTONOMOUS_COORDINATOR_AUTO_START: envBool('AUTONOMOUS_COORDINATOR_AUTO_START', false),
+    AUTONOMOUS_ENTRY_ENABLED: envBool('AUTONOMOUS_ENTRY_ENABLED', false),
+    AUTONOMOUS_EXIT_ENABLED: envBool('AUTONOMOUS_EXIT_ENABLED', false),
+    AUTONOMOUS_SHADOW_EXECUTION_ENABLED: envBool('AUTONOMOUS_SHADOW_EXECUTION_ENABLED', true),
+    AUTONOMOUS_UI_ENABLED: envBool('AUTONOMOUS_UI_ENABLED', true),
+    AUTONOMOUS_METRICS_ENABLED: envBool('AUTONOMOUS_METRICS_ENABLED', true),
+  };
+}
+
+export async function getAutonomousCurrent() {
+  const pipeline = await buildCurrentAutonomousPipeline({ persist: mongoose.connection?.readyState === 1 });
+  return { pipeline };
+}
+
+export async function getAutonomousActive() {
+  const [lifecycleTrades, positions] = await Promise.all([
+    listLifecycleActive().catch(() => []),
+    AutomationPositionModel.find({ status: { $in: ['PENDING_ENTRY', 'OPEN', 'EXITING'] } }).sort({ updatedAt: -1 }).lean().catch(() => []),
+  ]);
+  return {
+    trades: lifecycleTrades.map((trade: any) => ({
+      symbol: trade.underlying,
+      contract: trade.optionSymbol,
+      entry: null,
+      currentMark: null,
+      pnl: null,
+      lifecycleState: trade.state,
+      lifecycleAction: trade.currentAction,
+      currentConfidence: trade.confidence?.current ?? null,
+      timeHeld: null,
+      nextEvaluationAt: iso(trade.nextEvaluationAt),
+      ownership: 'AUTONOMOUS',
+      trade,
+    })),
+    positions,
+  };
+}
+
+export async function getAutonomousPending() {
+  const [pipeline, lifecyclePending, intents] = await Promise.all([
+    buildCurrentAutonomousPipeline({ persist: false }).catch(() => null),
+    listLifecyclePending().catch(() => []),
+    OrderIntentModel.find({ status: { $in: ['CREATED', 'APPROVED_AWAITING_EXECUTION', 'SUBMITTING', 'SUBMITTED', 'MANUAL_REVIEW'] } })
+      .sort({ updatedAt: -1 })
+      .limit(100)
+      .lean()
+      .catch(() => []),
+  ]);
+  return {
+    trades: lifecyclePending,
+    intents,
+    current: pipeline
+      ? {
+          symbol: pipeline.symbol,
+          contract: pipeline.optionContract,
+          recommendation: pipeline.decisionContext.recommendation,
+          winningStrategy: pipeline.strategyContext.winningStrategy,
+          evidenceScore: pipeline.strategyContext.evidenceScore,
+          riskStatus: pipeline.riskContext.approved == null ? 'PENDING' : pipeline.riskContext.approved ? 'APPROVED' : 'REJECTED',
+          entryStatus: pipeline.executionContext.status ?? (pipeline.blockingReasons.length ? 'BLOCKED' : 'WAITING'),
+          blockingReason: pipeline.blockingReasons.join(', ') || null,
+          ageSeconds: Math.max(0, Math.round((Date.now() - Date.parse(pipeline.updatedAt)) / 1000)),
+        }
+      : null,
+  };
+}
+
+export async function getAutonomousRecentDecisions(limit = 20) {
+  const [pipelines, decisions, risks, lifecycleEvents] = await Promise.all([
+    listAutonomousPipelines(limit).catch(() => []),
+    listDecisionScans(limit).catch(() => []),
+    getRiskHistory(limit),
+    listLifecycleTimeline(undefined, limit).catch(() => []),
+  ]);
+  const items = [
+    ...pipelines.map(pipeline => ({
+      time: pipeline.updatedAt,
+      symbol: pipeline.symbol,
+      action: pipeline.state,
+      subsystem: 'Autonomous Coordinator',
+      reason: pipeline.plainLanguageStatus,
+      pipelineId: pipeline.pipelineId,
+    })),
+    ...decisions.map((scan: any) => ({
+      time: iso(scan.timestamp) ?? iso(scan.createdAt) ?? new Date().toISOString(),
+      symbol: scan.winner?.symbol ?? null,
+      action: scan.winner?.recommendation ?? 'WATCH',
+      subsystem: 'Decision Intelligence',
+      reason: decisionExplanation(scan) ?? 'Decision scan completed.',
+      pipelineId: null,
+    })),
+    ...risks.map((risk: any) => ({
+      time: iso(risk.timestamp) ?? iso(risk.createdAt) ?? new Date().toISOString(),
+      symbol: risk.recommendation?.symbol ?? null,
+      action: risk.approval?.approved ? 'APPROVED' : 'REJECTED',
+      subsystem: 'Risk Engine',
+      reason: risk.reasonCodes?.join(', ') || (risk.approval?.approved ? 'Risk approved.' : 'Risk rejected.'),
+      pipelineId: null,
+    })),
+    ...lifecycleEvents.map((event: any) => ({
+      time: iso(event.at ?? event.timestamp) ?? new Date().toISOString(),
+      symbol: event.symbol ?? null,
+      action: event.eventType ?? event.event ?? 'LIFECYCLE',
+      subsystem: event.source ?? event.service ?? 'Trade Lifecycle',
+      reason: event.reason ?? 'Lifecycle event recorded.',
+      pipelineId: null,
+    })),
+  ];
+  return { decisions: items.sort((a, b) => Date.parse(b.time) - Date.parse(a.time)).slice(0, limit) };
+}
+
+async function getRiskHistory(limit: number) {
+  const { listRiskApprovals } = await import('../../riskEngine/controllers/riskEngine.service');
+  return listRiskApprovals(limit).catch(() => []);
+}
+
+export async function getAutonomousTimeline(limit = 100) {
+  const [pipelines, lifecycleEvents, automationEvents] = await Promise.all([
+    listAutonomousPipelines(limit).catch(() => []),
+    listLifecycleTimeline(undefined, limit).catch(() => []),
+    AutomationEventModel.find({}).sort({ timestamp: -1 }).limit(limit).lean().catch(() => []),
+  ]);
+  const timeline = [
+    ...pipelines.flatMap(pipeline =>
+      pipeline.timeline.map(event => ({
+        ...event,
+        pipelineId: pipeline.pipelineId,
+        symbol: pipeline.symbol,
+      }))
+    ),
+    ...lifecycleEvents.map((event: any) => ({
+      at: iso(event.at ?? event.timestamp) ?? new Date().toISOString(),
+      pipelineId: null,
+      symbol: event.symbol ?? null,
+      event: event.eventType ?? event.event ?? 'Lifecycle event',
+      actor: event.source ?? event.service ?? 'trade-lifecycle',
+      reason: event.reason ?? 'Lifecycle journal event.',
+      state: event.state ?? null,
+      relatedRecords: event.tradeId ? [{ subsystem: 'trade-lifecycle', recordId: event.tradeId }] : [],
+    })),
+    ...automationEvents.map((event: any) => ({
+      at: iso(event.timestamp) ?? new Date().toISOString(),
+      pipelineId: null,
+      symbol: event.symbol ?? null,
+      event: event.event ?? 'Automation event',
+      actor: event.service ?? 'automation',
+      reason: event.payload?.reason ?? event.event ?? 'Automation journal event.',
+      state: null,
+      relatedRecords: event.intentId ? [{ subsystem: 'execution-gateway', recordId: event.intentId }] : [],
+    })),
+  ];
+  return { events: timeline.sort((a, b) => Date.parse(b.at) - Date.parse(a.at)).slice(0, limit) };
+}
+
+export async function getAutonomousHealth() {
+  if (mongoose.connection?.readyState !== 1) {
+    const services: AutonomousServiceHealth[] = [
+      healthItem('MongoDB', false, null, 'MongoDB disconnected.', true),
+      healthItem('Automation scheduler', getSchedulerStatus().state === 'ACTIVE', getSchedulerStatus().lastTickAt, getSchedulerStatus().lastError, true),
+      healthItem('Monitor scheduler', getMonitorStatus().state === 'ACTIVE', getMonitorStatus().lastTickAt, getMonitorStatus().lastError, true),
+    ];
+    return {
+      overall: 'BLOCKED' as const,
+      generatedAt: new Date().toISOString(),
+      explanation: 'MongoDB is disconnected; journal-backed autonomous status is unavailable.',
+      services,
+    };
+  }
+  const [automationHealth, scheduler, monitor, latestEvent, latestDecision, latestStrategy, latestRisk] = await Promise.all([
+    getAutomationHealth().catch(() => null),
+    Promise.resolve(getSchedulerStatus()),
+    Promise.resolve(getMonitorStatus()),
+    getLatestEventRecord().catch(() => null),
+    getLatestDecisionScan().catch(() => null),
+    getLatestStrategyRun().catch(() => null),
+    getLatestRiskApproval().catch(() => null),
+  ]);
+  const brokerStream = getBrokerStreamHealth();
+  const services: AutonomousServiceHealth[] = [
+    healthItem('Massive REST', automationHealth?.gates?.massiveMarketData?.status === 'pass', null, automationHealth?.gates?.massiveMarketData?.detail ?? null, true),
+    healthItem('Massive Options WebSocket', brokerStream.state !== 'DISCONNECTED', iso(brokerStream.lastEventAt), brokerStream.state, true),
+    healthItem('Massive Stocks WebSocket', true, null, 'No stock websocket freshness reported by current subsystem.', true),
+    healthItem('Event Intelligence', Boolean(latestEvent), iso((latestEvent as any)?.timestamp ?? (latestEvent as any)?.createdAt), null, true),
+    healthItem('Decision Intelligence', Boolean(latestDecision), iso((latestDecision as any)?.timestamp ?? (latestDecision as any)?.createdAt), null, true),
+    healthItem('Strategy Orchestrator', Boolean(latestStrategy), iso((latestStrategy as any)?.timestamp ?? (latestStrategy as any)?.createdAt), null, true),
+    healthItem('Risk Engine', Boolean(latestRisk), iso((latestRisk as any)?.timestamp ?? (latestRisk as any)?.createdAt), null, true),
+    healthItem('Trade Lifecycle Manager', true, null, null, true),
+    healthItem('Execution Gateway', automationHealth?.gates?.brokerMode?.status === 'pass', null, automationHealth?.gates?.brokerMode?.detail ?? null, true),
+    healthItem('Alpaca Paper', automationHealth?.gates?.brokerApi?.status === 'pass', null, automationHealth?.gates?.brokerApi?.detail ?? null, true),
+    healthItem('Trade Evaluation', true, null, null, true),
+    healthItem('MongoDB', mongoose.connection?.readyState === 1, null, mongoose.connection?.readyState === 1 ? null : 'MongoDB disconnected.', true),
+    healthItem('Automation scheduler', scheduler.state === 'ACTIVE', scheduler.lastTickAt, scheduler.lastError, true, scheduler.ownerId ? 'Owned' : 'Not Owned'),
+    healthItem('Monitor scheduler', monitor.state === 'ACTIVE', monitor.lastTickAt, monitor.lastError, true, monitor.ownerId ? 'Owned' : 'Not Owned'),
+  ];
+  const overall: AutonomousOverallHealth = services.some(service => service.status === 'BLOCKED')
+    ? 'BLOCKED'
+    : services.some(service => service.status === 'DEGRADED')
+      ? 'DEGRADED'
+      : services.every(service => service.status === 'STOPPED')
+        ? 'STOPPED'
+        : 'HEALTHY';
+  return {
+    overall,
+    generatedAt: new Date().toISOString(),
+    explanation: explainHealth(overall, services),
+    services,
+  };
+}
+
+function healthItem(
+  name: string,
+  ok: boolean,
+  dataTimestamp: string | null,
+  detail: string | null,
+  featureEnabled: boolean,
+  ownerStatus: string | null = null
+): AutonomousServiceHealth {
+  const stale = dataTimestamp ? Date.now() - Date.parse(dataTimestamp) > 10 * 60_000 : !ok;
+  return {
+    name,
+    status: !featureEnabled ? 'STOPPED' : ok ? (stale ? 'DEGRADED' : 'HEALTHY') : 'BLOCKED',
+    lastSuccessfulRunAt: ok ? dataTimestamp : null,
+    lastAttemptAt: dataTimestamp,
+    latencyMs: null,
+    dataTimestamp,
+    stale,
+    staleReason: stale ? detail ?? 'No fresh timestamp is available.' : null,
+    lastError: ok ? null : detail,
+    featureEnabled,
+    ownerStatus,
+  };
+}
+
+function explainHealth(overall: AutonomousOverallHealth, services: AutonomousServiceHealth[]): string {
+  if (overall === 'HEALTHY') return 'Every autonomous trading service is healthy and current.';
+  const blocked = services.filter(service => service.status === 'BLOCKED').map(service => service.name);
+  if (blocked.length > 0) return `Blocked services: ${blocked.join(', ')}.`;
+  const degraded = services.filter(service => service.status === 'DEGRADED').map(service => service.name);
+  if (degraded.length > 0) return `Degraded services: ${degraded.join(', ')}.`;
+  return 'Autonomous services are stopped.';
+}
+
+export async function getAutonomousMetrics() {
+  const [pipelines, positions, intents, orders] = await Promise.all([
+    listAutonomousPipelines(500).catch(() => []),
+    AutomationPositionModel.find({}).limit(1000).lean().catch(() => []),
+    OrderIntentModel.find({}).limit(1000).lean().catch(() => []),
+    BrokerOrderModel.find({}).limit(1000).lean().catch(() => []),
+  ]);
+  const sourceNames: AutonomousMetricsSource['source'][] = ['SHADOW_SIMULATION', 'AUTONOMOUS_PAPER', 'MANUAL_PAPER'];
+  const sources: AutonomousMetricsSource[] = sourceNames.map(source => {
+    const sourcePipelines = pipelines.filter(pipeline => pipeline.executionSource === source);
+    const sourcePositions = source === 'AUTONOMOUS_PAPER' ? positions : [];
+    const completed = sourcePositions.filter((position: any) => position.status === 'CLOSED');
+    const returns = completed.map((position: any) => finite(position.returnPct)).filter((value): value is number => value != null);
+    const topReason = topValue(sourcePipelines.flatMap(pipeline => pipeline.riskContext.reasonCodes));
+    return {
+      source,
+      eventsProcessed: sourcePipelines.filter(pipeline => pipeline.eventContext.eventIds.length > 0).length,
+      opportunitiesEvaluated: sourcePipelines.filter(pipeline => pipeline.decisionContext.scanId).length,
+      strategiesEvaluated: sourcePipelines.filter(pipeline => pipeline.strategyContext.runId).length,
+      recommendationsGenerated: sourcePipelines.filter(pipeline => pipeline.decisionContext.recommendation).length,
+      riskApprovals: sourcePipelines.filter(pipeline => pipeline.riskContext.approved === true).length,
+      riskRejections: sourcePipelines.filter(pipeline => pipeline.riskContext.approved === false).length,
+      shadowEntries: source === 'SHADOW_SIMULATION' ? sourcePipelines.filter(pipeline => pipeline.executionContext.requested).length : 0,
+      paperEntriesRequested: source === 'AUTONOMOUS_PAPER' ? intents.filter((intent: any) => intent.intentType === 'ENTRY').length : 0,
+      ordersSubmitted: source === 'AUTONOMOUS_PAPER' ? orders.length : 0,
+      ordersFilled: source === 'AUTONOMOUS_PAPER' ? orders.filter((order: any) => String(order.status).toUpperCase().includes('FILL')).length : 0,
+      entryFailures: sourcePipelines.filter(pipeline => pipeline.state === 'ENTRY_BLOCKED' || pipeline.state === 'FAILED').length,
+      lifecycleEvaluations: sourcePipelines.filter(pipeline => pipeline.lifecycleContext.lifecycleId).length,
+      exitRecommendations: sourcePositions.filter((position: any) => position.exitReason).length,
+      exitOrders: source === 'AUTONOMOUS_PAPER' ? intents.filter((intent: any) => intent.intentType === 'EXIT').length : 0,
+      completedTrades: completed.length,
+      winRate: completed.length ? completed.filter((position: any) => finite(position.realizedPnl) != null && finite(position.realizedPnl)! > 0).length / completed.length : null,
+      averageReturn: returns.length ? returns.reduce((sum, value) => sum + value, 0) / returns.length : null,
+      averageHoldTimeMinutes: null,
+      maximumDrawdown: minNumber(sourcePositions.map((position: any) => finite(position.maxAdverseExcursion))),
+      topRejectionReason: topReason,
+      staleDataBlocks: sourcePipelines.filter(pipeline => pipeline.blockingReasons.some(reason => reason.includes('STALE'))).length,
+      duplicateOrderBlocks: sourcePipelines.filter(pipeline => pipeline.blockingReasons.includes('DUPLICATE_ORDER_INTENT')).length,
+    };
+  });
+  return { generatedAt: new Date().toISOString(), sources };
+}
+
+function topValue(values: string[]): string | null {
+  const counts = new Map<string, number>();
+  values.forEach(value => counts.set(value, (counts.get(value) ?? 0) + 1));
+  return [...counts.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ?? null;
+}
+
+function minNumber(values: Array<number | null>): number | null {
+  const finiteValues = values.filter((value): value is number => value != null);
+  return finiteValues.length ? Math.min(...finiteValues) : null;
+}
+
+export async function getAutonomousPipelineById(pipelineId: string) {
+  const pipeline = await getAutonomousPipeline(pipelineId);
+  if (!pipeline) throw Object.assign(new Error('AUTONOMOUS_PIPELINE_NOT_FOUND'), { status: 404 });
+  return { pipeline };
+}
+
+export function getRuntimeExecutionMode() {
+  const runtime = getAutomationRuntime();
+  return runtime.adapter?.describe?.() ?? null;
+}

--- a/server/src/features/autonomousTrading/index.ts
+++ b/server/src/features/autonomousTrading/index.ts
@@ -1,0 +1,6 @@
+export { autonomousTradingRouter } from './routes/autonomousTrading.routes';
+export { buildCurrentAutonomousPipeline, getAutonomousStatus } from './coordinator/autonomousCoordinator.service';
+export { evaluateAutonomousEntryGate } from './contracts/entryGate';
+export { createShadowExecution } from './shadow/shadowExecutionAdapter';
+export * from './types/pipelineTypes';
+

--- a/server/src/features/autonomousTrading/routes/autonomousTrading.routes.ts
+++ b/server/src/features/autonomousTrading/routes/autonomousTrading.routes.ts
@@ -1,0 +1,97 @@
+import { Router, type Response } from 'express';
+import {
+  getAutonomousActive,
+  getAutonomousCurrent,
+  getAutonomousHealth,
+  getAutonomousMetrics,
+  getAutonomousPending,
+  getAutonomousPipelineById,
+  getAutonomousRecentDecisions,
+  getAutonomousStatus,
+  getAutonomousTimeline,
+} from '../coordinator/autonomousCoordinator.service';
+
+export const autonomousTradingRouter = Router();
+
+function sendError(res: Response, error: unknown): void {
+  const status = typeof (error as any)?.status === 'number' ? (error as any).status : 500;
+  res.status(status).json({ error: (error as Error)?.message ?? 'autonomous trading request failed' });
+}
+
+function limitFrom(value: unknown, fallback = 50): number {
+  const parsed = typeof value === 'string' ? Number(value) : fallback;
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+autonomousTradingRouter.get('/status', async (_req, res) => {
+  try {
+    res.json({ status: await getAutonomousStatus() });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+autonomousTradingRouter.get('/current', async (_req, res) => {
+  try {
+    res.json(await getAutonomousCurrent());
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+autonomousTradingRouter.get('/active', async (_req, res) => {
+  try {
+    res.json(await getAutonomousActive());
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+autonomousTradingRouter.get('/pending', async (_req, res) => {
+  try {
+    res.json(await getAutonomousPending());
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+autonomousTradingRouter.get('/recent-decisions', async (req, res) => {
+  try {
+    res.json(await getAutonomousRecentDecisions(limitFrom(req.query.limit, 20)));
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+autonomousTradingRouter.get('/timeline', async (req, res) => {
+  try {
+    res.json(await getAutonomousTimeline(limitFrom(req.query.limit, 100)));
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+autonomousTradingRouter.get('/metrics', async (_req, res) => {
+  try {
+    res.json(await getAutonomousMetrics());
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+autonomousTradingRouter.get('/health', async (_req, res) => {
+  try {
+    res.json(await getAutonomousHealth());
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+autonomousTradingRouter.get('/pipeline/:pipelineId', async (req, res) => {
+  try {
+    res.json(await getAutonomousPipelineById(req.params.pipelineId));
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+

--- a/server/src/features/autonomousTrading/shadow/shadowExecutionAdapter.ts
+++ b/server/src/features/autonomousTrading/shadow/shadowExecutionAdapter.ts
@@ -1,0 +1,73 @@
+import { randomUUID } from 'crypto';
+
+export type ShadowExecutionRequest = {
+  pipelineId: string;
+  symbol: string;
+  optionContract: string;
+  quantity: number;
+  bid: number | null;
+  ask: number | null;
+  stopPrice: number | null;
+  targetPrice: number | null;
+  slippagePct?: number | null;
+  requestedAt?: Date;
+};
+
+export type ShadowExecutionRecord = {
+  shadowExecutionId: string;
+  pipelineId: string;
+  source: 'SHADOW_SIMULATION';
+  symbol: string;
+  optionContract: string;
+  quantity: number;
+  bid: number | null;
+  ask: number | null;
+  mid: number | null;
+  slippagePct: number;
+  intendedEntryPrice: number | null;
+  simulatedFillPrice: number | null;
+  stopPrice: number | null;
+  targetPrice: number | null;
+  status: 'SIMULATED_FILLED' | 'SIMULATED_BLOCKED';
+  reason: string;
+  requestedAt: string;
+  filledAt: string | null;
+  simulatedPnl: number | null;
+};
+
+function midFrom(bid: number | null, ask: number | null): number | null {
+  if (bid == null || ask == null || bid <= 0 || ask < bid) return null;
+  return Number(((bid + ask) / 2).toFixed(2));
+}
+
+export function createShadowExecution(request: ShadowExecutionRequest): ShadowExecutionRecord {
+  const requestedAt = request.requestedAt ?? new Date();
+  const slippagePct = Math.max(0, request.slippagePct ?? Number(process.env.AUTONOMOUS_SHADOW_SLIPPAGE_PCT ?? 0.02));
+  const mid = midFrom(request.bid, request.ask);
+  const simulatedFillPrice = mid == null ? null : Number((mid * (1 + slippagePct)).toFixed(2));
+  return {
+    shadowExecutionId: `shadow_${randomUUID()}`,
+    pipelineId: request.pipelineId,
+    source: 'SHADOW_SIMULATION',
+    symbol: request.symbol,
+    optionContract: request.optionContract,
+    quantity: request.quantity,
+    bid: request.bid,
+    ask: request.ask,
+    mid,
+    slippagePct,
+    intendedEntryPrice: mid,
+    simulatedFillPrice,
+    stopPrice: request.stopPrice,
+    targetPrice: request.targetPrice,
+    status: simulatedFillPrice == null ? 'SIMULATED_BLOCKED' : 'SIMULATED_FILLED',
+    reason:
+      simulatedFillPrice == null
+        ? 'Shadow execution could not simulate a fill because bid/ask data was unavailable or invalid.'
+        : 'Shadow execution simulated a midpoint fill with configured slippage. No broker order was submitted.',
+    requestedAt: requestedAt.toISOString(),
+    filledAt: simulatedFillPrice == null ? null : requestedAt.toISOString(),
+    simulatedPnl: null,
+  };
+}
+

--- a/server/src/features/autonomousTrading/state/pipelineStateMachine.ts
+++ b/server/src/features/autonomousTrading/state/pipelineStateMachine.ts
@@ -1,0 +1,59 @@
+import type {
+  AutonomousPipelineRelatedRecord,
+  AutonomousPipelineState,
+  AutonomousPipelineTimelineEvent,
+} from '../types/pipelineTypes';
+
+const VALID_TRANSITIONS: Record<AutonomousPipelineState, AutonomousPipelineState[]> = {
+  OBSERVING: ['EVENT_DETECTED', 'OPPORTUNITY_IDENTIFIED', 'FAILED', 'CANCELLED'],
+  EVENT_DETECTED: ['OPPORTUNITY_IDENTIFIED', 'FAILED', 'CANCELLED'],
+  OPPORTUNITY_IDENTIFIED: ['STRATEGY_SELECTED', 'FAILED', 'CANCELLED'],
+  STRATEGY_SELECTED: ['RISK_REVIEW', 'FAILED', 'CANCELLED'],
+  RISK_REVIEW: ['RISK_REJECTED', 'RISK_APPROVED', 'FAILED', 'CANCELLED'],
+  RISK_REJECTED: ['COMPLETED', 'FAILED', 'CANCELLED'],
+  RISK_APPROVED: ['LIFECYCLE_CREATED', 'ENTRY_BLOCKED', 'FAILED', 'CANCELLED'],
+  LIFECYCLE_CREATED: ['ENTRY_BLOCKED', 'ENTRY_REQUESTED', 'ENTRY_FILLED', 'MONITORING', 'FAILED', 'CANCELLED'],
+  ENTRY_BLOCKED: ['ENTRY_REQUESTED', 'COMPLETED', 'FAILED', 'CANCELLED'],
+  ENTRY_REQUESTED: ['ENTRY_SUBMITTED', 'ENTRY_FILLED', 'FAILED', 'CANCELLED'],
+  ENTRY_SUBMITTED: ['ENTRY_FILLED', 'FAILED', 'CANCELLED'],
+  ENTRY_FILLED: ['MONITORING', 'EXIT_RECOMMENDED', 'FAILED', 'CANCELLED'],
+  MONITORING: ['EXIT_RECOMMENDED', 'EVALUATING', 'COMPLETED', 'FAILED', 'CANCELLED'],
+  EXIT_RECOMMENDED: ['EXIT_REQUESTED', 'FAILED', 'CANCELLED'],
+  EXIT_REQUESTED: ['EXIT_FILLED', 'FAILED', 'CANCELLED'],
+  EXIT_FILLED: ['EVALUATING', 'COMPLETED', 'FAILED', 'CANCELLED'],
+  EVALUATING: ['COMPLETED', 'FAILED'],
+  COMPLETED: [],
+  FAILED: [],
+  CANCELLED: [],
+};
+
+export function canTransition(from: AutonomousPipelineState, to: AutonomousPipelineState): boolean {
+  return from === to || VALID_TRANSITIONS[from]?.includes(to) === true;
+}
+
+export function buildPipelineTransition(args: {
+  from: AutonomousPipelineState;
+  to: AutonomousPipelineState;
+  actor: string;
+  reason: string;
+  event?: string;
+  reasonCode?: string | null;
+  relatedRecords?: AutonomousPipelineRelatedRecord[];
+  metadata?: Record<string, unknown>;
+  now?: Date;
+}): AutonomousPipelineTimelineEvent {
+  if (!canTransition(args.from, args.to)) {
+    throw new Error(`INVALID_AUTONOMOUS_PIPELINE_TRANSITION:${args.from}->${args.to}`);
+  }
+  return {
+    at: (args.now ?? new Date()).toISOString(),
+    state: args.to,
+    actor: args.actor,
+    event: args.event ?? `Pipeline moved to ${args.to}.`,
+    reason: args.reason,
+    reasonCode: args.reasonCode ?? null,
+    relatedRecords: args.relatedRecords ?? [],
+    metadata: args.metadata ?? {},
+  };
+}
+

--- a/server/src/features/autonomousTrading/storage/autonomousPipeline.model.ts
+++ b/server/src/features/autonomousTrading/storage/autonomousPipeline.model.ts
@@ -1,0 +1,38 @@
+import mongoose, { Schema } from 'mongoose';
+import type { AutonomousTradePipelineRecord } from '../types/pipelineTypes';
+
+export interface AutonomousPipelineDocument extends Omit<AutonomousTradePipelineRecord, 'createdAt' | 'updatedAt'> {
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const AutonomousPipelineSchema = new Schema<AutonomousPipelineDocument>(
+  {
+    pipelineId: { type: String, required: true, unique: true, index: true },
+    schemaVersion: { type: Number, required: true },
+    mode: { type: String, enum: ['MANUAL', 'SHADOW', 'AUTONOMOUS_PAPER'], required: true, index: true },
+    state: { type: String, required: true, index: true },
+    executionSource: { type: String, required: true, index: true },
+    symbol: { type: String, default: null, index: true },
+    optionContract: { type: String, default: null, index: true },
+    idempotencyKey: { type: String, required: true, unique: true, index: true },
+    eventContext: { type: Schema.Types.Mixed, required: true },
+    decisionContext: { type: Schema.Types.Mixed, required: true },
+    strategyContext: { type: Schema.Types.Mixed, required: true },
+    riskContext: { type: Schema.Types.Mixed, required: true },
+    lifecycleContext: { type: Schema.Types.Mixed, required: true },
+    executionContext: { type: Schema.Types.Mixed, required: true },
+    evaluationContext: { type: Schema.Types.Mixed, required: true },
+    blockingReasons: { type: [String], default: [] },
+    plainLanguageStatus: { type: String, required: true },
+    timeline: { type: [Schema.Types.Mixed] as any, default: [] },
+  },
+  { timestamps: true, collection: 'autonomous_trade_pipelines' }
+);
+
+AutonomousPipelineSchema.index({ updatedAt: -1 });
+AutonomousPipelineSchema.index({ state: 1, updatedAt: -1 });
+
+export const AutonomousPipelineModel =
+  (mongoose.models.AutonomousTradePipeline as mongoose.Model<AutonomousPipelineDocument>) ||
+  mongoose.model<AutonomousPipelineDocument>('AutonomousTradePipeline', AutonomousPipelineSchema);

--- a/server/src/features/autonomousTrading/storage/autonomousPipelineJournal.service.ts
+++ b/server/src/features/autonomousTrading/storage/autonomousPipelineJournal.service.ts
@@ -1,0 +1,62 @@
+import { writeStructuredLog } from '../../../shared/logging/safeLogging';
+import { AutonomousPipelineModel } from './autonomousPipeline.model';
+import type { AutonomousTradePipelineRecord, AutonomousPipelineTimelineEvent } from '../types/pipelineTypes';
+
+export function serializePipeline(doc: any): AutonomousTradePipelineRecord {
+  const raw = typeof doc?.toObject === 'function' ? doc.toObject() : doc;
+  return {
+    ...raw,
+    createdAt: raw.createdAt instanceof Date ? raw.createdAt.toISOString() : raw.createdAt,
+    updatedAt: raw.updatedAt instanceof Date ? raw.updatedAt.toISOString() : raw.updatedAt,
+  };
+}
+
+export async function upsertAutonomousPipeline(record: AutonomousTradePipelineRecord): Promise<AutonomousTradePipelineRecord> {
+  const { createdAt: _createdAt, ...setRecord } = record;
+  const saved = await AutonomousPipelineModel.findOneAndUpdate(
+    { pipelineId: record.pipelineId },
+    { $set: { ...setRecord, updatedAt: new Date(record.updatedAt) }, $setOnInsert: { createdAt: new Date(record.createdAt) } },
+    { upsert: true, returnDocument: 'after' }
+  );
+  writeStructuredLog({
+    component: 'server',
+    module: 'autonomous-trading',
+    event: 'PIPELINE_UPSERTED',
+    severity: 'info',
+    context: {
+      pipelineId: record.pipelineId,
+      symbol: record.symbol,
+      mode: record.mode,
+      state: record.state,
+      featureFlags: {
+        AUTONOMOUS_TRADING_ENABLED: process.env.AUTONOMOUS_TRADING_ENABLED ?? 'false',
+        AUTONOMOUS_ENTRY_ENABLED: process.env.AUTONOMOUS_ENTRY_ENABLED ?? 'false',
+        AUTONOMOUS_EXIT_ENABLED: process.env.AUTONOMOUS_EXIT_ENABLED ?? 'false',
+      },
+    },
+  });
+  return serializePipeline(saved);
+}
+
+export async function appendAutonomousPipelineEvent(
+  pipelineId: string,
+  event: AutonomousPipelineTimelineEvent
+): Promise<void> {
+  await AutonomousPipelineModel.updateOne(
+    { pipelineId },
+    { $push: { timeline: event }, $set: { state: event.state, updatedAt: new Date(event.at) } }
+  );
+}
+
+export async function listAutonomousPipelines(limit = 50): Promise<AutonomousTradePipelineRecord[]> {
+  const docs = await AutonomousPipelineModel.find({})
+    .sort({ updatedAt: -1 })
+    .limit(Math.min(Math.max(limit, 1), 500))
+    .lean();
+  return docs.map(serializePipeline);
+}
+
+export async function getAutonomousPipeline(pipelineId: string): Promise<AutonomousTradePipelineRecord | null> {
+  const doc = await AutonomousPipelineModel.findOne({ pipelineId }).lean();
+  return doc ? serializePipeline(doc) : null;
+}

--- a/server/src/features/autonomousTrading/types/pipelineTypes.ts
+++ b/server/src/features/autonomousTrading/types/pipelineTypes.ts
@@ -1,0 +1,181 @@
+export type AutonomousTradingMode = 'MANUAL' | 'SHADOW' | 'AUTONOMOUS_PAPER';
+
+export type AutonomousExecutionSource = 'MANUAL_PAPER' | 'AUTONOMOUS_PAPER' | 'SHADOW_SIMULATION';
+
+export const AUTONOMOUS_PIPELINE_STATES = [
+  'OBSERVING',
+  'EVENT_DETECTED',
+  'OPPORTUNITY_IDENTIFIED',
+  'STRATEGY_SELECTED',
+  'RISK_REVIEW',
+  'RISK_REJECTED',
+  'RISK_APPROVED',
+  'LIFECYCLE_CREATED',
+  'ENTRY_BLOCKED',
+  'ENTRY_REQUESTED',
+  'ENTRY_SUBMITTED',
+  'ENTRY_FILLED',
+  'MONITORING',
+  'EXIT_RECOMMENDED',
+  'EXIT_REQUESTED',
+  'EXIT_FILLED',
+  'EVALUATING',
+  'COMPLETED',
+  'FAILED',
+  'CANCELLED',
+] as const;
+
+export type AutonomousPipelineState = (typeof AUTONOMOUS_PIPELINE_STATES)[number];
+
+export type AutonomousPipelineRelatedRecord = {
+  subsystem:
+    | 'event-intelligence'
+    | 'decision-intelligence'
+    | 'strategy-orchestrator'
+    | 'risk-engine'
+    | 'trade-lifecycle'
+    | 'execution-gateway'
+    | 'alpaca-paper'
+    | 'trade-evaluation'
+    | 'automation'
+    | 'shadow-execution';
+  recordId: string;
+  collection?: string | null;
+};
+
+export type AutonomousPipelineTimelineEvent = {
+  at: string;
+  state: AutonomousPipelineState;
+  actor: string;
+  event: string;
+  reason: string;
+  reasonCode?: string | null;
+  relatedRecords: AutonomousPipelineRelatedRecord[];
+  metadata?: Record<string, unknown>;
+};
+
+export type AutonomousTradePipelineRecord = {
+  pipelineId: string;
+  schemaVersion: number;
+  createdAt: string;
+  updatedAt: string;
+  mode: AutonomousTradingMode;
+  state: AutonomousPipelineState;
+  executionSource: AutonomousExecutionSource;
+  symbol: string | null;
+  optionContract: string | null;
+  idempotencyKey: string;
+  eventContext: {
+    eventIds: string[];
+    importance: number | null;
+    sentiment: number | string | null;
+    summary: string | null;
+  };
+  decisionContext: {
+    scanId: string | null;
+    opportunityScore: number | null;
+    rank: number | null;
+    recommendation: string | null;
+    explanation: string | null;
+  };
+  strategyContext: {
+    runId: string | null;
+    winningStrategy: string | null;
+    confidence: number | null;
+    evidenceScore: number | null;
+    conflicts: string[];
+  };
+  riskContext: {
+    approvalId: string | null;
+    approved: boolean | null;
+    suggestedContracts: number | null;
+    dollarRisk: number | null;
+    reasonCodes: string[];
+    warnings: string[];
+    expiresAt: string | null;
+  };
+  lifecycleContext: {
+    lifecycleId: string | null;
+    state: string | null;
+    currentAction: string | null;
+    currentConfidence: number | null;
+    nextEvaluationAt: string | null;
+  };
+  executionContext: {
+    requested: boolean;
+    executionIntentId: string | null;
+    brokerOrderId: string | null;
+    status: string | null;
+    paper: boolean;
+    source: AutonomousExecutionSource;
+  };
+  evaluationContext: {
+    evaluationId: string | null;
+    status: string | null;
+    outcome: string | null;
+    returnPct: number | null;
+  };
+  blockingReasons: string[];
+  plainLanguageStatus: string;
+  timeline: AutonomousPipelineTimelineEvent[];
+};
+
+export type AutonomousServiceHealth = {
+  name: string;
+  status: 'HEALTHY' | 'DEGRADED' | 'BLOCKED' | 'STOPPED';
+  lastSuccessfulRunAt: string | null;
+  lastAttemptAt: string | null;
+  latencyMs: number | null;
+  dataTimestamp: string | null;
+  stale: boolean;
+  staleReason: string | null;
+  lastError: string | null;
+  featureEnabled: boolean;
+  ownerStatus: string | null;
+};
+
+export type AutonomousOverallHealth = 'HEALTHY' | 'DEGRADED' | 'BLOCKED' | 'STOPPED';
+
+export type AutonomousMetricsSource = {
+  source: AutonomousExecutionSource;
+  eventsProcessed: number;
+  opportunitiesEvaluated: number;
+  strategiesEvaluated: number;
+  recommendationsGenerated: number;
+  riskApprovals: number;
+  riskRejections: number;
+  shadowEntries: number;
+  paperEntriesRequested: number;
+  ordersSubmitted: number;
+  ordersFilled: number;
+  entryFailures: number;
+  lifecycleEvaluations: number;
+  exitRecommendations: number;
+  exitOrders: number;
+  completedTrades: number;
+  winRate: number | null;
+  averageReturn: number | null;
+  averageHoldTimeMinutes: number | null;
+  maximumDrawdown: number | null;
+  topRejectionReason: string | null;
+  staleDataBlocks: number;
+  duplicateOrderBlocks: number;
+};
+
+export type AutonomousOperatorStatus = {
+  generatedAt: string;
+  status: 'Running' | 'Paused' | 'Stopped' | 'Degraded';
+  mode: 'Manual' | 'Shadow' | 'Autonomous Paper';
+  modeBanner: string;
+  market: string;
+  broker: 'Alpaca Paper';
+  automationOwner: 'Owned' | 'Not Owned' | 'Unknown';
+  marketData: 'Live' | 'Delayed' | 'Stale' | 'Unavailable';
+  nextEvaluationAt: string | null;
+  emergencyStop: 'Active' | 'Inactive' | 'Unknown';
+  watching: string[];
+  currentActivity: string;
+  latestPipelineId: string | null;
+  featureFlags: Record<string, boolean | string>;
+};
+

--- a/server/src/features/decisionEngine/aiResearch.service.ts
+++ b/server/src/features/decisionEngine/aiResearch.service.ts
@@ -1,0 +1,3 @@
+import { generateAiResearch } from './scoring.service';
+
+export { generateAiResearch };

--- a/server/src/features/decisionEngine/decisionEngine.routes.ts
+++ b/server/src/features/decisionEngine/decisionEngine.routes.ts
@@ -1,0 +1,68 @@
+import { Router, type Response } from 'express';
+import { getDecisionScanById, getLatestDecisionScan, listDecisionScans } from './journal.service';
+import { buildDecisionScan, runDecisionEngineScan } from './scanner.service';
+import type { DecisionEngineScanInput } from './types';
+
+export const decisionEngineRouter = Router();
+
+function sendError(res: Response, error: unknown): void {
+  const status = typeof (error as any)?.status === 'number' ? (error as any).status : 500;
+  res.status(status).json({ error: (error as Error)?.message ?? 'decision engine request failed' });
+}
+
+decisionEngineRouter.get('/latest', async (_req, res) => {
+  try {
+    const scan = await getLatestDecisionScan();
+    if (!scan) {
+      res.status(404).json({ error: 'DECISION_SCAN_NOT_FOUND' });
+      return;
+    }
+    res.json({ scan });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+decisionEngineRouter.get('/scans', async (req, res) => {
+  try {
+    const limit = typeof req.query.limit === 'string' ? Number(req.query.limit) : 50;
+    res.json({ scans: await listDecisionScans(Number.isFinite(limit) ? limit : 50) });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+decisionEngineRouter.get('/scans/:scanId', async (req, res) => {
+  try {
+    const scan = await getDecisionScanById(req.params.scanId);
+    if (!scan) {
+      res.status(404).json({ error: 'DECISION_SCAN_NOT_FOUND' });
+      return;
+    }
+    res.json({ scan });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+decisionEngineRouter.post('/scan', async (_req, res) => {
+  try {
+    const scan = await runDecisionEngineScan();
+    res.status(201).json({ scan });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+decisionEngineRouter.post('/validate', (req, res) => {
+  try {
+    const input = req.body as DecisionEngineScanInput;
+    if (!Array.isArray(input?.watchlist) || !input?.chains || typeof input.chains !== 'object') {
+      res.status(400).json({ error: 'watchlist and chains are required' });
+      return;
+    }
+    res.json({ scan: buildDecisionScan(input) });
+  } catch (error) {
+    sendError(res, error);
+  }
+});

--- a/server/src/features/decisionEngine/decisionScanJournal.model.ts
+++ b/server/src/features/decisionEngine/decisionScanJournal.model.ts
@@ -1,0 +1,32 @@
+import mongoose, { Schema } from 'mongoose';
+import type { DecisionScan } from './types';
+
+export interface DecisionScanJournalDocument extends Omit<DecisionScan, 'timestamp'> {
+  timestamp: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const DecisionScanJournalSchema = new Schema<DecisionScanJournalDocument>(
+  {
+    scanId: { type: String, required: true, unique: true, index: true },
+    timestamp: { type: Date, required: true, index: true },
+    watchlist: { type: [String], required: true, default: [] },
+    relatedEvents: { type: [Schema.Types.Mixed], required: true, default: [] } as any,
+    candidates: { type: [Schema.Types.Mixed], required: true, default: [] } as any,
+    ranking: { type: Schema.Types.Mixed, required: true },
+    winner: { type: Schema.Types.Mixed, default: null },
+    rejections: { type: [Schema.Types.Mixed], required: true, default: [] } as any,
+    aiReasoning: { type: [Schema.Types.Mixed], required: true, default: [] } as any,
+    noTradeReason: { type: String, default: null },
+    dataSources: { type: [String], required: true, default: [] },
+    schemaVersion: { type: Number, required: true, default: 1 },
+  },
+  { timestamps: true, collection: 'decision_engine_scans' }
+);
+
+DecisionScanJournalSchema.index({ timestamp: -1, scanId: 1 });
+
+export const DecisionScanJournalModel =
+  (mongoose.models.DecisionScanJournal as mongoose.Model<DecisionScanJournalDocument>) ||
+  mongoose.model<DecisionScanJournalDocument>('DecisionScanJournal', DecisionScanJournalSchema);

--- a/server/src/features/decisionEngine/index.ts
+++ b/server/src/features/decisionEngine/index.ts
@@ -1,0 +1,2 @@
+export { decisionEngineRouter } from './decisionEngine.routes';
+export { startDecisionEngineScanner, stopDecisionEngineScanner } from './scanner.service';

--- a/server/src/features/decisionEngine/journal.service.ts
+++ b/server/src/features/decisionEngine/journal.service.ts
@@ -1,0 +1,44 @@
+import type { DecisionScan } from './types';
+import { DecisionScanJournalModel } from './decisionScanJournal.model';
+
+function serialize(doc: any): DecisionScan {
+  const value = typeof doc.toObject === 'function' ? doc.toObject() : doc;
+  return {
+    scanId: value.scanId,
+    timestamp: value.timestamp instanceof Date ? value.timestamp.toISOString() : String(value.timestamp),
+    watchlist: value.watchlist ?? [],
+    relatedEvents: value.relatedEvents ?? [],
+    candidates: value.candidates ?? [],
+    ranking: value.ranking,
+    winner: value.winner ?? null,
+    rejections: value.rejections ?? [],
+    aiReasoning: value.aiReasoning ?? [],
+    noTradeReason: value.noTradeReason ?? null,
+    dataSources: value.dataSources ?? [],
+    schemaVersion: value.schemaVersion ?? 1,
+  };
+}
+
+export async function appendDecisionScan(scan: DecisionScan): Promise<DecisionScan> {
+  const created = await DecisionScanJournalModel.create({
+    ...scan,
+    timestamp: new Date(scan.timestamp),
+  });
+  return serialize(created);
+}
+
+export async function getLatestDecisionScan(): Promise<DecisionScan | null> {
+  const doc = await DecisionScanJournalModel.findOne().sort({ timestamp: -1, createdAt: -1 });
+  return doc ? serialize(doc) : null;
+}
+
+export async function listDecisionScans(limit = 50): Promise<DecisionScan[]> {
+  const safeLimit = Math.max(1, Math.min(250, Math.floor(limit)));
+  const docs = await DecisionScanJournalModel.find().sort({ timestamp: -1, createdAt: -1 }).limit(safeLimit);
+  return docs.map(serialize);
+}
+
+export async function getDecisionScanById(scanId: string): Promise<DecisionScan | null> {
+  const doc = await DecisionScanJournalModel.findOne({ scanId });
+  return doc ? serialize(doc) : null;
+}

--- a/server/src/features/decisionEngine/ranking.service.ts
+++ b/server/src/features/decisionEngine/ranking.service.ts
@@ -1,0 +1,27 @@
+import type { CandidateOpportunity, DecisionRanking, RejectedCandidate } from './types';
+import { rejectionExplanation } from './scoring.service';
+
+export function rankDecisionCandidates(candidates: CandidateOpportunity[]): DecisionRanking {
+  const accepted = candidates
+    .filter(candidate => candidate.rejectionCodes.length === 0)
+    .sort((a, b) => b.overallScore - a.overallScore || a.contract.symbol.localeCompare(b.contract.symbol));
+  const rejectedCandidates: RejectedCandidate[] = candidates
+    .filter(candidate => candidate.rejectionCodes.length > 0)
+    .map(candidate => {
+      const reasonCode = candidate.rejectionCodes[0];
+      return {
+        candidate,
+        reasonCode,
+        explanation: candidate.rejectionExplanation ?? rejectionExplanation(reasonCode, candidate.contract),
+      };
+    })
+    .sort((a, b) => b.candidate.overallScore - a.candidate.overallScore || a.candidate.contract.symbol.localeCompare(b.candidate.contract.symbol));
+
+  return {
+    bestOpportunity: accepted[0] ?? null,
+    secondBest: accepted[1] ?? null,
+    thirdBest: accepted[2] ?? null,
+    top10: accepted.slice(0, 10),
+    rejectedCandidates,
+  };
+}

--- a/server/src/features/decisionEngine/scanner.service.ts
+++ b/server/src/features/decisionEngine/scanner.service.ts
@@ -1,0 +1,176 @@
+import { randomUUID } from 'crypto';
+import { REQUEST_PRIORITY } from '../../shared/data/massive';
+import { computeDteEt, expirationWindowForDte } from '../../shared/time/tradingCalendar';
+import { getOptionChainWindow } from '../marketData/optionsMarketDataOrchestrator.service';
+import { getMarketStatusSnapshot } from '../market/services/marketStatus';
+import { listWatchlist } from '../watchlist/watchlist.service';
+import type { DecisionContractSnapshot, DecisionEngineScanInput, DecisionScan } from './types';
+import { detectCandidateOpportunities } from './scoring.service';
+import { rankDecisionCandidates } from './ranking.service';
+import { appendDecisionScan } from './journal.service';
+
+const DEFAULT_SCAN_INTERVAL_MS = Math.max(30_000, Number(process.env.DECISION_ENGINE_SCAN_INTERVAL_MS ?? 120_000));
+let timer: NodeJS.Timeout | null = null;
+let scanInFlight: Promise<DecisionScan> | null = null;
+
+function finite(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function timestampToIso(value: unknown): string | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const ms = value > 1e17 ? Math.floor(value / 1e6) : value > 1e14 ? Math.floor(value / 1e3) : value < 1e12 ? value * 1000 : value;
+    return new Date(ms).toISOString();
+  }
+  if (typeof value === 'string') {
+    const ms = Date.parse(value);
+    return Number.isNaN(ms) ? null : new Date(ms).toISOString();
+  }
+  return null;
+}
+
+function normalizeLeg(leg: any, type: 'call' | 'put', now: number): DecisionContractSnapshot | null {
+  if (!leg?.ticker) return null;
+  const bid = finite(leg.bid);
+  const ask = finite(leg.ask);
+  const mid = finite(leg.mid) ?? finite(leg.snapshot?.last_quote?.midpoint) ?? (bid != null && ask != null ? (bid + ask) / 2 : null);
+  const spread = bid != null && ask != null ? Number((ask - bid).toFixed(4)) : null;
+  return {
+    symbol: String(leg.ticker).toUpperCase(),
+    type,
+    strike: finite(leg.strike),
+    expiration: typeof leg.expiration === 'string' ? leg.expiration : null,
+    dte: computeDteEt(typeof leg.expiration === 'string' ? leg.expiration : null, now),
+    bid,
+    ask,
+    mid,
+    spread,
+    spreadPct: spread != null && mid != null && mid > 0 ? Number((spread / mid).toFixed(4)) : null,
+    volume: finite(leg.volume ?? leg.day?.volume),
+    openInterest: finite(leg.openInterest ?? leg.open_interest),
+    iv: finite(leg.iv ?? leg.impliedVolatility ?? leg.implied_volatility),
+    delta: finite(leg.delta ?? leg.greeks?.delta),
+    gamma: finite(leg.gamma ?? leg.greeks?.gamma),
+    theta: finite(leg.theta ?? leg.greeks?.theta),
+    vega: finite(leg.vega ?? leg.greeks?.vega),
+    quoteTimestamp: timestampToIso(leg.quoteTimestamp ?? leg.snapshot?.last_quote?.last_updated),
+  };
+}
+
+async function buildLiveScanInput(now: number): Promise<DecisionEngineScanInput> {
+  const [marketStatus, watchlistDocs] = await Promise.all([getMarketStatusSnapshot(), listWatchlist()]);
+  const enabled = watchlistDocs
+    .filter(item => item.enabled)
+    .sort((a, b) => a.priority - b.priority || a.symbol.localeCompare(b.symbol));
+  const chains: DecisionEngineScanInput['chains'] = {};
+
+  await Promise.all(enabled.map(async item => {
+    const minDte = item.minDTE ?? 7;
+    const maxDte = item.maxDTE ?? 21;
+    const window = expirationWindowForDte(now, minDte, maxDte);
+    const response = await getOptionChainWindow({
+      underlying: item.symbol,
+      expirationGte: window.gte,
+      expirationLte: window.lte,
+      limit: 250,
+      priority: REQUEST_PRIORITY.VISIBLE_UI,
+    });
+    const contracts: DecisionContractSnapshot[] = [];
+    for (const group of response.expirations ?? []) {
+      if (typeof group.dte === 'number' && (group.dte < minDte || group.dte > maxDte)) continue;
+      for (const row of group.strikes ?? []) {
+        const call = normalizeLeg((row as any).call, 'call', now);
+        const put = normalizeLeg((row as any).put, 'put', now);
+        if (call) contracts.push(call);
+        if (put) contracts.push(put);
+      }
+    }
+    chains[item.symbol] = {
+      underlyingPrice: response.underlyingPrice,
+      underlyingTimeframe: response.underlyingContext?.timeframe ?? null,
+      complete: response.completeness?.complete !== false,
+      contracts,
+    };
+  }));
+
+  return {
+    now,
+    marketStatus: marketStatus.market,
+    watchlist: enabled.map(item => ({
+      symbol: item.symbol,
+      priority: item.priority,
+      minConfidence: item.minConfidence,
+      maxSpreadPercent: item.maxSpreadPercent,
+      minimumOpenInterest: item.minimumOpenInterest,
+      minimumVolume: item.minimumVolume,
+      maximumIV: item.maximumIV,
+      riskProfile: item.riskProfile,
+    })),
+    chains,
+  };
+}
+
+export function buildDecisionScan(input: DecisionEngineScanInput): DecisionScan {
+  const candidates = detectCandidateOpportunities(input);
+  const ranking = rankDecisionCandidates(candidates);
+  const timestamp = new Date(input.now ?? Date.now()).toISOString();
+  const noTradeReason = ranking.bestOpportunity
+    ? null
+    : candidates.length
+      ? 'No candidate cleared all decision-engine gates.'
+      : 'No candidate opportunities were detected from the supplied watchlist and market data.';
+  return {
+    scanId: randomUUID(),
+    timestamp,
+    watchlist: input.watchlist.map(item => item.symbol.trim().toUpperCase()),
+    relatedEvents: input.eventContext ?? [],
+    candidates,
+    ranking,
+    winner: ranking.bestOpportunity,
+    rejections: ranking.rejectedCandidates,
+    aiReasoning: candidates.map(candidate => candidate.aiResearch),
+    noTradeReason,
+    dataSources: ['watchlist', 'options-chain', 'quotes', 'open-interest', 'iv', 'greeks', 'market-status'],
+    schemaVersion: 1,
+  };
+}
+
+export async function runDecisionEngineScan(input?: DecisionEngineScanInput): Promise<DecisionScan> {
+  if (scanInFlight && !input) return scanInFlight;
+  const run = (async () => {
+    const now = input?.now ?? Date.now();
+    const scanInput = input ?? await buildLiveScanInput(now);
+    const scan = buildDecisionScan(scanInput);
+    return appendDecisionScan(scan);
+  })();
+  if (!input) scanInFlight = run;
+  try {
+    return await run;
+  } finally {
+    if (!input) scanInFlight = null;
+  }
+}
+
+export async function runDecisionEngineEventReevaluation(
+  eventContext: NonNullable<DecisionEngineScanInput['eventContext']>
+): Promise<DecisionScan> {
+  const now = Date.now();
+  const input = await buildLiveScanInput(now);
+  input.eventContext = eventContext;
+  return runDecisionEngineScan(input);
+}
+
+export function startDecisionEngineScanner(): void {
+  if (timer || process.env.DECISION_ENGINE_AUTO_START !== 'true') return;
+  timer = setInterval(() => {
+    runDecisionEngineScan().catch(error => {
+      console.warn('[decision-engine] scan failed', { error: (error as Error)?.message });
+    });
+  }, DEFAULT_SCAN_INTERVAL_MS);
+}
+
+export function stopDecisionEngineScanner(): void {
+  if (!timer) return;
+  clearInterval(timer);
+  timer = null;
+}

--- a/server/src/features/decisionEngine/scoring.service.ts
+++ b/server/src/features/decisionEngine/scoring.service.ts
@@ -1,0 +1,387 @@
+import { randomUUID } from 'crypto';
+import { computeDteEt } from '../../shared/time/tradingCalendar';
+import type {
+  AiResearchOutput,
+  CandidateOpportunity,
+  DecisionContractSnapshot,
+  DecisionEngineReasonCode,
+  DecisionEngineScanInput,
+  DecisionMarketContext,
+  DecisionScores,
+  ExplainedScore,
+} from './types';
+
+function finite(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function clampScore(value: number): number {
+  return Math.max(0, Math.min(100, Number(value.toFixed(2))));
+}
+
+function grade(score: number, unavailable = false): ExplainedScore['grade'] {
+  if (unavailable) return 'UNAVAILABLE';
+  if (score >= 75) return 'STRONG';
+  if (score >= 50) return 'ACCEPTABLE';
+  return 'WEAK';
+}
+
+function score(
+  key: ExplainedScore['key'],
+  value: number,
+  explanation: string,
+  inputs: ExplainedScore['inputs'],
+  unavailable = false
+): ExplainedScore {
+  const normalized = unavailable ? 0 : clampScore(value);
+  return {
+    key,
+    score: normalized,
+    maxScore: 100,
+    grade: grade(normalized, unavailable),
+    explanation,
+    inputs,
+  };
+}
+
+function spreadPct(contract: DecisionContractSnapshot): number | null {
+  if (finite(contract.spreadPct) != null) return contract.spreadPct;
+  const bid = finite(contract.bid);
+  const ask = finite(contract.ask);
+  const mid = finite(contract.mid) ?? (bid != null && ask != null ? (bid + ask) / 2 : null);
+  if (bid == null || ask == null || mid == null || mid <= 0) return null;
+  return (ask - bid) / mid;
+}
+
+function inferDirection(contract: DecisionContractSnapshot): CandidateOpportunity['direction'] {
+  return contract.type === 'call' ? 'BULLISH' : 'BEARISH';
+}
+
+function calculateLiquidity(contract: DecisionContractSnapshot, minimumOi: number, minimumVolume: number): ExplainedScore {
+  const oi = finite(contract.openInterest);
+  const volume = finite(contract.volume);
+  if (oi == null && volume == null) {
+    return score('liquidity', 0, 'Liquidity cannot be scored because volume and open interest were not supplied.', {
+      volume: null,
+      openInterest: null,
+      minimumVolume,
+      minimumOpenInterest: minimumOi,
+    }, true);
+  }
+  const oiScore = oi == null ? 0 : Math.min(60, (oi / Math.max(1, minimumOi)) * 45 + Math.min(15, oi / 1000));
+  const volumeScore = volume == null ? 0 : Math.min(40, (volume / Math.max(1, minimumVolume)) * 35 + Math.min(5, volume / 5000));
+  return score('liquidity', oiScore + volumeScore, 'Higher volume and open interest improve fill reliability and reduce exit risk.', {
+    volume,
+    openInterest: oi,
+    minimumVolume,
+    minimumOpenInterest: minimumOi,
+  });
+}
+
+function calculateSpread(contract: DecisionContractSnapshot, maxSpreadPct: number): ExplainedScore {
+  const pct = spreadPct(contract);
+  if (pct == null) {
+    return score('spread', 0, 'Spread cannot be scored because bid and ask were not both supplied.', {
+      bid: contract.bid,
+      ask: contract.ask,
+      spreadPct: null,
+      maxSpreadPct,
+    }, true);
+  }
+  const value = pct <= 0 ? 100 : 100 * (1 - Math.min(1, pct / Math.max(0.0001, maxSpreadPct)));
+  return score('spread', value, 'Tighter bid/ask spreads score higher because they reduce slippage before execution.', {
+    bid: contract.bid,
+    ask: contract.ask,
+    spreadPct: pct,
+    maxSpreadPct,
+  });
+}
+
+function calculateVolatility(contract: DecisionContractSnapshot, maximumIV: number | null): ExplainedScore {
+  const iv = finite(contract.iv);
+  if (iv == null) {
+    return score('volatility', 50, 'IV was not supplied; volatility score is neutral and marked by inputs.', {
+      iv: null,
+      maximumIV,
+    });
+  }
+  const ceiling = maximumIV ?? 0.85;
+  const value = iv <= ceiling ? 100 - Math.max(0, iv - 0.25) * 70 : Math.max(0, 45 - (iv - ceiling) * 100);
+  return score('volatility', value, 'IV below the configured ceiling scores better; elevated IV reduces risk/reward quality.', {
+    iv,
+    maximumIV: ceiling,
+  });
+}
+
+function calculateRisk(contract: DecisionContractSnapshot, liquidity: ExplainedScore, spread: ExplainedScore, volatility: ExplainedScore): ExplainedScore {
+  const theta = finite(contract.theta);
+  const delta = finite(contract.delta);
+  const thetaPenalty = theta == null ? 8 : Math.min(22, Math.abs(theta) * 100);
+  const deltaPenalty = delta == null ? 6 : Math.max(0, (Math.abs(delta) - 0.65) * 60);
+  const base = liquidity.score * 0.3 + spread.score * 0.3 + volatility.score * 0.25 + 15;
+  return score('risk', base - thetaPenalty - deltaPenalty, 'Risk score rewards tradability and penalizes high theta decay or extreme delta exposure.', {
+    theta,
+    delta,
+    liquidityScore: liquidity.score,
+    spreadScore: spread.score,
+    volatilityScore: volatility.score,
+  });
+}
+
+function calculateTrend(inputTrend: DecisionMarketContext['trend'], contract: DecisionContractSnapshot): ExplainedScore {
+  const delta = finite(contract.delta);
+  let value = 50;
+  if (inputTrend === 'BULLISH' && contract.type === 'call') value = 75;
+  if (inputTrend === 'BEARISH' && contract.type === 'put') value = 75;
+  if (inputTrend === 'BULLISH' && contract.type === 'put') value = 35;
+  if (inputTrend === 'BEARISH' && contract.type === 'call') value = 35;
+  if (delta != null) value += Math.max(-15, Math.min(15, (Math.abs(delta) - 0.35) * 50));
+  return score('trend', value, 'Trend score uses supplied market context plus contract delta as directional exposure evidence.', {
+    suppliedTrend: inputTrend,
+    contractType: contract.type,
+    delta,
+  });
+}
+
+function calculateMomentum(inputMomentum: DecisionMarketContext['momentum'], contract: DecisionContractSnapshot): ExplainedScore {
+  const volume = finite(contract.volume);
+  let value = inputMomentum === 'POSITIVE' ? 72 : inputMomentum === 'NEGATIVE' ? 38 : 52;
+  if (volume != null) value += Math.min(18, Math.log10(Math.max(1, volume)) * 4);
+  return score('momentum', value, 'Momentum score uses supplied momentum context and contract volume participation.', {
+    suppliedMomentum: inputMomentum,
+    volume,
+  });
+}
+
+function calculateConfidence(scores: Omit<DecisionScores, 'confidence' | 'overall'>): ExplainedScore {
+  const value =
+    scores.liquidity.score * 0.2 +
+    scores.trend.score * 0.15 +
+    scores.momentum.score * 0.15 +
+    scores.spread.score * 0.2 +
+    scores.volatility.score * 0.1 +
+    scores.risk.score * 0.2;
+  return score('confidence', value, 'Confidence is a weighted blend of explainable market, contract, and risk scores.', {
+    liquidityScore: scores.liquidity.score,
+    trendScore: scores.trend.score,
+    momentumScore: scores.momentum.score,
+    spreadScore: scores.spread.score,
+    volatilityScore: scores.volatility.score,
+    riskScore: scores.risk.score,
+  });
+}
+
+function buildScores(args: {
+  contract: DecisionContractSnapshot;
+  marketContext: DecisionMarketContext;
+  maxSpreadPct: number;
+  minimumOi: number;
+  minimumVolume: number;
+  maximumIV: number | null;
+}): DecisionScores {
+  const liquidity = calculateLiquidity(args.contract, args.minimumOi, args.minimumVolume);
+  const trend = calculateTrend(args.marketContext.trend, args.contract);
+  const momentum = calculateMomentum(args.marketContext.momentum, args.contract);
+  const spread = calculateSpread(args.contract, args.maxSpreadPct);
+  const volatility = calculateVolatility(args.contract, args.maximumIV);
+  const risk = calculateRisk(args.contract, liquidity, spread, volatility);
+  const confidence = calculateConfidence({ liquidity, trend, momentum, spread, volatility, risk });
+  const overall = score('overall', confidence.score, 'Overall score equals the final explainable confidence score for ranking.', {
+    confidenceScore: confidence.score,
+  });
+  return { liquidity, trend, momentum, spread, volatility, risk, confidence, overall };
+}
+
+function reasonCodes(args: {
+  contract: DecisionContractSnapshot;
+  scores: DecisionScores;
+  minConfidence: number;
+  maxSpreadPct: number;
+  minimumOi: number;
+  minimumVolume: number;
+  maximumIV: number | null;
+  marketStatus: string;
+  chainComplete: boolean;
+}): DecisionEngineReasonCode[] {
+  const codes: DecisionEngineReasonCode[] = [];
+  if (args.marketStatus !== 'open') codes.push('MARKET_CLOSED');
+  if (!args.chainComplete) codes.push('INCOMPLETE_CHAIN');
+  if (finite(args.contract.bid) == null || finite(args.contract.ask) == null) codes.push('NO_BID_ASK');
+  if ((finite(args.contract.volume) ?? 0) < args.minimumVolume) codes.push('LOW_VOLUME');
+  if ((finite(args.contract.openInterest) ?? 0) < args.minimumOi) codes.push('LOW_OPEN_INTEREST');
+  const pct = spreadPct(args.contract);
+  if (pct == null || pct > args.maxSpreadPct) codes.push('HIGH_SPREAD');
+  const iv = finite(args.contract.iv);
+  if (args.maximumIV != null && iv != null && iv > args.maximumIV) codes.push('HIGH_IV');
+  if (args.scores.confidence.score / 100 < args.minConfidence) codes.push('LOW_CONFIDENCE');
+  if (args.scores.risk.score < 45) codes.push('ELEVATED_RISK');
+  if (args.scores.trend.score < 45) codes.push('WEAK_TREND');
+  if (args.scores.momentum.score < 45) codes.push('WEAK_MOMENTUM');
+  return [...new Set(codes)];
+}
+
+export function rejectionExplanation(code: DecisionEngineReasonCode, contract: DecisionContractSnapshot): string {
+  const label = contract.symbol;
+  const map: Record<DecisionEngineReasonCode, string> = {
+    LOW_VOLUME: `${label} was rejected because supplied contract volume is below the configured minimum.`,
+    HIGH_SPREAD: `${label} was rejected because the bid/ask spread is too wide for an explainable entry.`,
+    LOW_CONFIDENCE: `${label} was rejected because blended confidence is below the watchlist threshold.`,
+    POOR_RISK_REWARD: `${label} was rejected because the expected reward does not justify the observed risk.`,
+    HIGH_IV: `${label} was rejected because supplied IV is above the configured ceiling.`,
+    LOW_OPEN_INTEREST: `${label} was rejected because open interest is below the configured minimum.`,
+    MARKET_CLOSED: `${label} was rejected because the market is not open.`,
+    BUYING_POWER: `${label} was rejected because buying power is insufficient for the position-size policy.`,
+    DATA_UNAVAILABLE: `${label} was rejected because required market data was unavailable.`,
+    INCOMPLETE_CHAIN: `${label} was rejected because the option-chain window was incomplete.`,
+    STALE_QUOTE: `${label} was rejected because the quote was stale.`,
+    NO_BID_ASK: `${label} was rejected because bid/ask data was not supplied.`,
+    LOW_LIQUIDITY: `${label} was rejected because liquidity quality is too low.`,
+    WEAK_TREND: `${label} was rejected because supplied trend context does not support the contract.`,
+    WEAK_MOMENTUM: `${label} was rejected because momentum evidence is weak.`,
+    ELEVATED_RISK: `${label} was rejected because risk score is elevated after spread, IV, delta, and theta checks.`,
+  };
+  return map[code];
+}
+
+function expectedMove(contract: DecisionContractSnapshot): AiResearchOutput['expectedMove'] {
+  const iv = finite(contract.iv);
+  const dte = finite(contract.dte);
+  if (iv == null || dte == null) {
+    return {
+      source: 'UNAVAILABLE',
+      value: null,
+      explanation: 'Expected move was not calculated because supplied IV or DTE is missing.',
+    };
+  }
+  return {
+    source: 'SUPPLIED_IV',
+    value: Number((iv * Math.sqrt(Math.max(1, dte) / 365)).toFixed(4)),
+    explanation: 'Expected move uses supplied IV and DTE only; no price or Greek was inferred.',
+  };
+}
+
+export function generateAiResearch(candidate: Omit<CandidateOpportunity, 'aiResearch'>): AiResearchOutput {
+  const bullishReasons: string[] = [];
+  const bearishReasons: string[] = [];
+  const risks: string[] = [];
+  if (candidate.direction === 'BULLISH') bullishReasons.push('Candidate is a call contract, so its payoff direction is bullish.');
+  if (candidate.direction === 'BEARISH') bearishReasons.push('Candidate is a put contract, so its payoff direction is bearish.');
+  if (candidate.scores.liquidity.score >= 70) bullishReasons.push(candidate.scores.liquidity.explanation);
+  if (candidate.scores.trend.score >= 70) bullishReasons.push(candidate.scores.trend.explanation);
+  if (candidate.scores.spread.score < 55) risks.push(candidate.scores.spread.explanation);
+  if (candidate.scores.volatility.score < 55) risks.push(candidate.scores.volatility.explanation);
+  if (candidate.scores.risk.score < 55) risks.push(candidate.scores.risk.explanation);
+  if (candidate.rejectionCodes.length) risks.push(...candidate.rejectionCodes.map(code => rejectionExplanation(code, candidate.contract)));
+  return {
+    symbol: candidate.symbol,
+    contract: candidate.contract.symbol,
+    confidence: candidate.confidence,
+    bullishReasons,
+    bearishReasons,
+    risks,
+    marketContext: candidate.marketContext,
+    expectedMove: expectedMove(candidate.contract),
+    recommendation: candidate.recommendation,
+    explanation: candidate.thesis,
+  };
+}
+
+function normalizeContract(raw: DecisionContractSnapshot, now: number): DecisionContractSnapshot {
+  const bid = finite(raw.bid);
+  const ask = finite(raw.ask);
+  const mid = finite(raw.mid) ?? (bid != null && ask != null ? Number(((bid + ask) / 2).toFixed(4)) : null);
+  const spread = finite(raw.spread) ?? (bid != null && ask != null ? Number((ask - bid).toFixed(4)) : null);
+  return {
+    ...raw,
+    bid,
+    ask,
+    mid,
+    spread,
+    spreadPct: finite(raw.spreadPct) ?? (spread != null && mid != null && mid > 0 ? Number((spread / mid).toFixed(4)) : null),
+    dte: finite(raw.dte) ?? computeDteEt(raw.expiration, now),
+    volume: finite(raw.volume),
+    openInterest: finite(raw.openInterest),
+    iv: finite(raw.iv),
+    delta: finite(raw.delta),
+    gamma: finite(raw.gamma),
+    theta: finite(raw.theta),
+    vega: finite(raw.vega),
+  };
+}
+
+export function detectCandidateOpportunities(input: DecisionEngineScanInput): CandidateOpportunity[] {
+  const now = input.now ?? Date.now();
+  const marketStatus = input.marketStatus ?? 'unknown';
+  const candidates: CandidateOpportunity[] = [];
+  for (const item of input.watchlist) {
+    const symbol = item.symbol.trim().toUpperCase();
+    const chain = input.chains[symbol];
+    if (!chain) continue;
+    const marketContext: DecisionMarketContext = {
+      marketStatus,
+      underlyingPrice: chain.underlyingPrice,
+      underlyingTimeframe: chain.underlyingTimeframe ?? null,
+      sector: item.sector ?? null,
+      marketBreadth: item.marketBreadth ?? null,
+      news: item.news ?? [],
+      trend: 'UNKNOWN',
+      momentum: 'UNKNOWN',
+    };
+    const maxSpreadPct = Math.max(0.0001, (item.maxSpreadPercent ?? 10) / 100);
+    const minimumOi = item.minimumOpenInterest ?? 200;
+    const minimumVolume = item.minimumVolume ?? 25;
+    const minConfidence = item.minConfidence ?? 0.5;
+    const maximumIV = item.maximumIV ?? null;
+    for (const rawContract of chain.contracts) {
+      const contract = normalizeContract(rawContract, now);
+      const scores = buildScores({
+        contract,
+        marketContext,
+        maxSpreadPct,
+        minimumOi,
+        minimumVolume,
+        maximumIV,
+      });
+      const codes = reasonCodes({
+        contract,
+        scores,
+        minConfidence,
+        maxSpreadPct,
+        minimumOi,
+        minimumVolume,
+        maximumIV,
+        marketStatus,
+        chainComplete: chain.complete !== false,
+      });
+      const direction = inferDirection(contract);
+      const recommendation: CandidateOpportunity['recommendation'] =
+        codes.length === 0 && direction === 'BULLISH'
+          ? 'BUY_CALL'
+          : codes.length === 0 && direction === 'BEARISH'
+            ? 'BUY_PUT'
+            : scores.overall.score >= 60
+              ? 'WATCH'
+              : 'AVOID';
+      const thesis = codes.length
+        ? `${contract.symbol} is not actionable: ${codes.map(code => rejectionExplanation(code, contract)).join(' ')}`
+        : `${contract.symbol} is actionable because the supplied contract data clears liquidity, spread, volatility, and confidence gates.`;
+      const candidateBase = {
+        id: randomUUID(),
+        symbol,
+        contract,
+        direction,
+        watchlistRank: item.priority ?? null,
+        scores,
+        confidence: Number((scores.confidence.score / 100).toFixed(4)),
+        overallScore: scores.overall.score,
+        recommendation,
+        thesis,
+        rejectionCodes: codes,
+        rejectionExplanation: codes[0] ? rejectionExplanation(codes[0], contract) : null,
+        marketContext,
+      };
+      candidates.push({ ...candidateBase, aiResearch: generateAiResearch(candidateBase) });
+    }
+  }
+  return candidates.sort((a, b) => b.overallScore - a.overallScore || a.contract.symbol.localeCompare(b.contract.symbol));
+}

--- a/server/src/features/decisionEngine/types.ts
+++ b/server/src/features/decisionEngine/types.ts
@@ -1,0 +1,171 @@
+export const DECISION_ENGINE_REASON_CODES = [
+  'LOW_VOLUME',
+  'HIGH_SPREAD',
+  'LOW_CONFIDENCE',
+  'POOR_RISK_REWARD',
+  'HIGH_IV',
+  'LOW_OPEN_INTEREST',
+  'MARKET_CLOSED',
+  'BUYING_POWER',
+  'DATA_UNAVAILABLE',
+  'INCOMPLETE_CHAIN',
+  'STALE_QUOTE',
+  'NO_BID_ASK',
+  'LOW_LIQUIDITY',
+  'WEAK_TREND',
+  'WEAK_MOMENTUM',
+  'ELEVATED_RISK',
+] as const;
+
+export type DecisionEngineReasonCode = (typeof DECISION_ENGINE_REASON_CODES)[number];
+
+export type ScoreKey =
+  | 'liquidity'
+  | 'trend'
+  | 'momentum'
+  | 'spread'
+  | 'volatility'
+  | 'risk'
+  | 'confidence'
+  | 'overall';
+
+export type ExplainedScore = {
+  key: ScoreKey;
+  score: number;
+  maxScore: 100;
+  grade: 'STRONG' | 'ACCEPTABLE' | 'WEAK' | 'UNAVAILABLE';
+  explanation: string;
+  inputs: Record<string, number | string | boolean | null>;
+};
+
+export type DecisionScores = Record<ScoreKey, ExplainedScore>;
+
+export type DecisionContractSnapshot = {
+  symbol: string;
+  type: 'call' | 'put';
+  strike: number | null;
+  expiration: string | null;
+  dte: number | null;
+  bid: number | null;
+  ask: number | null;
+  mid: number | null;
+  spread: number | null;
+  spreadPct: number | null;
+  volume: number | null;
+  openInterest: number | null;
+  iv: number | null;
+  delta: number | null;
+  gamma: number | null;
+  theta: number | null;
+  vega: number | null;
+  quoteTimestamp: string | null;
+};
+
+export type DecisionMarketContext = {
+  marketStatus: string;
+  underlyingPrice: number | null;
+  underlyingTimeframe: string | null;
+  sector: string | null;
+  marketBreadth: Record<string, unknown> | null;
+  news: Array<Record<string, unknown>>;
+  trend: 'BULLISH' | 'BEARISH' | 'NEUTRAL' | 'UNKNOWN';
+  momentum: 'POSITIVE' | 'NEGATIVE' | 'NEUTRAL' | 'UNKNOWN';
+};
+
+export type AiResearchOutput = {
+  symbol: string;
+  contract: string;
+  confidence: number;
+  bullishReasons: string[];
+  bearishReasons: string[];
+  risks: string[];
+  marketContext: DecisionMarketContext;
+  expectedMove: {
+    source: 'SUPPLIED_IV' | 'UNAVAILABLE';
+    value: number | null;
+    explanation: string;
+  };
+  recommendation: 'BUY_CALL' | 'BUY_PUT' | 'WATCH' | 'AVOID';
+  explanation: string;
+};
+
+export type CandidateOpportunity = {
+  id: string;
+  symbol: string;
+  contract: DecisionContractSnapshot;
+  direction: 'BULLISH' | 'BEARISH' | 'NEUTRAL';
+  watchlistRank: number | null;
+  scores: DecisionScores;
+  confidence: number;
+  overallScore: number;
+  recommendation: 'BUY_CALL' | 'BUY_PUT' | 'WATCH' | 'AVOID';
+  thesis: string;
+  rejectionCodes: DecisionEngineReasonCode[];
+  rejectionExplanation: string | null;
+  marketContext: DecisionMarketContext;
+  aiResearch: AiResearchOutput;
+};
+
+export type RejectedCandidate = {
+  candidate: CandidateOpportunity;
+  reasonCode: DecisionEngineReasonCode;
+  explanation: string;
+};
+
+export type DecisionRanking = {
+  bestOpportunity: CandidateOpportunity | null;
+  secondBest: CandidateOpportunity | null;
+  thirdBest: CandidateOpportunity | null;
+  top10: CandidateOpportunity[];
+  rejectedCandidates: RejectedCandidate[];
+};
+
+export type DecisionScan = {
+  scanId: string;
+  timestamp: string;
+  watchlist: string[];
+  relatedEvents: Array<{
+    eventId: string;
+    title: string;
+    category: string;
+    importance: number;
+    sentiment: number | string | null;
+    triggeredReevaluation: boolean;
+    marketContext: Record<string, unknown>;
+    historicalSimilarity: Record<string, unknown> | null;
+  }>;
+  candidates: CandidateOpportunity[];
+  ranking: DecisionRanking;
+  winner: CandidateOpportunity | null;
+  rejections: RejectedCandidate[];
+  aiReasoning: AiResearchOutput[];
+  noTradeReason: string | null;
+  dataSources: string[];
+  schemaVersion: number;
+};
+
+export type DecisionEngineScanInput = {
+  now?: number;
+  marketStatus?: string;
+  buyingPower?: number | null;
+  eventContext?: DecisionScan['relatedEvents'];
+  watchlist: Array<{
+    symbol: string;
+    priority?: number | null;
+    minConfidence?: number | null;
+    maxSpreadPercent?: number | null;
+    minimumOpenInterest?: number | null;
+    minimumVolume?: number | null;
+    maximumIV?: number | null;
+    riskProfile?: string | null;
+    sector?: string | null;
+    news?: Array<Record<string, unknown>>;
+    marketBreadth?: Record<string, unknown> | null;
+  }>;
+  chains: Record<string, {
+    underlyingPrice: number | null;
+    underlyingTimeframe?: string | null;
+    complete?: boolean;
+    contracts: DecisionContractSnapshot[];
+  }>;
+};

--- a/server/src/features/eventIntelligence/classification/classifier.service.ts
+++ b/server/src/features/eventIntelligence/classification/classifier.service.ts
@@ -1,0 +1,103 @@
+import type { EventCategory, EventSentimentLabel, NormalizedMarketEvent } from '../types/eventTypes';
+
+const CATEGORY_RULES: Array<{ category: EventCategory; patterns: RegExp[]; sectors?: string[] }> = [
+  { category: 'Federal Reserve', patterns: [/federal reserve/i, /\bfed\b/i, /fomc/i, /powell/i] },
+  { category: 'Economic', patterns: [/inflation/i, /cpi\b/i, /ppi\b/i, /payroll/i, /unemployment/i, /treasury yield/i, /gdp/i] },
+  { category: 'Earnings', patterns: [/earnings/i, /eps\b/i, /revenue/i, /quarterly results/i] },
+  { category: 'Guidance', patterns: [/guidance/i, /outlook/i, /forecast/i] },
+  { category: 'Merger', patterns: [/merger/i, /merge/i] },
+  { category: 'Acquisition', patterns: [/acqui[rs]/i, /takeover/i, /buyout/i] },
+  { category: 'SEC Filing', patterns: [/\bsec\b/i, /\b10-k\b/i, /\b10-q\b/i, /\b8-k\b/i, /filing/i] },
+  { category: 'Insider Activity', patterns: [/insider/i, /form 4/i] },
+  { category: 'Analyst Upgrade', patterns: [/upgrade/i, /raises rating/i, /price target raised/i] },
+  { category: 'Analyst Downgrade', patterns: [/downgrade/i, /cuts rating/i, /price target cut/i] },
+  { category: 'Product Launch', patterns: [/launch/i, /unveils/i, /introduces/i] },
+  { category: 'Supply Chain', patterns: [/supply chain/i, /shortage/i, /supplier/i, /logistics/i] },
+  { category: 'Commodity', patterns: [/commodity/i, /gold/i, /copper/i, /wheat/i] },
+  { category: 'Oil', patterns: [/\boil\b/i, /crude/i, /opec/i, /ceasefire/i], sectors: ['Energy'] },
+  { category: 'Natural Disaster', patterns: [/hurricane/i, /earthquake/i, /wildfire/i, /flood/i] },
+  { category: 'Cybersecurity', patterns: [/cyber/i, /hack/i, /ransomware/i, /breach/i] },
+  { category: 'Government Policy', patterns: [/government/i, /policy/i, /regulation/i, /white house/i] },
+  { category: 'Tariffs', patterns: [/tariff/i, /trade war/i, /import duty/i] },
+  { category: 'Litigation', patterns: [/lawsuit/i, /litigation/i, /settlement/i, /court/i] },
+  { category: 'AI', patterns: [/\bai\b/i, /artificial intelligence/i, /gpu/i], sectors: ['Technology'] },
+  { category: 'Technology', patterns: [/software/i, /semiconductor/i, /cloud/i, /chip/i], sectors: ['Technology'] },
+  { category: 'Healthcare', patterns: [/fda/i, /drug/i, /clinical/i, /healthcare/i, /biotech/i], sectors: ['Healthcare'] },
+  { category: 'Financial', patterns: [/bank/i, /credit/i, /loan/i, /financial/i], sectors: ['Financial'] },
+  { category: 'Energy', patterns: [/energy/i, /solar/i, /natural gas/i], sectors: ['Energy'] },
+  { category: 'Transportation', patterns: [/airline/i, /rail/i, /shipping/i, /transport/i], sectors: ['Transportation'] },
+  { category: 'Consumer', patterns: [/consumer/i, /retail/i, /restaurant/i], sectors: ['Consumer'] },
+  { category: 'Geopolitical', patterns: [/war/i, /iran/i, /russia/i, /china/i, /ceasefire/i, /sanction/i] },
+];
+
+const SECTOR_BY_SYMBOL: Record<string, string> = {
+  XLE: 'Energy',
+  CVX: 'Energy',
+  XOM: 'Energy',
+  OXY: 'Energy',
+  USO: 'Energy',
+  XLK: 'Technology',
+  NVDA: 'Technology',
+  AMD: 'Technology',
+  MSFT: 'Technology',
+  AAPL: 'Technology',
+  XLF: 'Financial',
+  JPM: 'Financial',
+  BAC: 'Financial',
+  XLV: 'Healthcare',
+  UNH: 'Healthcare',
+  XLY: 'Consumer',
+  XLP: 'Consumer',
+  XLI: 'Transportation',
+};
+
+function uniq(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean).map(value => value.trim()).filter(Boolean))].sort();
+}
+
+export function classifyEventText(title: string, summary: string | null = null): { category: EventCategory; sectors: string[]; confidence: number } {
+  const text = `${title} ${summary ?? ''}`;
+  for (const rule of CATEGORY_RULES) {
+    if (rule.patterns.some(pattern => pattern.test(text))) {
+      return { category: rule.category, sectors: rule.sectors ?? [], confidence: 0.85 };
+    }
+  }
+  return { category: 'News', sectors: [], confidence: 0.55 };
+}
+
+export function inferSentiment(value: unknown, title = '', summary: string | null = null): NormalizedMarketEvent['sentiment'] {
+  const raw = String(value ?? '').toLowerCase();
+  const text = `${title} ${summary ?? ''}`.toLowerCase();
+  let label: EventSentimentLabel = 'unknown';
+  let score: number | null = null;
+  if (raw.includes('positive') || raw.includes('bullish')) {
+    label = 'bullish';
+    score = 0.65;
+  } else if (raw.includes('negative') || raw.includes('bearish')) {
+    label = 'bearish';
+    score = -0.65;
+  } else if (raw.includes('neutral')) {
+    label = 'neutral';
+    score = 0;
+  } else if (/(beats|raises|approval|ceasefire|upgrade|record)/i.test(text)) {
+    label = 'bullish';
+    score = 0.45;
+  } else if (/(misses|cuts|downgrade|lawsuit|breach|war|tariff|shortage)/i.test(text)) {
+    label = 'bearish';
+    score = -0.45;
+  }
+  return { label, score, explanation: label === 'unknown' ? 'No supplied or keyword sentiment was available.' : 'Sentiment derived from supplied provider signal or event text.' };
+}
+
+export function enrichEventClassification(event: NormalizedMarketEvent): NormalizedMarketEvent {
+  const classified = classifyEventText(event.title, event.summary);
+  const symbolSectors = event.symbols.map(symbol => SECTOR_BY_SYMBOL[symbol.toUpperCase()]).filter(Boolean);
+  return {
+    ...event,
+    category: event.category === 'News' ? classified.category : event.category,
+    sectors: uniq([...event.sectors, ...classified.sectors, ...symbolSectors]),
+    confidence: Math.max(event.confidence, classified.confidence),
+  };
+}
+
+export { SECTOR_BY_SYMBOL };

--- a/server/src/features/eventIntelligence/events/decisionTrigger.service.ts
+++ b/server/src/features/eventIntelligence/events/decisionTrigger.service.ts
@@ -1,0 +1,66 @@
+import { runDecisionEngineEventReevaluation } from '../../decisionEngine/scanner.service';
+import type {
+  DecisionEngineEventTrigger,
+  EventIntelligenceRecord,
+  HistoricalSimilarity,
+  MarketImpactEstimate,
+  NormalizedMarketEvent,
+} from '../types/eventTypes';
+
+const HIGH_IMPORTANCE_THRESHOLD = Math.max(0, Math.min(100, Number(process.env.EVENT_INTELLIGENCE_TRIGGER_THRESHOLD ?? 80)));
+
+export async function notifyDecisionEngineOfEvent(args: {
+  event: NormalizedMarketEvent;
+  impact: MarketImpactEstimate;
+  historicalSimilarity: HistoricalSimilarity;
+  enabled?: boolean;
+}): Promise<DecisionEngineEventTrigger> {
+  const affectedAssets = [...new Set([...args.impact.affectedSymbols, ...args.impact.affectedEtfs])].sort();
+  const base = {
+    eventId: args.event.id,
+    importance: args.event.importance,
+    confidence: args.impact.confidence,
+    affectedAssets,
+    supportingEvidence: [
+      args.event.title,
+      args.impact.explanation,
+      args.historicalSimilarity.explanation,
+    ],
+  };
+  if (args.event.importance < HIGH_IMPORTANCE_THRESHOLD) {
+    return { ...base, triggered: false, status: 'SKIPPED_LOW_IMPORTANCE', triggeredAt: null, decisionScanId: null, error: null };
+  }
+  if (!affectedAssets.length) {
+    return { ...base, triggered: false, status: 'SKIPPED_NO_AFFECTED_ASSETS', triggeredAt: null, decisionScanId: null, error: null };
+  }
+  if (args.enabled === false) {
+    return { ...base, triggered: true, status: 'TRIGGERED', triggeredAt: new Date().toISOString(), decisionScanId: null, error: null };
+  }
+  try {
+    const scan = await runDecisionEngineEventReevaluation([
+      {
+        eventId: args.event.id,
+        title: args.event.title,
+        category: args.event.category,
+        importance: args.event.importance,
+        sentiment: args.event.sentiment.score ?? args.event.sentiment.label,
+        triggeredReevaluation: true,
+        marketContext: {
+          affectedSymbols: args.impact.affectedSymbols,
+          affectedEtfs: args.impact.affectedEtfs,
+          affectedSectors: args.impact.affectedSectors,
+          affectedCommodities: args.impact.affectedCommodities,
+          confidence: args.impact.confidence,
+        },
+        historicalSimilarity: args.historicalSimilarity,
+      },
+    ]);
+    return { ...base, triggered: true, status: 'TRIGGERED', triggeredAt: new Date().toISOString(), decisionScanId: scan.scanId, error: null };
+  } catch (error) {
+    return { ...base, triggered: false, status: 'FAILED', triggeredAt: null, decisionScanId: null, error: (error as Error)?.message ?? 'decision trigger failed' };
+  }
+}
+
+export function eventTriggeredDecision(record: EventIntelligenceRecord): boolean {
+  return record.decisionTrigger.triggered && record.decisionTrigger.status === 'TRIGGERED';
+}

--- a/server/src/features/eventIntelligence/events/eventProcessor.service.ts
+++ b/server/src/features/eventIntelligence/events/eventProcessor.service.ts
@@ -1,0 +1,62 @@
+import type { EventIntelligenceRecord, EventMarketContext, NormalizedMarketEvent } from '../types/eventTypes';
+import { enrichEventClassification } from '../classification/classifier.service';
+import { estimateMarketImpact } from '../impact/impact.service';
+import { scoreEventImportance } from '../impact/importance.service';
+import { findHistoricalSimilarity } from '../storage/historicalSimilarity.service';
+import { upsertEventRecord, listEventRecords } from '../storage/eventJournal.service';
+import { notifyDecisionEngineOfEvent } from './decisionTrigger.service';
+
+function uniq(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))].sort();
+}
+
+export async function processMarketEvent(
+  rawEvent: NormalizedMarketEvent,
+  options: { triggerDecisionEngine?: boolean; persist?: boolean } = {}
+): Promise<EventIntelligenceRecord> {
+  const classified = enrichEventClassification(rawEvent);
+  const initialImpact = estimateMarketImpact(classified);
+  const historicalSimilarity = await findHistoricalSimilarity(classified, initialImpact);
+  const importance = scoreEventImportance({ event: classified, impact: initialImpact, historicalSimilarity });
+  const event = {
+    ...classified,
+    importance: importance.importance,
+    importanceExplanation: importance.explanation,
+  };
+  const impact = {
+    ...estimateMarketImpact(event),
+    importance: importance.importance,
+  };
+  const decisionTrigger = await notifyDecisionEngineOfEvent({
+    event,
+    impact,
+    historicalSimilarity,
+    enabled: options.triggerDecisionEngine === true,
+  });
+  const record: EventIntelligenceRecord = {
+    event,
+    impact,
+    historicalSimilarity,
+    decisionTrigger,
+    createdAt: new Date().toISOString(),
+  };
+  return options.persist === false ? record : upsertEventRecord(record);
+}
+
+export async function buildEventMarketContext(limit = 50): Promise<EventMarketContext> {
+  const records = await listEventRecords(limit);
+  const highImportanceEvents = records.filter(record => record.event.importance >= 70);
+  return {
+    generatedAt: new Date().toISOString(),
+    highImportanceEvents,
+    affectedSymbols: uniq(records.flatMap(record => record.impact.affectedSymbols)),
+    affectedEtfs: uniq(records.flatMap(record => record.impact.affectedEtfs)),
+    affectedSectors: uniq(records.flatMap(record => record.impact.affectedSectors)),
+    sentiment: {
+      bullish: records.filter(record => record.event.sentiment.label === 'bullish').length,
+      bearish: records.filter(record => record.event.sentiment.label === 'bearish').length,
+      neutral: records.filter(record => record.event.sentiment.label === 'neutral').length,
+    },
+    latestTrigger: records.find(record => record.decisionTrigger.triggered)?.decisionTrigger ?? null,
+  };
+}

--- a/server/src/features/eventIntelligence/events/eventScanner.service.ts
+++ b/server/src/features/eventIntelligence/events/eventScanner.service.ts
@@ -1,0 +1,42 @@
+import { fetchMassiveEvents } from '../providers/massiveEventProvider.service';
+import { processMarketEvent } from './eventProcessor.service';
+import { listWatchlist } from '../../watchlist/watchlist.service';
+
+const SCAN_INTERVAL_MS = Math.max(60_000, Number(process.env.EVENT_INTELLIGENCE_SCAN_INTERVAL_MS ?? 180_000));
+let timer: NodeJS.Timeout | null = null;
+let scanInFlight: Promise<void> | null = null;
+
+export async function runEventIntelligenceScan(): Promise<void> {
+  if (scanInFlight) return scanInFlight;
+  scanInFlight = (async () => {
+    const watchlist = await listWatchlist().catch(() => []);
+    const symbols = watchlist.length ? watchlist.filter(item => item.enabled).map(item => item.symbol) : undefined;
+    const events = await fetchMassiveEvents({ symbols, limit: 20 });
+    await Promise.all(events.slice(0, 50).map(event => processMarketEvent(event, {
+      persist: true,
+      triggerDecisionEngine: true,
+    }).catch(error => {
+      console.warn('[event-intelligence] event processing failed', { eventId: event.id, error: (error as Error)?.message });
+    })));
+  })();
+  try {
+    await scanInFlight;
+  } finally {
+    scanInFlight = null;
+  }
+}
+
+export function startEventIntelligenceScanner(): void {
+  if (timer || process.env.EVENT_INTELLIGENCE_AUTO_START !== 'true') return;
+  timer = setInterval(() => {
+    runEventIntelligenceScan().catch(error => {
+      console.warn('[event-intelligence] scan failed', { error: (error as Error)?.message });
+    });
+  }, SCAN_INTERVAL_MS);
+}
+
+export function stopEventIntelligenceScanner(): void {
+  if (!timer) return;
+  clearInterval(timer);
+  timer = null;
+}

--- a/server/src/features/eventIntelligence/impact/impact.service.ts
+++ b/server/src/features/eventIntelligence/impact/impact.service.ts
@@ -1,0 +1,47 @@
+import type { MarketImpactEstimate, NormalizedMarketEvent } from '../types/eventTypes';
+
+const ETF_BY_SECTOR: Record<string, string[]> = {
+  Energy: ['XLE', 'USO'],
+  Technology: ['XLK', 'QQQ'],
+  Healthcare: ['XLV'],
+  Financial: ['XLF'],
+  Consumer: ['XLY', 'XLP'],
+  Transportation: ['IYT', 'XLI'],
+};
+
+const SYMBOLS_BY_THEME: Record<string, string[]> = {
+  Oil: ['USO', 'XLE', 'CVX', 'XOM', 'OXY'],
+  Energy: ['XLE', 'CVX', 'XOM', 'OXY'],
+  AI: ['NVDA', 'AMD', 'MSFT', 'QQQ', 'XLK'],
+  Technology: ['AAPL', 'MSFT', 'NVDA', 'AMD', 'QQQ', 'XLK'],
+  Financial: ['JPM', 'BAC', 'XLF'],
+  Healthcare: ['UNH', 'XLV'],
+};
+
+function uniq(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean).map(value => value.toUpperCase()))].sort();
+}
+
+export function estimateMarketImpact(event: NormalizedMarketEvent): MarketImpactEstimate {
+  const themeSymbols = SYMBOLS_BY_THEME[event.category] ?? [];
+  const sectorEtfs = event.sectors.flatMap(sector => ETF_BY_SECTOR[sector] ?? []);
+  const affectedSymbols = uniq([...event.symbols, ...themeSymbols]);
+  const affectedEtfs = uniq([...sectorEtfs, ...affectedSymbols.filter(symbol => ['SPY', 'QQQ', 'XLE', 'USO', 'XLK', 'XLF', 'XLV', 'XLY', 'XLP', 'IYT', 'XLI'].includes(symbol))]);
+  const affectedCommodities = event.category === 'Oil' || event.category === 'Commodity' ? ['Oil'] : [];
+  const isBullish = event.sentiment.score != null ? event.sentiment.score > 0.15 : event.sentiment.label === 'bullish';
+  const isBearish = event.sentiment.score != null ? event.sentiment.score < -0.15 : event.sentiment.label === 'bearish';
+  return {
+    eventId: event.id,
+    potentialBullishImpact: isBullish ? affectedSymbols : [],
+    potentialBearishImpact: isBearish ? affectedSymbols : [],
+    affectedSymbols,
+    affectedEtfs,
+    affectedSectors: event.sectors,
+    affectedCommodities,
+    confidence: Number(Math.min(1, event.confidence + affectedSymbols.length * 0.02).toFixed(4)),
+    importance: event.importance,
+    explanation: `Impact maps ${event.category} to ${affectedSymbols.length} symbols, ${affectedEtfs.length} ETFs, and ${event.sectors.length} sectors.`,
+  };
+}
+
+export { ETF_BY_SECTOR, SYMBOLS_BY_THEME };

--- a/server/src/features/eventIntelligence/impact/importance.service.ts
+++ b/server/src/features/eventIntelligence/impact/importance.service.ts
@@ -1,0 +1,31 @@
+import type { HistoricalSimilarity, MarketImpactEstimate, NormalizedMarketEvent } from '../types/eventTypes';
+
+function hoursSince(timestamp: string, now = Date.now()): number {
+  const ms = Date.parse(timestamp);
+  return Number.isNaN(ms) ? 999 : Math.max(0, (now - ms) / 3_600_000);
+}
+
+function clamp(value: number): number {
+  return Math.max(0, Math.min(100, Number(value.toFixed(2))));
+}
+
+export function scoreEventImportance(args: {
+  event: NormalizedMarketEvent;
+  impact: MarketImpactEstimate;
+  historicalSimilarity?: HistoricalSimilarity | null;
+  now?: number;
+}): { importance: number; explanation: string } {
+  const recencyScore = Math.max(0, 25 - hoursSince(args.event.timestamp, args.now) * 2);
+  const providerScore = args.event.provider.startsWith('massive') ? 12 : 6;
+  const sentimentScore = args.event.sentiment.score == null ? 6 : Math.min(15, Math.abs(args.event.sentiment.score) * 15);
+  const impactScore = Math.min(22, args.impact.affectedSymbols.length * 2 + args.impact.affectedEtfs.length * 2 + args.impact.affectedCommodities.length * 4);
+  const breadthScore = Math.min(12, args.impact.affectedSectors.length * 4);
+  const historyScore = args.historicalSimilarity?.similarEvents.length ? 8 : 0;
+  const categoryScore = ['Geopolitical', 'Federal Reserve', 'Economic', 'Oil', 'Earnings'].includes(args.event.category) ? 10 : 0;
+  const confidenceScore = Math.min(8, args.event.confidence * 8);
+  const importance = clamp(recencyScore + providerScore + sentimentScore + impactScore + breadthScore + historyScore + categoryScore + confidenceScore);
+  return {
+    importance,
+    explanation: `Importance ${importance}/100 from recency ${recencyScore.toFixed(1)}, provider ${providerScore}, sentiment ${sentimentScore.toFixed(1)}, impact ${impactScore}, sector breadth ${breadthScore}, historical similarity ${historyScore}, category ${categoryScore}, confidence ${confidenceScore.toFixed(1)}.`,
+  };
+}

--- a/server/src/features/eventIntelligence/index.ts
+++ b/server/src/features/eventIntelligence/index.ts
@@ -1,0 +1,2 @@
+export { eventIntelligenceRouter } from './routes/eventIntelligence.routes';
+export { startEventIntelligenceScanner, stopEventIntelligenceScanner } from './events/eventScanner.service';

--- a/server/src/features/eventIntelligence/providers/massiveEventProvider.service.ts
+++ b/server/src/features/eventIntelligence/providers/massiveEventProvider.service.ts
@@ -1,0 +1,240 @@
+import { createHash } from 'crypto';
+import { massiveGet, REQUEST_PRIORITY } from '../../../shared/data/massive';
+import { getInflation, getLaborMarket, getTickerNews, getTreasuryYields } from '../../../shared/data/massiveMacro';
+import { getMarketStatusSnapshot } from '../../market/services/marketStatus';
+import { classifyEventText, enrichEventClassification, inferSentiment } from '../classification/classifier.service';
+import type { EventProvider, NormalizedMarketEvent } from '../types/eventTypes';
+
+const EVENT_NEWS_TTL_MS = 5 * 60_000;
+const EVENT_REFERENCE_TTL_MS = 15 * 60_000;
+
+function eventId(provider: EventProvider, parts: Array<string | null | undefined>): string {
+  const hash = createHash('sha256').update([provider, ...parts].join('|')).digest('hex').slice(0, 24);
+  return `${provider}:${hash}`;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function normalizeSymbols(values: unknown): string[] {
+  if (!Array.isArray(values)) return [];
+  return [...new Set(values.map(value => String(value ?? '').trim().toUpperCase()).filter(Boolean))].sort();
+}
+
+function normalizeNewsArticle(article: {
+  id: string;
+  title: string;
+  description: string | null;
+  publisher: string | null;
+  publishedUtc: string | null;
+  articleUrl: string | null;
+  tickers: string[];
+  sentiment: { ticker: string; sentiment: string; reasoning: string | null }[];
+}, provider: EventProvider): NormalizedMarketEvent {
+  const classified = classifyEventText(article.title, article.description);
+  const primarySentiment = article.sentiment[0] ?? null;
+  const event: NormalizedMarketEvent = {
+    id: eventId(provider, [article.id, article.title, article.publishedUtc]),
+    provider,
+    timestamp: article.publishedUtc ?? nowIso(),
+    title: article.title,
+    summary: article.description,
+    category: classified.category,
+    sentiment: inferSentiment(primarySentiment?.sentiment, article.title, article.description),
+    symbols: normalizeSymbols(article.tickers),
+    sectors: classified.sectors,
+    confidence: classified.confidence,
+    importance: 0,
+    importanceExplanation: 'Importance is assigned by the Event Importance Engine.',
+    source: article.publisher,
+    url: article.articleUrl,
+    raw: { article },
+  };
+  return enrichEventClassification(event);
+}
+
+async function fetchMarketNews(limit: number): Promise<NormalizedMarketEvent[]> {
+  const payload = await massiveGet<any>(
+    '/v2/reference/news',
+    { limit, order: 'desc', sort: 'published_utc' },
+    { cacheTtlMs: EVENT_NEWS_TTL_MS, priority: REQUEST_PRIORITY.SCANNER }
+  );
+  const results = Array.isArray(payload?.results) ? payload.results : [];
+  return results.map((item: any) => normalizeNewsArticle({
+    id: String(item?.id ?? ''),
+    title: String(item?.title ?? ''),
+    description: item?.description ?? null,
+    publisher: item?.publisher?.name ?? null,
+    publishedUtc: item?.published_utc ?? null,
+    articleUrl: item?.article_url ?? null,
+    tickers: normalizeSymbols(item?.tickers),
+    sentiment: Array.isArray(item?.insights)
+      ? item.insights.map((insight: any) => ({
+          ticker: String(insight?.ticker ?? ''),
+          sentiment: String(insight?.sentiment ?? 'unknown'),
+          reasoning: insight?.sentiment_reasoning ?? null,
+        }))
+      : [],
+  }, 'massive-market-news'));
+}
+
+async function fetchCompanyNews(symbols: string[], limit: number): Promise<NormalizedMarketEvent[]> {
+  const articles = await Promise.all(symbols.map(symbol => getTickerNews(symbol, limit).catch(() => [])));
+  return articles.flat().map(article => normalizeNewsArticle(article, 'massive-news'));
+}
+
+async function fetchSentiment(symbols: string[]): Promise<NormalizedMarketEvent[]> {
+  const events = await Promise.all(symbols.map(async symbol => {
+    const payload = await massiveGet<any>(
+      `/v1/sentiment/${symbol.toUpperCase()}`,
+      {},
+      { cacheTtlMs: EVENT_REFERENCE_TTL_MS, priority: REQUEST_PRIORITY.SCANNER }
+    ).catch(() => null);
+    const raw = Array.isArray(payload?.results) ? payload.results[0] : payload?.result ?? payload ?? null;
+    if (!raw) return null;
+    const score = typeof raw.score === 'number' ? raw.score : typeof raw.sentiment_score === 'number' ? raw.sentiment_score : typeof raw.net_sentiment === 'number' ? raw.net_sentiment : null;
+    const label = raw.label ?? raw.sentiment ?? (score != null ? score > 0.2 ? 'bullish' : score < -0.2 ? 'bearish' : 'neutral' : 'unknown');
+    const title = `${symbol.toUpperCase()} sentiment ${label}`;
+    const classified = classifyEventText(title, null);
+    return enrichEventClassification({
+      id: eventId('massive-sentiment', [symbol, String(label), String(score)]),
+      provider: 'massive-sentiment',
+      timestamp: nowIso(),
+      title,
+      summary: raw.summary ?? raw.reasoning ?? null,
+      category: classified.category,
+      sentiment: { label, score, explanation: 'Sentiment supplied by Massive sentiment endpoint.' },
+      symbols: [symbol.toUpperCase()],
+      sectors: classified.sectors,
+      confidence: score == null ? 0.55 : Math.min(0.95, Math.abs(score) + 0.45),
+      importance: 0,
+      importanceExplanation: 'Importance is assigned by the Event Importance Engine.',
+      source: 'Massive sentiment',
+      url: null,
+      raw: { payload: raw },
+    } as NormalizedMarketEvent);
+  }));
+  return events.filter((event): event is NormalizedMarketEvent => event != null);
+}
+
+async function fetchMarketStatusEvent(): Promise<NormalizedMarketEvent[]> {
+  const status = await getMarketStatusSnapshot();
+  const title = `Market status is ${status.market}`;
+  return [{
+    id: eventId('massive-market-status', [status.market, status.serverTime.toISOString()]),
+    provider: 'massive-market-status',
+    timestamp: status.serverTime.toISOString(),
+    title,
+    summary: `Market=${status.market}; preMarket=${status.preMarket}; afterHours=${status.afterHours}; weekend=${status.isWeekend}; holiday=${status.isHoliday}.`,
+    category: 'Market Status',
+    sentiment: { label: status.market === 'open' ? 'neutral' : 'unknown', score: null, explanation: 'Market status is contextual, not directional.' },
+    symbols: ['SPY', 'QQQ'],
+    sectors: [],
+    confidence: 0.9,
+    importance: 0,
+    importanceExplanation: 'Importance is assigned by the Event Importance Engine.',
+    source: 'Massive market status',
+    url: null,
+    raw: { status },
+  }];
+}
+
+async function fetchEconomicEvents(): Promise<NormalizedMarketEvent[]> {
+  const [yields, inflation, labor] = await Promise.all([
+    getTreasuryYields(2).catch(() => []),
+    getInflation(2).catch(() => []),
+    getLaborMarket(2).catch(() => []),
+  ]);
+  const events: NormalizedMarketEvent[] = [];
+  for (const row of yields.slice(0, 1)) {
+    events.push({
+      id: eventId('massive-economic', ['treasury-yields', row.date]),
+      provider: 'massive-economic',
+      timestamp: `${row.date}T12:00:00.000Z`,
+      title: 'Treasury yield update',
+      summary: `2Y=${row.yield2Year ?? 'n/a'}, 10Y=${row.yield10Year ?? 'n/a'}, 30Y=${row.yield30Year ?? 'n/a'}.`,
+      category: 'Economic',
+      sentiment: { label: 'neutral', score: null, explanation: 'Yield events require downstream strategy interpretation.' },
+      symbols: ['SPY', 'QQQ', 'XLF'],
+      sectors: ['Financial'],
+      confidence: 0.8,
+      importance: 0,
+      importanceExplanation: 'Importance is assigned by the Event Importance Engine.',
+      source: 'Massive economy',
+      url: null,
+      raw: { row },
+    });
+  }
+  for (const [name, rows] of [['Inflation', inflation], ['Labor market', labor]] as const) {
+    const row = rows[0];
+    if (!row) continue;
+    events.push({
+      id: eventId('massive-economic', [name, row.date]),
+      provider: 'massive-economic',
+      timestamp: `${row.date}T12:00:00.000Z`,
+      title: `${name} update`,
+      summary: Object.entries(row.values).slice(0, 4).map(([key, value]) => `${key}=${value}`).join(', '),
+      category: 'Economic',
+      sentiment: { label: 'neutral', score: null, explanation: 'Macro events are stored as context unless provider sentiment is supplied.' },
+      symbols: ['SPY', 'QQQ'],
+      sectors: [],
+      confidence: 0.75,
+      importance: 0,
+      importanceExplanation: 'Importance is assigned by the Event Importance Engine.',
+      source: 'Massive economy',
+      url: null,
+      raw: { row },
+    });
+  }
+  return events;
+}
+
+async function fetchReferenceEndpoint(path: string, provider: EventProvider, category: NormalizedMarketEvent['category'], symbols: string[], limit: number): Promise<NormalizedMarketEvent[]> {
+  const payload = await massiveGet<any>(
+    path,
+    { limit, order: 'desc' },
+    { cacheTtlMs: EVENT_REFERENCE_TTL_MS, priority: REQUEST_PRIORITY.SCANNER }
+  ).catch(() => null);
+  const results = Array.isArray(payload?.results) ? payload.results : [];
+  return results.map((row: any) => {
+    const symbol = String(row?.ticker ?? row?.symbol ?? row?.underlying_ticker ?? '').toUpperCase();
+    const date = row?.execution_date ?? row?.declaration_date ?? row?.pay_date ?? row?.date ?? row?.report_date ?? nowIso();
+    const title = `${category}: ${symbol || path}`;
+    return enrichEventClassification({
+      id: eventId(provider, [path, symbol, String(date), JSON.stringify(row).slice(0, 128)]),
+      provider,
+      timestamp: String(date).includes('T') ? String(date) : `${date}T12:00:00.000Z`,
+      title,
+      summary: row?.description ?? row?.type ?? null,
+      category,
+      sentiment: inferSentiment(row?.sentiment, title, row?.description ?? null),
+      symbols: normalizeSymbols(symbol ? [symbol] : symbols),
+      sectors: [],
+      confidence: 0.65,
+      importance: 0,
+      importanceExplanation: 'Importance is assigned by the Event Importance Engine.',
+      source: 'Massive reference',
+      url: null,
+      raw: { row },
+    });
+  });
+}
+
+export async function fetchMassiveEvents(args: { symbols?: string[]; limit?: number } = {}): Promise<NormalizedMarketEvent[]> {
+  const symbols = normalizeSymbols(args.symbols ?? ['SPY', 'QQQ', 'XLE', 'OXY', 'CVX', 'NVDA', 'AMD']);
+  const limit = Math.max(1, Math.min(50, args.limit ?? 10));
+  const batches = await Promise.all([
+    fetchMarketNews(limit).catch(() => []),
+    fetchCompanyNews(symbols.slice(0, 8), Math.min(5, limit)).catch(() => []),
+    fetchSentiment(symbols.slice(0, 8)).catch(() => []),
+    fetchMarketStatusEvent().catch(() => []),
+    fetchEconomicEvents().catch(() => []),
+    fetchReferenceEndpoint('/vX/reference/financials', 'massive-earnings', 'Earnings', symbols, limit).catch(() => []),
+    fetchReferenceEndpoint('/v3/reference/dividends', 'massive-corporate-actions', 'Corporate Action', symbols, limit).catch(() => []),
+    fetchReferenceEndpoint('/v3/reference/splits', 'massive-corporate-actions', 'Corporate Action', symbols, limit).catch(() => []),
+  ]);
+  const byId = new Map<string, NormalizedMarketEvent>();
+  for (const event of batches.flat()) byId.set(event.id, event);
+  return [...byId.values()].sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp));
+}

--- a/server/src/features/eventIntelligence/routes/eventIntelligence.routes.ts
+++ b/server/src/features/eventIntelligence/routes/eventIntelligence.routes.ts
@@ -1,0 +1,73 @@
+import { Router, type Response } from 'express';
+import {
+  getLatestEventRecord,
+  listEventRecords,
+  listEventRecordsBySector,
+  listEventRecordsBySymbol,
+} from '../storage/eventJournal.service';
+import { buildEventMarketContext } from '../events/eventProcessor.service';
+
+export const eventIntelligenceRouter = Router();
+
+function sendError(res: Response, error: unknown): void {
+  const status = typeof (error as any)?.status === 'number' ? (error as any).status : 500;
+  res.status(status).json({ error: (error as Error)?.message ?? 'event intelligence request failed' });
+}
+
+function limitFrom(value: unknown, fallback = 50): number {
+  const parsed = typeof value === 'string' ? Number(value) : fallback;
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+eventIntelligenceRouter.get('/events', async (req, res) => {
+  try {
+    res.json({ events: await listEventRecords(limitFrom(req.query.limit)) });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+eventIntelligenceRouter.get('/latest', async (_req, res) => {
+  try {
+    const event = await getLatestEventRecord();
+    if (!event) {
+      res.status(404).json({ error: 'EVENT_INTELLIGENCE_NOT_FOUND' });
+      return;
+    }
+    res.json({ event });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+eventIntelligenceRouter.get('/history', async (req, res) => {
+  try {
+    res.json({ history: await listEventRecords(limitFrom(req.query.limit, 100)) });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+eventIntelligenceRouter.get('/symbol/:ticker', async (req, res) => {
+  try {
+    res.json({ events: await listEventRecordsBySymbol(req.params.ticker, limitFrom(req.query.limit)) });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+eventIntelligenceRouter.get('/sector/:sector', async (req, res) => {
+  try {
+    res.json({ events: await listEventRecordsBySector(req.params.sector, limitFrom(req.query.limit)) });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+eventIntelligenceRouter.get('/context', async (req, res) => {
+  try {
+    res.json({ context: await buildEventMarketContext(limitFrom(req.query.limit, 100)) });
+  } catch (error) {
+    sendError(res, error);
+  }
+});

--- a/server/src/features/eventIntelligence/storage/eventIntelligence.model.ts
+++ b/server/src/features/eventIntelligence/storage/eventIntelligence.model.ts
@@ -1,0 +1,35 @@
+import mongoose, { Schema } from 'mongoose';
+import type { EventIntelligenceRecord } from '../types/eventTypes';
+
+export interface EventIntelligenceDocument extends Omit<EventIntelligenceRecord, 'createdAt'> {
+  eventId: string;
+  timestamp: Date;
+  symbols: string[];
+  sectors: string[];
+  importance: number;
+  category: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const EventIntelligenceSchema = new Schema<EventIntelligenceDocument>(
+  {
+    eventId: { type: String, required: true, unique: true, index: true },
+    timestamp: { type: Date, required: true, index: true },
+    symbols: { type: [String], required: true, default: [], index: true },
+    sectors: { type: [String], required: true, default: [], index: true },
+    importance: { type: Number, required: true, index: true },
+    category: { type: String, required: true, index: true },
+    event: { type: Schema.Types.Mixed, required: true },
+    impact: { type: Schema.Types.Mixed, required: true },
+    historicalSimilarity: { type: Schema.Types.Mixed, required: true },
+    decisionTrigger: { type: Schema.Types.Mixed, required: true },
+  },
+  { timestamps: true, collection: 'event_intelligence_events' }
+);
+
+EventIntelligenceSchema.index({ timestamp: -1, importance: -1 });
+
+export const EventIntelligenceModel =
+  (mongoose.models.EventIntelligence as mongoose.Model<EventIntelligenceDocument>) ||
+  mongoose.model<EventIntelligenceDocument>('EventIntelligence', EventIntelligenceSchema);

--- a/server/src/features/eventIntelligence/storage/eventJournal.service.ts
+++ b/server/src/features/eventIntelligence/storage/eventJournal.service.ts
@@ -1,0 +1,55 @@
+import type { EventIntelligenceRecord } from '../types/eventTypes';
+import { EventIntelligenceModel } from './eventIntelligence.model';
+
+function serialize(doc: any): EventIntelligenceRecord {
+  const value = typeof doc.toObject === 'function' ? doc.toObject() : doc;
+  return {
+    event: value.event,
+    impact: value.impact,
+    historicalSimilarity: value.historicalSimilarity,
+    decisionTrigger: value.decisionTrigger,
+    createdAt: value.createdAt instanceof Date ? value.createdAt.toISOString() : String(value.createdAt),
+  };
+}
+
+export async function upsertEventRecord(record: EventIntelligenceRecord): Promise<EventIntelligenceRecord> {
+  const updated = await EventIntelligenceModel.findOneAndUpdate(
+    { eventId: record.event.id },
+    {
+      $set: {
+        eventId: record.event.id,
+        timestamp: new Date(record.event.timestamp),
+        symbols: record.impact.affectedSymbols,
+        sectors: record.impact.affectedSectors,
+        importance: record.event.importance,
+        category: record.event.category,
+        event: record.event,
+        impact: record.impact,
+        historicalSimilarity: record.historicalSimilarity,
+        decisionTrigger: record.decisionTrigger,
+      },
+    },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
+  return serialize(updated);
+}
+
+export async function listEventRecords(limit = 50): Promise<EventIntelligenceRecord[]> {
+  const docs = await EventIntelligenceModel.find().sort({ timestamp: -1, importance: -1 }).limit(Math.max(1, Math.min(250, limit)));
+  return docs.map(serialize);
+}
+
+export async function getLatestEventRecord(): Promise<EventIntelligenceRecord | null> {
+  const doc = await EventIntelligenceModel.findOne().sort({ timestamp: -1, importance: -1 });
+  return doc ? serialize(doc) : null;
+}
+
+export async function listEventRecordsBySymbol(symbol: string, limit = 50): Promise<EventIntelligenceRecord[]> {
+  const docs = await EventIntelligenceModel.find({ symbols: symbol.toUpperCase() }).sort({ timestamp: -1, importance: -1 }).limit(Math.max(1, Math.min(250, limit)));
+  return docs.map(serialize);
+}
+
+export async function listEventRecordsBySector(sector: string, limit = 50): Promise<EventIntelligenceRecord[]> {
+  const docs = await EventIntelligenceModel.find({ sectors: new RegExp(`^${sector}$`, 'i') }).sort({ timestamp: -1, importance: -1 }).limit(Math.max(1, Math.min(250, limit)));
+  return docs.map(serialize);
+}

--- a/server/src/features/eventIntelligence/storage/historicalSimilarity.service.ts
+++ b/server/src/features/eventIntelligence/storage/historicalSimilarity.service.ts
@@ -1,0 +1,71 @@
+import type { HistoricalSimilarity, MarketImpactEstimate, NormalizedMarketEvent } from '../types/eventTypes';
+import { DecisionJournalModel } from '../../intelligence/models/decisionJournal.model';
+import { TradeReportModel } from '../../intelligence/models/tradeReport.model';
+
+function numeric(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+export async function findHistoricalSimilarity(
+  event: NormalizedMarketEvent,
+  impact: MarketImpactEstimate
+): Promise<HistoricalSimilarity> {
+  try {
+    const symbols = impact.affectedSymbols.length ? impact.affectedSymbols : event.symbols;
+    const eventRegex = new RegExp(event.category.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+    const [decisions, tradeReports] = await Promise.all([
+      DecisionJournalModel.find({
+        $or: [
+          { 'context.symbol': { $in: symbols } },
+          { 'reasonSummary.humanSummary': eventRegex },
+          { 'reasonSummary.supportingReasons': eventRegex },
+        ],
+      }).sort({ timestamp: -1 }).limit(20),
+      TradeReportModel.find({
+        $or: [
+          { 'identity.underlying': { $in: symbols } },
+          { 'context.symbol': { $in: symbols } },
+        ],
+      }).sort({ createdAt: -1 }).limit(20),
+    ]);
+
+    const previousOutcomes = tradeReports.map((report: any) => ({
+      tradeId: report.tradeId ?? null,
+      outcome: numeric(report.performance?.realizedPnl) != null && report.performance.realizedPnl > 0 ? 'WIN' : numeric(report.performance?.realizedPnl) != null && report.performance.realizedPnl < 0 ? 'LOSS' : 'UNKNOWN',
+      returnPct: numeric(report.performance?.returnPct),
+    }));
+    const resolved = previousOutcomes.filter(outcome => outcome.outcome !== 'UNKNOWN');
+    const wins = resolved.filter(outcome => outcome.outcome === 'WIN').length;
+    const returns = previousOutcomes.map(outcome => outcome.returnPct).filter((value): value is number => value != null);
+    const holdTimes = tradeReports.map((report: any) => numeric(report.lifecycle?.holdTimeMinutes)).filter((value): value is number => value != null);
+    return {
+      eventId: event.id,
+      similarEvents: decisions.map((decision: any) => ({
+        decisionId: decision.decisionId,
+        timestamp: decision.timestamp instanceof Date ? decision.timestamp.toISOString() : String(decision.timestamp),
+        symbol: decision.context?.symbol ?? null,
+        contract: decision.context?.contract ?? null,
+        reason: decision.reasonSummary?.humanSummary ?? decision.decision?.humanReadableReasons?.[0] ?? 'Similar symbol or category context.',
+      })),
+      previousTrades: tradeReports.length,
+      previousOutcomes,
+      historicalWinRate: resolved.length ? Number((wins / resolved.length).toFixed(4)) : null,
+      averageHoldingTimeMinutes: holdTimes.length ? Number((holdTimes.reduce((sum, value) => sum + value, 0) / holdTimes.length).toFixed(2)) : null,
+      averageReturn: returns.length ? Number((returns.reduce((sum, value) => sum + value, 0) / returns.length).toFixed(4)) : null,
+      explanation: decisions.length || tradeReports.length
+        ? `Found ${decisions.length} related decisions and ${tradeReports.length} related trade reports by symbol/category.`
+        : 'No similar decision journal or trade report history was found.',
+    };
+  } catch (error) {
+    return {
+      eventId: event.id,
+      similarEvents: [],
+      previousTrades: 0,
+      previousOutcomes: [],
+      historicalWinRate: null,
+      averageHoldingTimeMinutes: null,
+      averageReturn: null,
+      explanation: `Historical lookup unavailable: ${(error as Error)?.message ?? 'unknown error'}.`,
+    };
+  }
+}

--- a/server/src/features/eventIntelligence/types/eventTypes.ts
+++ b/server/src/features/eventIntelligence/types/eventTypes.ts
@@ -1,0 +1,130 @@
+export const EVENT_CATEGORIES = [
+  'Geopolitical',
+  'Federal Reserve',
+  'Economic',
+  'Earnings',
+  'Guidance',
+  'Merger',
+  'Acquisition',
+  'SEC Filing',
+  'Insider Activity',
+  'Analyst Upgrade',
+  'Analyst Downgrade',
+  'Product Launch',
+  'Supply Chain',
+  'Commodity',
+  'Oil',
+  'Natural Disaster',
+  'Cybersecurity',
+  'Government Policy',
+  'Tariffs',
+  'Litigation',
+  'AI',
+  'Technology',
+  'Healthcare',
+  'Financial',
+  'Energy',
+  'Transportation',
+  'Consumer',
+  'Market Status',
+  'Corporate Action',
+  'News',
+] as const;
+
+export type EventCategory = (typeof EVENT_CATEGORIES)[number];
+export type EventSentimentLabel = 'bullish' | 'bearish' | 'neutral' | 'unknown';
+export type EventProvider =
+  | 'massive-news'
+  | 'massive-market-news'
+  | 'massive-sentiment'
+  | 'massive-market-status'
+  | 'massive-economic'
+  | 'massive-earnings'
+  | 'massive-corporate-actions';
+
+export type NormalizedMarketEvent = {
+  id: string;
+  provider: EventProvider;
+  timestamp: string;
+  title: string;
+  summary: string | null;
+  category: EventCategory;
+  sentiment: {
+    label: EventSentimentLabel;
+    score: number | null;
+    explanation: string | null;
+  };
+  symbols: string[];
+  sectors: string[];
+  confidence: number;
+  importance: number;
+  importanceExplanation: string;
+  source: string | null;
+  url: string | null;
+  raw: Record<string, unknown>;
+};
+
+export type MarketImpactEstimate = {
+  eventId: string;
+  potentialBullishImpact: string[];
+  potentialBearishImpact: string[];
+  affectedSymbols: string[];
+  affectedEtfs: string[];
+  affectedSectors: string[];
+  affectedCommodities: string[];
+  confidence: number;
+  importance: number;
+  explanation: string;
+};
+
+export type HistoricalSimilarity = {
+  eventId: string;
+  similarEvents: Array<{
+    decisionId: string;
+    timestamp: string;
+    symbol: string | null;
+    contract: string | null;
+    reason: string;
+  }>;
+  previousTrades: number;
+  previousOutcomes: Array<{ tradeId: string | null; outcome: string; returnPct: number | null }>;
+  historicalWinRate: number | null;
+  averageHoldingTimeMinutes: number | null;
+  averageReturn: number | null;
+  explanation: string;
+};
+
+export type DecisionEngineEventTrigger = {
+  eventId: string;
+  triggered: boolean;
+  status: 'TRIGGERED' | 'SKIPPED_LOW_IMPORTANCE' | 'SKIPPED_NO_AFFECTED_ASSETS' | 'FAILED';
+  triggeredAt: string | null;
+  importance: number;
+  confidence: number;
+  affectedAssets: string[];
+  supportingEvidence: string[];
+  decisionScanId: string | null;
+  error: string | null;
+};
+
+export type EventIntelligenceRecord = {
+  event: NormalizedMarketEvent;
+  impact: MarketImpactEstimate;
+  historicalSimilarity: HistoricalSimilarity;
+  decisionTrigger: DecisionEngineEventTrigger;
+  createdAt: string;
+};
+
+export type EventMarketContext = {
+  generatedAt: string;
+  highImportanceEvents: EventIntelligenceRecord[];
+  affectedSymbols: string[];
+  affectedEtfs: string[];
+  affectedSectors: string[];
+  sentiment: {
+    bullish: number;
+    bearish: number;
+    neutral: number;
+  };
+  latestTrigger: DecisionEngineEventTrigger | null;
+};

--- a/server/src/features/intelligence/intelligence.routes.ts
+++ b/server/src/features/intelligence/intelligence.routes.ts
@@ -39,6 +39,18 @@ import {
   listStrategyAnalytics,
   validateWindowType,
 } from './services/strategyAnalytics.service';
+import {
+  getConfidenceCalibration,
+  getEventPerformance,
+  getFedPerformance,
+  getHistoricalPerformance,
+  getLearningDataset,
+  getMarketRegimePerformance,
+  getOptionsFlowPerformance,
+  getSectorPerformance,
+  getStrategyScorecards,
+  getTradeReview,
+} from './services/learningPerformance.service';
 
 export const intelligenceRouter = Router();
 
@@ -127,6 +139,91 @@ intelligenceRouter.get('/analytics/date/:date', async (req, res) => {
       return;
     }
     res.json({ analytics });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+function limitFromQuery(value: unknown, fallback = 500): number {
+  const parsed = typeof value === 'string' ? Number(value) : fallback;
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+intelligenceRouter.get('/learning/trade-review', async (req, res) => {
+  try {
+    res.json(await getTradeReview(limitFromQuery(req.query.limit, 100)));
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+intelligenceRouter.get('/learning/confidence-calibration', async (req, res) => {
+  try {
+    res.json(await getConfidenceCalibration(limitFromQuery(req.query.limit)));
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+intelligenceRouter.get('/learning/strategy-scorecards', async (req, res) => {
+  try {
+    res.json(await getStrategyScorecards(limitFromQuery(req.query.limit)));
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+intelligenceRouter.get('/learning/dataset', async (req, res) => {
+  try {
+    res.json(await getLearningDataset(limitFromQuery(req.query.limit)));
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+intelligenceRouter.get('/performance/historical', async (req, res) => {
+  try {
+    res.json(await getHistoricalPerformance(limitFromQuery(req.query.limit)));
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+intelligenceRouter.get('/performance/market-regime', async (req, res) => {
+  try {
+    res.json(await getMarketRegimePerformance(limitFromQuery(req.query.limit)));
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+intelligenceRouter.get('/performance/event', async (req, res) => {
+  try {
+    res.json(await getEventPerformance(limitFromQuery(req.query.limit)));
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+intelligenceRouter.get('/performance/sector', async (req, res) => {
+  try {
+    res.json(await getSectorPerformance(limitFromQuery(req.query.limit)));
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+intelligenceRouter.get('/performance/fed', async (req, res) => {
+  try {
+    res.json(await getFedPerformance(limitFromQuery(req.query.limit)));
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+intelligenceRouter.get('/performance/options-flow', async (req, res) => {
+  try {
+    res.json(await getOptionsFlowPerformance(limitFromQuery(req.query.limit)));
   } catch (error) {
     sendError(res, error);
   }

--- a/server/src/features/intelligence/services/learningPerformance.service.ts
+++ b/server/src/features/intelligence/services/learningPerformance.service.ts
@@ -1,0 +1,200 @@
+import { DecisionJournalModel } from '../models/decisionJournal.model';
+import { TradeReportModel } from '../models/tradeReport.model';
+
+type Bucket = {
+  key: string;
+  label: string;
+  totalTrades: number;
+  wins: number;
+  losses: number;
+  breakeven: number;
+  winRate: number | null;
+  averageReturnPct: number | null;
+  netPnl: number | null;
+  sampleTradeIds: string[];
+};
+
+function finite(value: unknown): number | null {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function classifyTrade(report: any): 'WIN' | 'LOSS' | 'BREAKEVEN' {
+  const pnl = finite(report?.performance?.realizedPnl);
+  if (pnl == null || pnl === 0) return 'BREAKEVEN';
+  return pnl > 0 ? 'WIN' : 'LOSS';
+}
+
+function bucketReports(reports: any[], keyOf: (report: any) => string | null, labelOf = (key: string) => key): Bucket[] {
+  const buckets = new Map<string, any[]>();
+  for (const report of reports) {
+    const key = keyOf(report) ?? 'UNAVAILABLE';
+    const group = buckets.get(key) ?? [];
+    group.push(report);
+    buckets.set(key, group);
+  }
+  return [...buckets.entries()]
+    .map(([key, group]) => {
+      const wins = group.filter(report => classifyTrade(report) === 'WIN').length;
+      const losses = group.filter(report => classifyTrade(report) === 'LOSS').length;
+      const breakeven = group.length - wins - losses;
+      const returns = group.map(report => finite(report?.performance?.returnPct)).filter((value): value is number => value != null);
+      const pnls = group.map(report => finite(report?.performance?.realizedPnl)).filter((value): value is number => value != null);
+      return {
+        key,
+        label: labelOf(key),
+        totalTrades: group.length,
+        wins,
+        losses,
+        breakeven,
+        winRate: group.length ? wins / group.length : null,
+        averageReturnPct: returns.length ? returns.reduce((sum, value) => sum + value, 0) / returns.length : null,
+        netPnl: pnls.length ? pnls.reduce((sum, value) => sum + value, 0) : null,
+        sampleTradeIds: group.slice(0, 5).map(report => report.tradeId).filter(Boolean),
+      };
+    })
+    .sort((a, b) => b.totalTrades - a.totalTrades || String(a.key).localeCompare(String(b.key)));
+}
+
+async function recentTradeReports(limit = 500) {
+  return TradeReportModel.find({ status: 'GENERATED' })
+    .sort({ tradingDate: -1, createdAt: -1 })
+    .limit(Math.min(Math.max(limit, 1), 2000))
+    .lean();
+}
+
+export async function getTradeReview(limit = 100) {
+  const reports = await recentTradeReports(limit);
+  return {
+    generatedAt: new Date().toISOString(),
+    totalTrades: reports.length,
+    reviews: reports.map((report: any) => ({
+      tradeId: report.tradeId,
+      reportId: report.reportId,
+      tradingDate: report.tradingDate,
+      symbol: report.identity?.underlying ?? null,
+      contract: report.identity?.optionSymbol ?? null,
+      strategy: report.identity?.strategy ?? report.identity?.strategyVersionId ?? null,
+      outcome: classifyTrade(report),
+      returnPct: finite(report.performance?.returnPct),
+      realizedPnl: finite(report.performance?.realizedPnl),
+      confidence: finite(report.signal?.confidence),
+      overallGrade: report.grades?.overall?.grade ?? null,
+      lessons: report.lessons ?? { strengths: [], weaknesses: [], improvementSuggestions: [] },
+    })),
+  };
+}
+
+export async function getConfidenceCalibration(limit = 500) {
+  const reports = await recentTradeReports(limit);
+  const buckets = bucketReports(reports, report => {
+    const confidence = finite(report?.signal?.confidence);
+    if (confidence == null) return 'UNAVAILABLE';
+    if (confidence < 0.4) return '0.00-0.39';
+    if (confidence < 0.6) return '0.40-0.59';
+    if (confidence < 0.75) return '0.60-0.74';
+    if (confidence < 0.9) return '0.75-0.89';
+    return '0.90-1.00';
+  });
+  return {
+    generatedAt: new Date().toISOString(),
+    buckets,
+    explanation: 'Compares entry confidence bands with realized paper outcomes from persisted trade reports.',
+  };
+}
+
+export async function getStrategyScorecards(limit = 500) {
+  const reports = await recentTradeReports(limit);
+  return {
+    generatedAt: new Date().toISOString(),
+    scorecards: bucketReports(reports, report => report.identity?.strategy ?? report.identity?.strategyVersionId ?? null),
+  };
+}
+
+export async function getLearningDataset(limit = 500) {
+  const [reports, decisions] = await Promise.all([
+    recentTradeReports(limit),
+    DecisionJournalModel.find({})
+      .sort({ timestamp: -1 })
+      .limit(Math.min(Math.max(limit, 1), 2000))
+      .lean(),
+  ]);
+  return {
+    generatedAt: new Date().toISOString(),
+    tradeExamples: reports.map((report: any) => ({
+      tradeId: report.tradeId,
+      symbol: report.identity?.underlying ?? null,
+      strategy: report.identity?.strategy ?? report.identity?.strategyVersionId ?? null,
+      marketRegime: report.marketContext?.marketRegime ?? null,
+      eventIds: report.evidence?.eventIds ?? [],
+      confidence: finite(report.signal?.confidence),
+      flowScore: finite(report.signal?.flowScore),
+      riskApproved: report.signal?.riskApproved ?? null,
+      riskReasonCodes: report.signal?.riskReasonCodes ?? [],
+      outcome: classifyTrade(report),
+      returnPct: finite(report.performance?.returnPct),
+    })),
+    decisionExamples: decisions.map((decision: any) => ({
+      decisionId: decision.decisionId,
+      tradeId: decision.tradeId ?? null,
+      timestamp: decision.timestamp,
+      symbol: decision.context?.symbol ?? null,
+      strategy: decision.context?.strategy ?? null,
+      marketRegime: decision.context?.marketRegime ?? decision.evaluation?.marketRegime ?? null,
+      action: decision.decision?.decision ?? null,
+      approved: decision.decision?.approved ?? null,
+      reasonCodes: decision.decision?.reasonCodes ?? [],
+      confidence: finite(decision.evaluation?.confidence),
+    })),
+  };
+}
+
+export async function getHistoricalPerformance(limit = 500) {
+  const reports = await recentTradeReports(limit);
+  return {
+    generatedAt: new Date().toISOString(),
+    performance: bucketReports(reports, report => report.tradingDate ?? null),
+  };
+}
+
+export async function getMarketRegimePerformance(limit = 500) {
+  const reports = await recentTradeReports(limit);
+  return { generatedAt: new Date().toISOString(), performance: bucketReports(reports, report => report.marketContext?.marketRegime ?? null) };
+}
+
+export async function getEventPerformance(limit = 500) {
+  const reports = await recentTradeReports(limit);
+  const expanded = reports.flatMap((report: any) => (report.evidence?.eventIds ?? ['UNAVAILABLE']).map((eventId: string) => ({ ...report, eventId })));
+  return { generatedAt: new Date().toISOString(), performance: bucketReports(expanded, report => report.eventId ?? null) };
+}
+
+export async function getSectorPerformance(limit = 500) {
+  const reports = await recentTradeReports(limit);
+  return {
+    generatedAt: new Date().toISOString(),
+    performance: bucketReports(reports, report => String(report.marketContext?.sectorContext?.sector ?? report.marketContext?.sectorContext?.name ?? 'UNAVAILABLE')),
+  };
+}
+
+export async function getFedPerformance(limit = 500) {
+  const reports = await recentTradeReports(limit);
+  const fedReports = reports.filter((report: any) => {
+    const haystack = JSON.stringify([report.marketContext, report.lessons, report.evidence?.eventIds]).toLowerCase();
+    return haystack.includes('fed') || haystack.includes('fomc') || haystack.includes('federal reserve');
+  });
+  return { generatedAt: new Date().toISOString(), performance: bucketReports(fedReports, report => report.marketContext?.marketRegime ?? 'FED_EVENT') };
+}
+
+export async function getOptionsFlowPerformance(limit = 500) {
+  const reports = await recentTradeReports(limit);
+  return {
+    generatedAt: new Date().toISOString(),
+    performance: bucketReports(reports, report => {
+      const score = finite(report.signal?.flowScore);
+      if (score == null) return 'UNAVAILABLE';
+      if (score < 0.4) return 'WEAK_FLOW';
+      if (score < 0.7) return 'MODERATE_FLOW';
+      return 'STRONG_FLOW';
+    }),
+  };
+}

--- a/server/src/features/learning/analytics/eventAnalytics.service.ts
+++ b/server/src/features/learning/analytics/eventAnalytics.service.ts
@@ -1,0 +1,60 @@
+import { LearningTradeReviewModel } from '../storage/learningTradeReview.model';
+
+function finite(value: unknown): number | null {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function classifyEvent(review: any): string[] {
+  const text = JSON.stringify([
+    review.fedEvent,
+    review.newsEvent,
+    review.evidence?.eventIds,
+    review.entryReason,
+    review.exitReason,
+    review.whySucceeded,
+    review.whyFailed,
+  ]).toLowerCase();
+  const events = new Set<string>();
+  if (text.includes('fed') || text.includes('fomc') || text.includes('powell')) events.add('Fed');
+  if (text.includes('cpi')) events.add('CPI');
+  if (text.includes('ppi')) events.add('PPI');
+  if (text.includes('jobs') || text.includes('payroll')) events.add('Jobs');
+  if (text.includes('oil') || text.includes('crude') || text.includes('energy')) events.add('Oil');
+  if (text.includes('earnings')) events.add('Earnings');
+  if (text.includes('breaking') || text.includes('headline') || review.newsEvent === 'BREAKING_NEWS') events.add('Breaking News');
+  if (text.includes('sentiment')) events.add('Sentiment');
+  if (finite(review.evidenceScore) != null || text.includes('flow')) events.add('Options Flow');
+  if (!events.size) events.add('Unclassified');
+  return [...events];
+}
+
+export async function getLearningEventAnalytics() {
+  const reviews = await LearningTradeReviewModel.find({}).sort({ exitTimestamp: -1 }).lean();
+  const groups = new Map<string, typeof reviews>();
+  for (const review of reviews) {
+    for (const event of classifyEvent(review)) {
+      groups.set(event, [...(groups.get(event) ?? []), review]);
+    }
+  }
+  const events = [...groups.entries()].map(([event, group]) => {
+    const returns = group.map(review => finite(review.actualReturn)).filter((value): value is number => value != null);
+    const wins = group.filter(review => review.outcome === 'WIN' || review.outcome === 'PARTIAL_WIN').length;
+    const strategyCounts = new Map<string, number>();
+    for (const review of group) {
+      const strategy = review.winningStrategy ?? review.entryStrategy ?? 'UNAVAILABLE';
+      strategyCounts.set(strategy, (strategyCounts.get(strategy) ?? 0) + 1);
+    }
+    return {
+      event,
+      trades: group.length,
+      winRate: group.length ? wins / group.length : null,
+      averageReturn: returns.length ? returns.reduce((sum, value) => sum + value, 0) / returns.length : null,
+      topStrategies: [...strategyCounts.entries()]
+        .map(([strategy, trades]) => ({ strategy, trades }))
+        .sort((a, b) => b.trades - a.trades)
+        .slice(0, 5),
+    };
+  });
+  return { generatedAt: new Date().toISOString(), events: events.sort((a, b) => b.trades - a.trades) };
+}

--- a/server/src/features/learning/analytics/tradeReview.service.ts
+++ b/server/src/features/learning/analytics/tradeReview.service.ts
@@ -1,0 +1,267 @@
+import { DecisionJournalModel } from '../../intelligence/models/decisionJournal.model';
+import { TradeReportModel, type TradeReportDocument } from '../../intelligence/models/tradeReport.model';
+import { LearningDatasetModel } from '../storage/learningDataset.model';
+import { LearningTradeReviewModel, type LearningTradeReviewDocument } from '../storage/learningTradeReview.model';
+import type { LearningDatasetRecord, LearningOutcome, LearningTradeReview } from '../types/learningTypes';
+
+const REVIEW_SCHEMA_VERSION = 1;
+const DATASET_SCHEMA_VERSION = 1;
+const MAX_LIMIT = 2000;
+
+function finite(value: unknown): number | null {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function avg(values: Array<number | null | undefined>): number | null {
+  const filtered = values.filter((value): value is number => typeof value === 'number' && Number.isFinite(value));
+  return filtered.length ? filtered.reduce((sum, value) => sum + value, 0) / filtered.length : null;
+}
+
+function text(value: unknown): string {
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function includesAny(haystack: string, words: string[]): boolean {
+  const lower = haystack.toLowerCase();
+  return words.some(word => lower.includes(word));
+}
+
+function classifyOutcome(report: Pick<TradeReportDocument, 'performance'>): LearningOutcome {
+  const realizedPnl = finite(report.performance?.realizedPnl);
+  const actualReturn = finite(report.performance?.returnPct);
+  const basis = realizedPnl ?? actualReturn;
+  if (basis == null) return 'UNKNOWN';
+  if (basis > 0 && actualReturn != null && actualReturn < 0.5) return 'PARTIAL_WIN';
+  if (basis > 0) return 'WIN';
+  if (basis < 0) return 'LOSS';
+  return 'BREAKEVEN';
+}
+
+function deriveEventLabel(report: TradeReportDocument, kind: 'fed' | 'news'): string | null {
+  const haystack = text([report.evidence?.eventIds, report.marketContext, report.lessons, report.timeline]);
+  if (kind === 'fed' && includesAny(haystack, ['fed', 'fomc', 'federal reserve', 'powell'])) return 'FED';
+  if (kind === 'news' && includesAny(haystack, ['news', 'headline', 'breaking', 'earnings', 'cpi', 'ppi', 'jobs', 'oil'])) {
+    if (includesAny(haystack, ['cpi'])) return 'CPI';
+    if (includesAny(haystack, ['ppi'])) return 'PPI';
+    if (includesAny(haystack, ['jobs', 'payroll'])) return 'JOBS';
+    if (includesAny(haystack, ['oil', 'crude', 'energy'])) return 'OIL';
+    if (includesAny(haystack, ['earnings'])) return 'EARNINGS';
+    return 'BREAKING_NEWS';
+  }
+  return null;
+}
+
+function deriveSector(report: TradeReportDocument): string | null {
+  const sectorContext = report.marketContext?.sectorContext as Record<string, unknown> | null;
+  const candidate =
+    sectorContext?.sector ??
+    sectorContext?.name ??
+    sectorContext?.label ??
+    sectorContext?.symbol ??
+    null;
+  return typeof candidate === 'string' && candidate.trim() ? candidate : null;
+}
+
+function deriveEvidenceScore(report: TradeReportDocument): number | null {
+  return avg([
+    finite(report.signal?.flowScore),
+    finite(report.signal?.momentumScore),
+    finite(report.signal?.trendScore),
+    finite(report.signal?.selectedContractScore),
+  ]);
+}
+
+function firstReason(report: TradeReportDocument, fallback: string | null): string | null {
+  return (
+    report.grades?.entry?.reasons?.[0] ??
+    report.grades?.market?.reasons?.[0] ??
+    report.signal?.riskReasonCodes?.[0] ??
+    fallback
+  );
+}
+
+export function buildLearningTradeReview(report: TradeReportDocument): LearningTradeReview {
+  const outcome = classifyOutcome(report);
+  return {
+    reviewId: `learning-review:${report.reportId}:v${REVIEW_SCHEMA_VERSION}`,
+    schemaVersion: REVIEW_SCHEMA_VERSION,
+    sourceReportId: report.reportId,
+    sourceTradeId: report.tradeId,
+    generatedAt: new Date(),
+    entryTimestamp: report.lifecycle?.openedAt ?? null,
+    exitTimestamp: report.lifecycle?.closedAt ?? null,
+    entryStrategy: report.identity?.strategyVersionId ?? null,
+    winningStrategy: report.identity?.strategy ?? report.identity?.strategyVersionId ?? null,
+    marketRegime: report.marketContext?.marketRegime ?? report.marketContext?.trend ?? null,
+    fedEvent: deriveEventLabel(report, 'fed'),
+    newsEvent: deriveEventLabel(report, 'news'),
+    sector: deriveSector(report),
+    symbol: report.identity?.underlying ?? null,
+    contract: report.identity?.optionSymbol ?? null,
+    direction: report.identity?.direction ?? null,
+    confidence: finite(report.signal?.confidence),
+    evidenceScore: deriveEvidenceScore(report),
+    riskScore: finite(report.signal?.riskScore),
+    entryReason: firstReason(report, report.signal?.candidateStatus ?? null),
+    exitReason: report.lifecycle?.exitReason ?? report.grades?.exit?.reasons?.[0] ?? null,
+    maximumFavorableExcursion: finite(report.performance?.maxFavorableExcursion),
+    maximumAdverseExcursion: finite(report.performance?.maxAdverseExcursion),
+    holdingTimeMinutes: finite(report.lifecycle?.holdTimeMinutes),
+    expectedReturn: finite((report.execution?.entryIntent as Record<string, unknown> | null)?.estimatedReward),
+    actualReturn: finite(report.performance?.returnPct),
+    realizedPnl: finite(report.performance?.realizedPnl),
+    outcome,
+    win: outcome === 'WIN',
+    loss: outcome === 'LOSS',
+    partialWin: outcome === 'PARTIAL_WIN',
+    whySucceeded: report.lessons?.strengths ?? [],
+    whyFailed: report.lessons?.weaknesses ?? [],
+    whatCouldImprove: report.lessons?.improvementSuggestions ?? [],
+    evidence: {
+      eventIds: report.evidence?.eventIds ?? [],
+      positionId: report.evidence?.positionId ?? null,
+      riskDecisionId: report.evidence?.riskDecisionId ?? null,
+      tradeCandidateId: report.evidence?.tradeCandidateId ?? null,
+      contractSelectionId: report.evidence?.contractSelectionId ?? null,
+      universeEvaluationIds: report.evidence?.universeEvaluationIds ?? [],
+      tradeReportId: report.reportId,
+    },
+  };
+}
+
+export async function buildLearningDataset(report: TradeReportDocument): Promise<LearningDatasetRecord> {
+  const decision = await DecisionJournalModel.findOne({
+    $or: [{ tradeId: report.tradeId }, { reportId: report.reportId }],
+  })
+    .sort({ timestamp: -1 })
+    .lean();
+  const outcome = classifyOutcome(report);
+  return {
+    datasetId: `learning-dataset:${report.reportId}:v${DATASET_SCHEMA_VERSION}`,
+    schemaVersion: DATASET_SCHEMA_VERSION,
+    sourceReportId: report.reportId,
+    sourceTradeId: report.tradeId,
+    generatedAt: new Date(),
+    version: `learning-dataset-v${DATASET_SCHEMA_VERSION}`,
+    marketSnapshot: report.marketContext ?? null,
+    technicalIndicators: {
+      flowScore: report.signal?.flowScore ?? null,
+      momentumScore: report.signal?.momentumScore ?? null,
+      trendScore: report.signal?.trendScore ?? null,
+      greeks: report.greeks ?? null,
+    },
+    massiveData: {
+      liquidity: report.marketContext?.liquidity ?? null,
+      underlyingPriceAtSelection: report.marketContext?.underlyingPriceAtSelection ?? null,
+    },
+    news: { fedEvent: deriveEventLabel(report, 'fed'), newsEvent: deriveEventLabel(report, 'news'), eventIds: report.evidence?.eventIds ?? [] },
+    sentiment: report.marketContext?.sectorContext ?? null,
+    eventIntelligence: { eventIds: report.evidence?.eventIds ?? [] },
+    decisionIntelligence: decision ? {
+      decisionId: decision.decisionId,
+      action: decision.decision?.decision ?? null,
+      reasonCodes: decision.decision?.reasonCodes ?? [],
+      confidence: decision.evaluation?.confidence ?? null,
+    } : null,
+    strategyRankings: { strategy: report.identity?.strategy ?? null, strategyVersionId: report.identity?.strategyVersionId ?? null },
+    riskPackage: {
+      riskDecisionId: report.evidence?.riskDecisionId ?? null,
+      riskApproved: report.signal?.riskApproved ?? null,
+      riskScore: report.signal?.riskScore ?? null,
+      riskReasonCodes: report.signal?.riskReasonCodes ?? [],
+    },
+    lifecycle: report.lifecycle ?? null,
+    executionResult: report.execution ?? null,
+    tradeEvaluation: {
+      reportId: report.reportId,
+      grades: report.grades,
+      lessons: report.lessons,
+      warnings: report.warnings,
+    },
+    outcome: {
+      label: outcome,
+      actualReturn: finite(report.performance?.returnPct),
+      realizedPnl: finite(report.performance?.realizedPnl),
+    },
+  };
+}
+
+function limitValue(limit = 500): number {
+  return Math.min(Math.max(Number.isFinite(limit) ? limit : 500, 1), MAX_LIMIT);
+}
+
+export async function synchronizeLearningArtifacts(limit = 500): Promise<{ scanned: number; reviewsCreated: number; datasetsCreated: number }> {
+  const reports = await TradeReportModel.find({ status: 'GENERATED' })
+    .sort({ tradingDate: -1, createdAt: -1 })
+    .limit(limitValue(limit))
+    .lean();
+
+  let reviewsCreated = 0;
+  let datasetsCreated = 0;
+  for (const report of reports) {
+    const review = buildLearningTradeReview(report as TradeReportDocument);
+    try {
+      await LearningTradeReviewModel.create(review);
+      reviewsCreated += 1;
+    } catch (error: any) {
+      if (error?.code !== 11000) throw error;
+    }
+    const dataset = await buildLearningDataset(report as TradeReportDocument);
+    try {
+      await LearningDatasetModel.create(dataset);
+      datasetsCreated += 1;
+    } catch (error: any) {
+      if (error?.code !== 11000) throw error;
+    }
+  }
+
+  return { scanned: reports.length, reviewsCreated, datasetsCreated };
+}
+
+export async function getLearningStatus() {
+  const [completedTrades, reviews, datasets, latestReview] = await Promise.all([
+    TradeReportModel.countDocuments({ status: 'GENERATED' }),
+    LearningTradeReviewModel.countDocuments({}),
+    LearningDatasetModel.countDocuments({}),
+    LearningTradeReviewModel.findOne({}).sort({ generatedAt: -1 }).lean(),
+  ]);
+  const pendingReviews = Math.max(0, completedTrades - reviews);
+  const pendingDatasets = Math.max(0, completedTrades - datasets);
+  return {
+    status: pendingReviews || pendingDatasets ? 'LEARNING_PENDING' : 'CURRENT',
+    generatedAt: new Date().toISOString(),
+    completedTrades,
+    tradeReviews: reviews,
+    datasets,
+    pendingReviews,
+    pendingDatasets,
+    latestReviewAt: latestReview?.generatedAt ?? null,
+    explanation:
+      completedTrades === 0
+        ? 'No completed trade reports are available for learning yet.'
+        : pendingReviews || pendingDatasets
+          ? 'Learning has completed trade reports waiting for artifact generation.'
+          : 'Learning artifacts are current with completed trade reports.',
+  };
+}
+
+export async function listLearningTradeReviews(limit = 100): Promise<LearningTradeReviewDocument[]> {
+  return LearningTradeReviewModel.find({})
+    .sort({ exitTimestamp: -1, generatedAt: -1 })
+    .limit(limitValue(limit))
+    .lean();
+}
+
+export async function listLearningDatasets(limit = 100) {
+  return LearningDatasetModel.find({})
+    .sort({ generatedAt: -1 })
+    .limit(limitValue(limit))
+    .lean();
+}

--- a/server/src/features/learning/calibration/calibration.service.ts
+++ b/server/src/features/learning/calibration/calibration.service.ts
@@ -1,0 +1,51 @@
+import { LearningTradeReviewModel } from '../storage/learningTradeReview.model';
+
+function finite(value: unknown): number | null {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function band(confidence: number | null): string {
+  if (confidence == null) return 'UNAVAILABLE';
+  const normalized = confidence > 1 ? confidence / 100 : confidence;
+  if (normalized < 0.5) return '0-49%';
+  if (normalized < 0.65) return '50-64%';
+  if (normalized < 0.8) return '65-79%';
+  if (normalized < 0.9) return '80-89%';
+  return '90-100%';
+}
+
+function verdict(predicted: number | null, actual: number | null): 'Overconfident' | 'Underconfident' | 'Well calibrated' | 'Insufficient data' {
+  if (predicted == null || actual == null) return 'Insufficient data';
+  const error = predicted - actual;
+  if (Math.abs(error) <= 0.08) return 'Well calibrated';
+  return error > 0 ? 'Overconfident' : 'Underconfident';
+}
+
+export async function getLearningConfidenceCalibration() {
+  const reviews = await LearningTradeReviewModel.find({}).sort({ exitTimestamp: -1 }).lean();
+  const groups = new Map<string, typeof reviews>();
+  for (const review of reviews) {
+    const key = band(finite(review.confidence));
+    groups.set(key, [...(groups.get(key) ?? []), review]);
+  }
+  const buckets = [...groups.entries()].map(([confidenceBand, group]) => {
+    const predictedValues = group.map(review => {
+      const value = finite(review.confidence);
+      return value != null && value > 1 ? value / 100 : value;
+    }).filter((value): value is number => value != null);
+    const wins = group.filter(review => review.outcome === 'WIN' || review.outcome === 'PARTIAL_WIN').length;
+    const predictedConfidence = predictedValues.length ? predictedValues.reduce((sum, value) => sum + value, 0) / predictedValues.length : null;
+    const actualSuccessRate = group.length ? wins / group.length : null;
+    return {
+      confidenceBand,
+      totalTrades: group.length,
+      predictedConfidence,
+      actualSuccessRate,
+      historicalAccuracy: actualSuccessRate,
+      calibrationError: predictedConfidence != null && actualSuccessRate != null ? predictedConfidence - actualSuccessRate : null,
+      verdict: verdict(predictedConfidence, actualSuccessRate),
+    };
+  });
+  return { generatedAt: new Date().toISOString(), buckets };
+}

--- a/server/src/features/learning/controllers/learning.controller.ts
+++ b/server/src/features/learning/controllers/learning.controller.ts
@@ -1,0 +1,73 @@
+import type { NextFunction, Request, Response } from 'express';
+import {
+  getLearningStatus,
+  listLearningTradeReviews,
+} from '../analytics/tradeReview.service';
+import { getLearningConfidenceCalibration } from '../calibration/calibration.service';
+import { getLearningDatasets } from '../datasets/dataset.service';
+import { getLearningEventAnalytics } from '../analytics/eventAnalytics.service';
+import {
+  getLearningRegimeAnalytics,
+  getLearningStrategyScorecards,
+} from '../scorecards/scorecard.service';
+
+function limitFromQuery(value: unknown, fallback = 100): number {
+  const parsed = typeof value === 'string' ? Number(value) : fallback;
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export async function getStatus(_req: Request, res: Response, next: NextFunction) {
+  try {
+    res.json(await getLearningStatus());
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function getTrades(req: Request, res: Response, next: NextFunction) {
+  try {
+    res.json({ generatedAt: new Date().toISOString(), reviews: await listLearningTradeReviews(limitFromQuery(req.query.limit)) });
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function getScorecards(_req: Request, res: Response, next: NextFunction) {
+  try {
+    res.json(await getLearningStrategyScorecards());
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function getCalibration(_req: Request, res: Response, next: NextFunction) {
+  try {
+    res.json(await getLearningConfidenceCalibration());
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function getRegimes(_req: Request, res: Response, next: NextFunction) {
+  try {
+    res.json(await getLearningRegimeAnalytics());
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function getEvents(_req: Request, res: Response, next: NextFunction) {
+  try {
+    res.json(await getLearningEventAnalytics());
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function getDatasets(req: Request, res: Response, next: NextFunction) {
+  try {
+    res.json(await getLearningDatasets(limitFromQuery(req.query.limit)));
+  } catch (error) {
+    next(error);
+  }
+}

--- a/server/src/features/learning/datasets/dataset.service.ts
+++ b/server/src/features/learning/datasets/dataset.service.ts
@@ -1,0 +1,10 @@
+import { listLearningDatasets } from '../analytics/tradeReview.service';
+
+export async function getLearningDatasets(limit = 100) {
+  const datasets = await listLearningDatasets(limit);
+  return {
+    generatedAt: new Date().toISOString(),
+    schemaVersion: 1,
+    datasets,
+  };
+}

--- a/server/src/features/learning/index.ts
+++ b/server/src/features/learning/index.ts
@@ -1,0 +1,7 @@
+export { learningRouter } from './routes/learning.routes';
+export {
+  getLearningSchedulerStatus,
+  startLearningScheduler,
+  stopLearningScheduler,
+} from './scheduler/learningScheduler.service';
+export { synchronizeLearningArtifacts } from './analytics/tradeReview.service';

--- a/server/src/features/learning/journal/learningJournal.service.ts
+++ b/server/src/features/learning/journal/learningJournal.service.ts
@@ -1,0 +1,11 @@
+import { writeStructuredLog } from '../../../shared/logging/safeLogging';
+
+export function logLearningEvent(event: string, context: Record<string, unknown> = {}): void {
+  writeStructuredLog({
+    component: 'server',
+    module: 'learning-intelligence',
+    event,
+    severity: 'info',
+    context,
+  });
+}

--- a/server/src/features/learning/routes/learning.routes.ts
+++ b/server/src/features/learning/routes/learning.routes.ts
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+import {
+  getCalibration,
+  getDatasets,
+  getEvents,
+  getRegimes,
+  getScorecards,
+  getStatus,
+  getTrades,
+} from '../controllers/learning.controller';
+
+export const learningRouter = Router();
+
+learningRouter.get('/status', getStatus);
+learningRouter.get('/trades', getTrades);
+learningRouter.get('/scorecards', getScorecards);
+learningRouter.get('/calibration', getCalibration);
+learningRouter.get('/regimes', getRegimes);
+learningRouter.get('/events', getEvents);
+learningRouter.get('/datasets', getDatasets);

--- a/server/src/features/learning/scheduler/learningScheduler.service.ts
+++ b/server/src/features/learning/scheduler/learningScheduler.service.ts
@@ -1,0 +1,60 @@
+import mongoose from 'mongoose';
+import { synchronizeLearningArtifacts } from '../analytics/tradeReview.service';
+import { logLearningEvent } from '../journal/learningJournal.service';
+
+const DEFAULT_INTERVAL_MS = 15 * 60 * 1000;
+
+let timer: NodeJS.Timeout | null = null;
+let running = false;
+let lastSuccessfulRunAt: Date | null = null;
+let lastAttemptAt: Date | null = null;
+let lastError: string | null = null;
+
+function intervalMs(): number {
+  const configured = Number(process.env.LEARNING_SYNC_INTERVAL_MS);
+  return Number.isFinite(configured) && configured >= 60_000 ? configured : DEFAULT_INTERVAL_MS;
+}
+
+async function runOnce() {
+  if (running) return;
+  if (mongoose.connection.readyState !== 1) {
+    lastError = 'MongoDB disconnected';
+    return;
+  }
+  running = true;
+  lastAttemptAt = new Date();
+  try {
+    const result = await synchronizeLearningArtifacts(500);
+    lastSuccessfulRunAt = new Date();
+    lastError = null;
+    logLearningEvent('LEARNING_ARTIFACT_SYNC_COMPLETED', result);
+  } catch (error: any) {
+    lastError = error?.message ?? String(error);
+    logLearningEvent('LEARNING_ARTIFACT_SYNC_FAILED', { message: lastError });
+  } finally {
+    running = false;
+  }
+}
+
+export function startLearningScheduler(): void {
+  if (timer || process.env.LEARNING_SYNC_ENABLED === 'false') return;
+  void runOnce();
+  timer = setInterval(() => void runOnce(), intervalMs());
+}
+
+export function stopLearningScheduler(): void {
+  if (!timer) return;
+  clearInterval(timer);
+  timer = null;
+}
+
+export function getLearningSchedulerStatus() {
+  return {
+    running,
+    enabled: process.env.LEARNING_SYNC_ENABLED !== 'false',
+    intervalMs: intervalMs(),
+    lastSuccessfulRunAt,
+    lastAttemptAt,
+    lastError,
+  };
+}

--- a/server/src/features/learning/scorecards/scorecard.service.ts
+++ b/server/src/features/learning/scorecards/scorecard.service.ts
@@ -1,0 +1,131 @@
+import { LearningTradeReviewModel } from '../storage/learningTradeReview.model';
+import type { LearningWindow } from '../types/learningTypes';
+
+type ReviewLike = {
+  winningStrategy?: string | null;
+  marketRegime?: string | null;
+  sector?: string | null;
+  exitTimestamp?: Date | string | null;
+  outcome?: string | null;
+  actualReturn?: number | null;
+  realizedPnl?: number | null;
+  holdingTimeMinutes?: number | null;
+  riskScore?: number | null;
+  confidence?: number | null;
+};
+
+function finite(value: unknown): number | null {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function median(values: number[]): number | null {
+  if (!values.length) return null;
+  const sorted = values.slice().sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+function avg(values: number[]): number | null {
+  return values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : null;
+}
+
+function stddev(values: number[]): number | null {
+  const average = avg(values);
+  if (average == null || values.length < 2) return null;
+  const variance = values.reduce((sum, value) => sum + (value - average) ** 2, 0) / (values.length - 1);
+  return Math.sqrt(variance);
+}
+
+function maxDrawdown(returns: number[]): number | null {
+  if (!returns.length) return null;
+  let equity = 0;
+  let peak = 0;
+  let drawdown = 0;
+  for (const value of returns) {
+    equity += value;
+    peak = Math.max(peak, equity);
+    drawdown = Math.min(drawdown, equity - peak);
+  }
+  return drawdown;
+}
+
+function since(window: LearningWindow): Date | null {
+  const now = Date.now();
+  if (window === 'LAST_30_DAYS') return new Date(now - 30 * 24 * 60 * 60 * 1000);
+  if (window === 'LAST_90_DAYS') return new Date(now - 90 * 24 * 60 * 60 * 1000);
+  return null;
+}
+
+function summarize(group: ReviewLike[], key: string, window: LearningWindow) {
+  const returns = group.map(item => finite(item.actualReturn)).filter((value): value is number => value != null);
+  const risks = group.map(item => finite(item.riskScore)).filter((value): value is number => value != null);
+  const holds = group.map(item => finite(item.holdingTimeMinutes)).filter((value): value is number => value != null);
+  const wins = group.filter(item => item.outcome === 'WIN' || item.outcome === 'PARTIAL_WIN').length;
+  const losses = group.filter(item => item.outcome === 'LOSS').length;
+  const largestWinner = returns.length ? Math.max(...returns) : null;
+  const largestLoser = returns.length ? Math.min(...returns) : null;
+  const volatility = stddev(returns);
+  const averageReturn = avg(returns);
+  return {
+    key,
+    window,
+    totalTrades: group.length,
+    wins,
+    losses,
+    winRate: group.length ? wins / group.length : null,
+    averageReturn,
+    medianReturn: median(returns),
+    averageHoldTimeMinutes: avg(holds),
+    averageRisk: avg(risks),
+    largestWinner,
+    largestLoser,
+    sharpe: averageReturn != null && volatility && volatility > 0 ? averageReturn / volatility : null,
+    maxDrawdown: maxDrawdown(returns),
+  };
+}
+
+async function reviewsForWindow(window: LearningWindow) {
+  const start = since(window);
+  const query = start ? { exitTimestamp: { $gte: start } } : {};
+  return LearningTradeReviewModel.find(query).sort({ exitTimestamp: 1 }).lean();
+}
+
+export async function getLearningStrategyScorecards() {
+  const windows: LearningWindow[] = ['LAST_30_DAYS', 'LAST_90_DAYS', 'LIFETIME'];
+  const results = await Promise.all(windows.map(async window => {
+    const reviews = await reviewsForWindow(window);
+    const byStrategy = new Map<string, ReviewLike[]>();
+    for (const review of reviews) {
+      const key = review.winningStrategy ?? review.entryStrategy ?? 'UNAVAILABLE';
+      byStrategy.set(key, [...(byStrategy.get(key) ?? []), review]);
+    }
+    return [...byStrategy.entries()]
+      .map(([key, group]) => summarize(group, key, window))
+      .sort((a, b) => (b.winRate ?? -1) - (a.winRate ?? -1) || b.totalTrades - a.totalTrades);
+  }));
+  return { generatedAt: new Date().toISOString(), scorecards: results.flat() };
+}
+
+export async function getLearningRegimeAnalytics() {
+  const reviews = await LearningTradeReviewModel.find({}).sort({ exitTimestamp: -1 }).lean();
+  const groups = new Map<string, ReviewLike[]>();
+  for (const review of reviews) {
+    const keys = new Set([review.marketRegime ?? 'UNAVAILABLE']);
+    const regimeText = `${review.marketRegime ?? ''} ${review.newsEvent ?? ''} ${review.fedEvent ?? ''}`.toLowerCase();
+    if (regimeText.includes('trend')) keys.add('TRENDING');
+    if (regimeText.includes('range')) keys.add('RANGE');
+    if (regimeText.includes('high vol')) keys.add('HIGH_VOLATILITY');
+    if (regimeText.includes('low vol')) keys.add('LOW_VOLATILITY');
+    if (regimeText.includes('risk on')) keys.add('RISK_ON');
+    if (regimeText.includes('risk off')) keys.add('RISK_OFF');
+    if (review.newsEvent) keys.add('NEWS_DRIVEN');
+    if (review.fedEvent) keys.add('FED');
+    if (`${review.sector ?? ''}`.toLowerCase().includes('energy')) keys.add('ENERGY_ROTATION');
+    for (const key of keys) groups.set(key, [...(groups.get(key) ?? []), review]);
+  }
+  return {
+    generatedAt: new Date().toISOString(),
+    regimes: [...groups.entries()].map(([key, group]) => summarize(group, key, 'LIFETIME')).sort((a, b) => b.totalTrades - a.totalTrades),
+  };
+}

--- a/server/src/features/learning/storage/learningDataset.model.ts
+++ b/server/src/features/learning/storage/learningDataset.model.ts
@@ -1,0 +1,50 @@
+import mongoose, { Schema } from 'mongoose';
+import type { LearningDatasetRecord } from '../types/learningTypes';
+
+export type LearningDatasetDocument = LearningDatasetRecord & {
+  _id?: unknown;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+const LearningDatasetSchema = new Schema<LearningDatasetDocument>(
+  {
+    datasetId: { type: String, required: true, unique: true, index: true },
+    schemaVersion: { type: Number, required: true, default: 1 },
+    sourceReportId: { type: String, required: true, index: true },
+    sourceTradeId: { type: String, required: true, index: true },
+    generatedAt: { type: Date, required: true, default: () => new Date() },
+    version: { type: String, required: true, default: 'learning-dataset-v1' },
+    marketSnapshot: { type: Schema.Types.Mixed, default: null },
+    technicalIndicators: { type: Schema.Types.Mixed, default: null },
+    massiveData: { type: Schema.Types.Mixed, default: null },
+    news: { type: Schema.Types.Mixed, default: null },
+    sentiment: { type: Schema.Types.Mixed, default: null },
+    eventIntelligence: { type: Schema.Types.Mixed, default: null },
+    decisionIntelligence: { type: Schema.Types.Mixed, default: null },
+    strategyRankings: { type: Schema.Types.Mixed, default: null },
+    riskPackage: { type: Schema.Types.Mixed, default: null },
+    lifecycle: { type: Schema.Types.Mixed, default: null },
+    executionResult: { type: Schema.Types.Mixed, default: null },
+    tradeEvaluation: { type: Schema.Types.Mixed, default: null },
+    outcome: {
+      label: { type: String, enum: ['WIN', 'LOSS', 'PARTIAL_WIN', 'BREAKEVEN', 'UNKNOWN'], required: true },
+      actualReturn: { type: Number, default: null },
+      realizedPnl: { type: Number, default: null },
+    },
+  },
+  { timestamps: true, collection: 'learning_datasets' }
+);
+
+LearningDatasetSchema.pre('save', async function preventMutation() {
+  if (this.isNew || !this.isModified()) return;
+  throw new Error('LEARNING_DATASET_APPEND_ONLY');
+});
+
+LearningDatasetSchema.pre(['findOneAndUpdate', 'updateOne', 'updateMany'], function preventQueryMutation() {
+  this.setQuery({ $and: [this.getQuery(), { _id: null }] });
+});
+
+export const LearningDatasetModel =
+  (mongoose.models.LearningDataset as mongoose.Model<LearningDatasetDocument>) ||
+  mongoose.model<LearningDatasetDocument>('LearningDataset', LearningDatasetSchema);

--- a/server/src/features/learning/storage/learningTradeReview.model.ts
+++ b/server/src/features/learning/storage/learningTradeReview.model.ts
@@ -1,0 +1,74 @@
+import mongoose, { Schema } from 'mongoose';
+import type { LearningTradeReview } from '../types/learningTypes';
+
+export type LearningTradeReviewDocument = LearningTradeReview & {
+  _id?: unknown;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+const LearningTradeReviewSchema = new Schema<LearningTradeReviewDocument>(
+  {
+    reviewId: { type: String, required: true, unique: true, index: true },
+    schemaVersion: { type: Number, required: true, default: 1 },
+    sourceReportId: { type: String, required: true, index: true },
+    sourceTradeId: { type: String, required: true, index: true },
+    generatedAt: { type: Date, required: true, default: () => new Date() },
+    entryTimestamp: { type: Date, default: null },
+    exitTimestamp: { type: Date, default: null, index: true },
+    entryStrategy: { type: String, default: null, index: true },
+    winningStrategy: { type: String, default: null, index: true },
+    marketRegime: { type: String, default: null, index: true },
+    fedEvent: { type: String, default: null, index: true },
+    newsEvent: { type: String, default: null },
+    sector: { type: String, default: null, index: true },
+    symbol: { type: String, default: null, index: true },
+    contract: { type: String, default: null },
+    direction: { type: String, default: null },
+    confidence: { type: Number, default: null },
+    evidenceScore: { type: Number, default: null },
+    riskScore: { type: Number, default: null },
+    entryReason: { type: String, default: null },
+    exitReason: { type: String, default: null },
+    maximumFavorableExcursion: { type: Number, default: null },
+    maximumAdverseExcursion: { type: Number, default: null },
+    holdingTimeMinutes: { type: Number, default: null },
+    expectedReturn: { type: Number, default: null },
+    actualReturn: { type: Number, default: null },
+    realizedPnl: { type: Number, default: null },
+    outcome: { type: String, enum: ['WIN', 'LOSS', 'PARTIAL_WIN', 'BREAKEVEN', 'UNKNOWN'], required: true, index: true },
+    win: { type: Boolean, required: true, default: false },
+    loss: { type: Boolean, required: true, default: false },
+    partialWin: { type: Boolean, required: true, default: false },
+    whySucceeded: { type: [String], required: true, default: [] },
+    whyFailed: { type: [String], required: true, default: [] },
+    whatCouldImprove: { type: [String], required: true, default: [] },
+    evidence: {
+      eventIds: { type: [String], required: true, default: [] },
+      positionId: { type: String, default: null },
+      riskDecisionId: { type: String, default: null },
+      tradeCandidateId: { type: String, default: null },
+      contractSelectionId: { type: String, default: null },
+      universeEvaluationIds: { type: [String], required: true, default: [] },
+      tradeReportId: { type: String, required: true },
+    },
+  },
+  { timestamps: true, collection: 'learning_trade_reviews' }
+);
+
+LearningTradeReviewSchema.index({ winningStrategy: 1, exitTimestamp: -1 });
+LearningTradeReviewSchema.index({ marketRegime: 1, exitTimestamp: -1 });
+LearningTradeReviewSchema.index({ sector: 1, exitTimestamp: -1 });
+
+LearningTradeReviewSchema.pre('save', async function preventMutation() {
+  if (this.isNew || !this.isModified()) return;
+  throw new Error('LEARNING_TRADE_REVIEW_APPEND_ONLY');
+});
+
+LearningTradeReviewSchema.pre(['findOneAndUpdate', 'updateOne', 'updateMany'], function preventQueryMutation() {
+  this.setQuery({ $and: [this.getQuery(), { _id: null }] });
+});
+
+export const LearningTradeReviewModel =
+  (mongoose.models.LearningTradeReview as mongoose.Model<LearningTradeReviewDocument>) ||
+  mongoose.model<LearningTradeReviewDocument>('LearningTradeReview', LearningTradeReviewSchema);

--- a/server/src/features/learning/types/learningTypes.ts
+++ b/server/src/features/learning/types/learningTypes.ts
@@ -1,0 +1,75 @@
+export type LearningOutcome = 'WIN' | 'LOSS' | 'PARTIAL_WIN' | 'BREAKEVEN' | 'UNKNOWN';
+
+export type LearningWindow = 'LAST_30_DAYS' | 'LAST_90_DAYS' | 'LIFETIME';
+
+export type LearningTradeReview = {
+  reviewId: string;
+  schemaVersion: number;
+  sourceReportId: string;
+  sourceTradeId: string;
+  generatedAt: Date;
+  entryTimestamp: Date | null;
+  exitTimestamp: Date | null;
+  entryStrategy: string | null;
+  winningStrategy: string | null;
+  marketRegime: string | null;
+  fedEvent: string | null;
+  newsEvent: string | null;
+  sector: string | null;
+  symbol: string | null;
+  contract: string | null;
+  direction: string | null;
+  confidence: number | null;
+  evidenceScore: number | null;
+  riskScore: number | null;
+  entryReason: string | null;
+  exitReason: string | null;
+  maximumFavorableExcursion: number | null;
+  maximumAdverseExcursion: number | null;
+  holdingTimeMinutes: number | null;
+  expectedReturn: number | null;
+  actualReturn: number | null;
+  realizedPnl: number | null;
+  outcome: LearningOutcome;
+  win: boolean;
+  loss: boolean;
+  partialWin: boolean;
+  whySucceeded: string[];
+  whyFailed: string[];
+  whatCouldImprove: string[];
+  evidence: {
+    eventIds: string[];
+    positionId: string | null;
+    riskDecisionId: string | null;
+    tradeCandidateId: string | null;
+    contractSelectionId: string | null;
+    universeEvaluationIds: string[];
+    tradeReportId: string;
+  };
+};
+
+export type LearningDatasetRecord = {
+  datasetId: string;
+  schemaVersion: number;
+  sourceReportId: string;
+  sourceTradeId: string;
+  generatedAt: Date;
+  version: string;
+  marketSnapshot: Record<string, unknown> | null;
+  technicalIndicators: Record<string, unknown> | null;
+  massiveData: Record<string, unknown> | null;
+  news: Record<string, unknown> | null;
+  sentiment: Record<string, unknown> | null;
+  eventIntelligence: Record<string, unknown> | null;
+  decisionIntelligence: Record<string, unknown> | null;
+  strategyRankings: Record<string, unknown> | null;
+  riskPackage: Record<string, unknown> | null;
+  lifecycle: Record<string, unknown> | null;
+  executionResult: Record<string, unknown> | null;
+  tradeEvaluation: Record<string, unknown> | null;
+  outcome: {
+    label: LearningOutcome;
+    actualReturn: number | null;
+    realizedPnl: number | null;
+  };
+};

--- a/server/src/features/riskEngine/approval/riskApproval.service.ts
+++ b/server/src/features/riskEngine/approval/riskApproval.service.ts
@@ -1,0 +1,269 @@
+import { randomUUID } from 'crypto';
+import { estimateGreekImpact, normalizeGreeks } from '../greeks/greeks.service';
+import { getRiskRuleSet, RISK_REASON_EXPLANATIONS, riskApprovalRequired, riskEngineEnabled } from '../limits/riskRules.service';
+import { sectorExposureRatio } from '../portfolio/riskPortfolio.service';
+import { estimateCorrelationRisk } from '../correlation/correlation.service';
+import { calculatePositionSize } from '../positionSizing/positionSizing.service';
+import type {
+  ApprovalPackage,
+  CorrelationResult,
+  RiskCheck,
+  RiskPortfolioSnapshot,
+  RiskReasonCode,
+  RiskRecommendationInput,
+  RiskRuleSet,
+} from '../types/riskTypes';
+
+function pass(explanation: string, metrics: RiskCheck['supportingMetrics'] = {}): RiskCheck {
+  return { code: 'PASSED', passed: true, explanation, supportingMetrics: metrics, suggestedImprovement: null };
+}
+
+function fail(
+  code: RiskReasonCode,
+  metrics: RiskCheck['supportingMetrics'],
+  suggestedImprovement: string
+): RiskCheck {
+  return {
+    code,
+    passed: false,
+    explanation: RISK_REASON_EXPLANATIONS[code],
+    supportingMetrics: metrics,
+    suggestedImprovement,
+  };
+}
+
+function isMarketOpen(status: string): boolean {
+  return ['open', 'OPEN', 'regular', 'REGULAR'].includes(status);
+}
+
+function buildReason(check: RiskCheck): ApprovalPackage['reasons'][number] | null {
+  if (check.passed || check.code === 'PASSED') return null;
+  return {
+    code: check.code,
+    explanation: check.explanation,
+    supportingMetrics: check.supportingMetrics,
+    suggestedImprovement: check.suggestedImprovement,
+  };
+}
+
+function validateLiquidity(input: RiskRecommendationInput, rules: RiskRuleSet): RiskCheck {
+  const liquidity = input.contract?.liquidity;
+  if (!liquidity) {
+    return fail('MISSING_LIQUIDITY_DATA', {}, 'Attach bid, ask, spread, volume, open interest, and IV to the recommendation package.');
+  }
+  if (liquidity.bid == null || liquidity.bid <= 0) {
+    return fail('LOW_LIQUIDITY', { bid: liquidity.bid }, 'Wait for a live bid before requesting risk approval.');
+  }
+  if (liquidity.ask == null || liquidity.ask <= 0) {
+    return fail('LOW_LIQUIDITY', { ask: liquidity.ask }, 'Wait for a live ask before requesting risk approval.');
+  }
+  if (liquidity.spreadPct == null || liquidity.spreadPct > rules.maximumSpreadPct) {
+    return fail(
+      'HIGH_SPREAD',
+      { spreadPct: liquidity.spreadPct, maximumSpreadPct: rules.maximumSpreadPct },
+      'Use a tighter contract or wait for the spread to narrow.'
+    );
+  }
+  if (liquidity.volume == null || liquidity.volume < rules.minimumVolume) {
+    return fail('LOW_LIQUIDITY', { volume: liquidity.volume, minimumVolume: rules.minimumVolume }, 'Use a contract with higher same-day volume.');
+  }
+  if (liquidity.openInterest == null || liquidity.openInterest < rules.minimumOpenInterest) {
+    return fail(
+      'LOW_LIQUIDITY',
+      { openInterest: liquidity.openInterest, minimumOpenInterest: rules.minimumOpenInterest },
+      'Use a contract with stronger open interest.'
+    );
+  }
+  if (liquidity.impliedVolatility != null && liquidity.impliedVolatility > rules.maximumIv) {
+    return fail('HIGH_IV', { impliedVolatility: liquidity.impliedVolatility, maximumIv: rules.maximumIv }, 'Wait for IV to normalize or choose a lower-IV structure.');
+  }
+  return pass('Liquidity metrics satisfy bid, ask, spread, volume, open interest, and IV limits.', {
+    spreadPct: liquidity.spreadPct,
+    volume: liquidity.volume,
+    openInterest: liquidity.openInterest,
+  });
+}
+
+function validateGreeks(
+  input: RiskRecommendationInput,
+  portfolio: RiskPortfolioSnapshot,
+  rules: RiskRuleSet,
+  contracts: number
+): RiskCheck {
+  const next = estimateGreekImpact(portfolio.greeks, normalizeGreeks(input.contract?.greeks), contracts);
+  if (next.delta != null && Math.abs(next.delta) > rules.maximumDelta) {
+    return fail('MAX_DELTA', { portfolioDelta: next.delta, maximumDelta: rules.maximumDelta }, 'Reduce size or use a hedge with lower directional exposure.');
+  }
+  if (next.gamma != null && Math.abs(next.gamma) > rules.maximumGamma) {
+    return fail('MAX_GAMMA', { portfolioGamma: next.gamma, maximumGamma: rules.maximumGamma }, 'Reduce size or choose a lower-gamma contract.');
+  }
+  if (next.theta != null && Math.abs(next.theta) > rules.maximumTheta) {
+    return fail('MAX_THETA', { portfolioTheta: next.theta, maximumTheta: rules.maximumTheta }, 'Reduce theta decay or select a farther-dated contract.');
+  }
+  if (next.vega != null && Math.abs(next.vega) > rules.maximumVega) {
+    return fail('MAX_VEGA', { portfolioVega: next.vega, maximumVega: rules.maximumVega }, 'Reduce volatility exposure before approval.');
+  }
+  return pass('Portfolio Greeks remain inside configured limits after the proposed size.', {
+    delta: next.delta,
+    gamma: next.gamma,
+    theta: next.theta,
+    vega: next.vega,
+  });
+}
+
+function validateBuyingPower(portfolio: RiskPortfolioSnapshot, allocation: number): RiskCheck {
+  if (portfolio.buyingPower == null) {
+    return pass('Buying power was not available from persisted state; approval remains limited by capital and risk rules.', {
+      buyingPowerKnown: false,
+      allocation,
+    });
+  }
+  if (allocation > portfolio.buyingPower) {
+    return fail(
+      'INSUFFICIENT_BUYING_POWER',
+      { buyingPower: portfolio.buyingPower, allocation },
+      'Reduce position size or free buying power before requesting approval.'
+    );
+  }
+  return pass('Buying power covers the proposed allocation.', { buyingPower: portfolio.buyingPower, allocation });
+}
+
+function validateCorrelation(correlation: CorrelationResult, rules: RiskRuleSet): RiskCheck {
+  if (correlation.score > rules.maximumCorrelation) {
+    return fail(
+      'HIGH_CORRELATION',
+      { correlationScore: correlation.score, maximumCorrelation: rules.maximumCorrelation, symbols: correlation.correlatedSymbols.join(',') },
+      'Reduce size or avoid adding another position in the same correlation cluster.'
+    );
+  }
+  return pass(correlation.explanation, { correlationScore: correlation.score });
+}
+
+function validateDailyBudget(portfolio: RiskPortfolioSnapshot, allocation: number, rules: RiskRuleSet): RiskCheck {
+  if (portfolio.riskBudget.remainingRiskBudget <= 0 || allocation > portfolio.riskBudget.remainingRiskBudget) {
+    return fail(
+      'MAX_DAILY_LOSS',
+      { remainingRiskBudget: portfolio.riskBudget.remainingRiskBudget, allocation, maximumDailyLoss: rules.maximumDailyLoss },
+      'Wait for the next trading session or reduce risk below the remaining daily budget.'
+    );
+  }
+  return pass('Daily risk budget can absorb the proposed allocation.', {
+    remainingRiskBudget: portfolio.riskBudget.remainingRiskBudget,
+    allocation,
+  });
+}
+
+function validateRecommendation(input: RiskRecommendationInput, rules: RiskRuleSet): RiskCheck[] {
+  const checks: RiskCheck[] = [];
+  if (!riskEngineEnabled()) {
+    checks.push(fail('NO_ACTIONABLE_RECOMMENDATION', { riskEngineEnabled: false }, 'Enable RISK_ENGINE_ENABLED before approving risk.'));
+  }
+  if (input.recommendation.action !== 'BUY') {
+    checks.push(
+      fail(
+        'NO_ACTIONABLE_RECOMMENDATION',
+        { action: input.recommendation.action },
+        'Only actionable BUY recommendations can receive execution approval.'
+      )
+    );
+  }
+  if (input.confidence < rules.minimumConfidence) {
+    checks.push(fail('LOW_CONFIDENCE', { confidence: input.confidence, minimumConfidence: rules.minimumConfidence }, 'Wait for stronger evidence or more confirming strategies.'));
+  }
+  if (!isMarketOpen(input.marketStatus)) {
+    checks.push(fail('MARKET_CLOSED', { marketStatus: input.marketStatus }, 'Request approval only while the relevant market is open.'));
+  }
+  const lockout = input.eventContext.latestEvents.find(event => event.importance >= rules.newsLockoutImportance);
+  if (lockout) {
+    checks.push(
+      fail(
+        'NEWS_LOCKOUT',
+        { event: lockout.title, importance: lockout.importance, lockoutThreshold: rules.newsLockoutImportance },
+        'Wait for event risk to settle or lower the news lockout threshold by rule version.'
+      )
+    );
+  }
+  return checks;
+}
+
+export function evaluateRiskApproval(
+  input: RiskRecommendationInput,
+  portfolio: RiskPortfolioSnapshot,
+  now = new Date()
+): ApprovalPackage {
+  const rules = getRiskRuleSet(now);
+  const sizing = calculatePositionSize(input, portfolio, rules);
+  const correlationRisk = estimateCorrelationRisk(input, portfolio);
+  const liquidityRisk = validateLiquidity(input, rules);
+  const greekRisk = validateGreeks(input, portfolio, rules, sizing.suggestedContracts);
+  const buyingPowerRisk = validateBuyingPower(portfolio, sizing.capitalAllocation);
+  const checks: RiskCheck[] = [
+    ...validateRecommendation(input, rules),
+    liquidityRisk,
+    greekRisk,
+    buyingPowerRisk,
+    validateCorrelation(correlationRisk, rules),
+    validateDailyBudget(portfolio, sizing.capitalAllocation, rules),
+  ];
+
+  if (sizing.suggestedContracts <= 0) {
+    checks.push(
+      fail(
+        'MAX_POSITION_SIZE',
+        { suggestedContracts: sizing.suggestedContracts, dollarRisk: sizing.dollarRisk },
+        'Increase available risk budget or reduce unit contract risk.'
+      )
+    );
+  }
+  if (sizing.suggestedContracts > rules.maximumContracts || sizing.dollarRisk > rules.maximumDollarRisk) {
+    checks.push(
+      fail(
+        'MAX_DOLLAR_RISK',
+        { suggestedContracts: sizing.suggestedContracts, dollarRisk: sizing.dollarRisk, maximumDollarRisk: rules.maximumDollarRisk },
+        'Reduce requested contracts below configured dollar risk.'
+      )
+    );
+  }
+  if (portfolio.exposure.currentOpenTrades >= rules.maximumOpenTrades) {
+    checks.push(
+      fail(
+        'MAX_OPEN_TRADES',
+        { currentOpenTrades: portfolio.exposure.currentOpenTrades, maximumOpenTrades: rules.maximumOpenTrades },
+        'Close or reduce existing positions before opening another trade.'
+      )
+    );
+  }
+  const sectorRatio = sectorExposureRatio(portfolio, input.sector, sizing.capitalAllocation);
+  if (sectorRatio > rules.maximumSectorExposurePct) {
+    checks.push(
+      fail(
+        'MAX_SECTOR_EXPOSURE',
+        { sector: input.sector, sectorExposurePct: Number(sectorRatio.toFixed(4)), maximumSectorExposurePct: rules.maximumSectorExposurePct },
+        'Reduce size or avoid adding more exposure to this sector.'
+      )
+    );
+  }
+
+  const reasons = checks.map(buildReason).filter(Boolean) as ApprovalPackage['reasons'];
+  const approved = riskApprovalRequired() ? reasons.length === 0 : reasons.every(reason => reason.code === 'NO_ACTIONABLE_RECOMMENDATION');
+  return {
+    approved,
+    status: approved ? 'APPROVE' : 'REJECT',
+    approvalId: randomUUID(),
+    recommendationId: input.recommendationId,
+    suggestedPositionSize: sizing,
+    portfolioRisk: portfolio.riskBudget,
+    sectorExposure: portfolio.exposure.sectorExposure,
+    correlationRisk,
+    liquidityRisk,
+    greekRisk,
+    buyingPowerRisk,
+    remainingRiskBudget: Math.max(0, Number((portfolio.riskBudget.remainingRiskBudget - sizing.capitalAllocation).toFixed(2))),
+    reasons,
+    warnings: [
+      ...(input.contract?.estimatedUnitRisk == null ? ['Contract unit risk was not supplied; configurable default risk was used for sizing.'] : []),
+      ...(portfolio.buyingPower == null ? ['Buying power is unavailable in persisted state; live broker buying power was not queried by this read-side engine.'] : []),
+    ],
+    timestamp: now.toISOString(),
+  };
+}

--- a/server/src/features/riskEngine/controllers/riskEngine.service.ts
+++ b/server/src/features/riskEngine/controllers/riskEngine.service.ts
@@ -1,0 +1,95 @@
+import { getLatestStrategyRun } from '../../strategyOrchestrator/controllers/orchestrator.service';
+import type { StrategyOrchestratorRun } from '../../strategyOrchestrator/types/orchestratorTypes';
+import { evaluateRiskApproval } from '../approval/riskApproval.service';
+import { getRiskRuleSet } from '../limits/riskRules.service';
+import { buildRiskPortfolioSnapshot } from '../portfolio/riskPortfolio.service';
+import { appendRiskJournalRecord, getLatestRiskApproval, listRiskApprovals } from '../journal/riskJournal.service';
+import type { ApprovalPackage, RiskJournalRecord, RiskRecommendationInput } from '../types/riskTypes';
+
+function directionFromRun(run: StrategyOrchestratorRun): RiskRecommendationInput['direction'] {
+  const winner = run.strategiesEvaluated.find(strategy => strategy.strategyId === run.winner?.strategyId);
+  return winner?.direction ?? 'NEUTRAL';
+}
+
+function expectedReturnFromRun(run: StrategyOrchestratorRun): number {
+  const winner = run.strategiesEvaluated.find(strategy => strategy.strategyId === run.winner?.strategyId);
+  return winner?.expectedReturn ?? 0;
+}
+
+function sectorFromRun(run: StrategyOrchestratorRun): string | null {
+  const symbol = run.decisionEngineContext.bestOpportunity?.symbol;
+  const sectorFromEvent = run.eventContext.latestEvents
+    .find(event => symbol && event.affectedSymbols.includes(symbol))
+    ?.affectedSectors?.[0];
+  return sectorFromEvent ?? run.eventContext.latestEvents[0]?.affectedSectors?.[0] ?? null;
+}
+
+export function buildRiskRecommendationFromStrategyRun(run: StrategyOrchestratorRun): RiskRecommendationInput {
+  const symbol = run.decisionEngineContext.bestOpportunity?.symbol ?? run.eventContext.latestEvents[0]?.affectedSymbols?.[0] ?? null;
+  return {
+    recommendationId: run.recommendation.riskHandoff.packageId,
+    strategyRunId: run.runId,
+    recommendation: run.recommendation,
+    symbol,
+    sector: sectorFromRun(run),
+    strategyId: run.winner?.strategyId ?? null,
+    direction: directionFromRun(run),
+    confidence: run.recommendation.confidence,
+    expectedReturn: expectedReturnFromRun(run),
+    marketRegime: run.marketContext.regime,
+    marketStatus: run.marketContext.marketStatus,
+    eventContext: run.eventContext,
+    raw: run,
+  };
+}
+
+export async function buildRiskApprovalQueue(): Promise<{
+  latestStrategyRunId: string | null;
+  pending: RiskRecommendationInput[];
+}> {
+  const latest = await getLatestStrategyRun().catch(() => null);
+  return {
+    latestStrategyRunId: latest?.runId ?? null,
+    pending: latest ? [buildRiskRecommendationFromStrategyRun(latest)] : [],
+  };
+}
+
+export async function runRiskReview(options: {
+  recommendation?: RiskRecommendationInput;
+  persist?: boolean;
+  now?: Date;
+} = {}): Promise<{ approval: ApprovalPackage; record: RiskJournalRecord | null }> {
+  const now = options.now ?? new Date();
+  const recommendation =
+    options.recommendation ??
+    (await getLatestStrategyRun().then(run => (run ? buildRiskRecommendationFromStrategyRun(run) : null)));
+  if (!recommendation) {
+    throw Object.assign(new Error('RISK_RECOMMENDATION_NOT_FOUND'), { status: 404 });
+  }
+  const portfolio = await buildRiskPortfolioSnapshot(now);
+  const approval = evaluateRiskApproval(recommendation, portfolio, now);
+  const record = options.persist === false ? null : await appendRiskJournalRecord(recommendation, approval, portfolio, now);
+  return { approval, record };
+}
+
+export async function getRiskEngineStatus() {
+  const [latestApproval, queue, portfolio] = await Promise.all([
+    getLatestRiskApproval().catch(() => null),
+    buildRiskApprovalQueue().catch(() => ({ latestStrategyRunId: null, pending: [] })),
+    buildRiskPortfolioSnapshot().catch(() => null),
+  ]);
+  return {
+    enabled: (process.env.RISK_ENGINE_ENABLED ?? 'true').toLowerCase() !== 'false',
+    approvalRequired: (process.env.RISK_ENGINE_APPROVAL_REQUIRED ?? 'true').toLowerCase() !== 'false',
+    latestApprovalId: latestApproval?.approvalId ?? null,
+    latestStatus: latestApproval?.approval.status ?? null,
+    pendingRecommendations: queue.pending.length,
+    portfolioHeat:
+      portfolio && portfolio.riskBudget.maximumOpenRisk > 0
+        ? Number((portfolio.riskBudget.openRisk / portfolio.riskBudget.maximumOpenRisk).toFixed(4))
+        : 0,
+    ruleVersion: getRiskRuleSet().ruleVersion,
+  };
+}
+
+export { buildRiskPortfolioSnapshot, getLatestRiskApproval, getRiskRuleSet, listRiskApprovals };

--- a/server/src/features/riskEngine/correlation/correlation.service.ts
+++ b/server/src/features/riskEngine/correlation/correlation.service.ts
@@ -1,0 +1,48 @@
+import type { CorrelationResult, RiskPortfolioSnapshot, RiskRecommendationInput } from '../types/riskTypes';
+
+const CORRELATION_GROUPS: Record<string, string[]> = {
+  Energy: ['OXY', 'CVX', 'XLE', 'XOM', 'USO', 'COP', 'SLB'],
+  Technology: ['AAPL', 'MSFT', 'NVDA', 'QQQ', 'XLK', 'AMD', 'META', 'GOOGL'],
+  Financial: ['JPM', 'BAC', 'GS', 'XLF', 'MS', 'WFC'],
+  Healthcare: ['UNH', 'PFE', 'JNJ', 'XLV', 'MRK', 'ABBV'],
+  BroadMarket: ['SPY', 'QQQ', 'IWM', 'DIA'],
+};
+
+function groupFor(symbol: string | null, sector: string | null): string | null {
+  if (sector && CORRELATION_GROUPS[sector]) return sector;
+  if (!symbol) return null;
+  const upper = symbol.toUpperCase();
+  return Object.entries(CORRELATION_GROUPS).find(([, symbols]) => symbols.includes(upper))?.[0] ?? null;
+}
+
+export function estimateCorrelationRisk(
+  input: RiskRecommendationInput,
+  portfolio: RiskPortfolioSnapshot
+): CorrelationResult {
+  const targetGroup = groupFor(input.symbol, input.sector);
+  if (!targetGroup) {
+    return {
+      score: 0,
+      correlatedSymbols: [],
+      explanation: 'No known high-correlation group matched this recommendation.',
+    };
+  }
+  const groupSymbols = new Set(CORRELATION_GROUPS[targetGroup]);
+  const correlated = portfolio.currentPositions
+    .filter(position => {
+      const symbol = position.underlying ?? position.symbol;
+      return groupSymbols.has(symbol) || position.sector === targetGroup;
+    })
+    .map(position => position.underlying ?? position.symbol);
+  const exposure = correlated.reduce((sum, symbol) => sum + (portfolio.exposure.tickerExposure[symbol] ?? 0), 0);
+  const exposureScore = portfolio.portfolioSize > 0 ? Math.min(0.9, exposure / portfolio.portfolioSize) : 0;
+  const densityScore = Math.min(0.85, correlated.length * 0.22);
+  const score = Number(Math.max(exposureScore, densityScore).toFixed(2));
+  return {
+    score,
+    correlatedSymbols: Array.from(new Set(correlated)),
+    explanation: correlated.length
+      ? `${input.symbol ?? 'Recommendation'} overlaps with ${targetGroup} exposure: ${Array.from(new Set(correlated)).join(', ')}.`
+      : `${input.symbol ?? 'Recommendation'} maps to ${targetGroup}, but no existing correlated positions were found.`,
+  };
+}

--- a/server/src/features/riskEngine/greeks/greeks.service.ts
+++ b/server/src/features/riskEngine/greeks/greeks.service.ts
@@ -1,0 +1,48 @@
+import type { RiskGreekSnapshot, RiskPortfolioSnapshot } from '../types/riskTypes';
+
+function finite(value: unknown): number | null {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function normalizeGreeks(value: Partial<RiskGreekSnapshot> | null | undefined): RiskGreekSnapshot {
+  return {
+    delta: finite(value?.delta),
+    gamma: finite(value?.gamma),
+    theta: finite(value?.theta),
+    vega: finite(value?.vega),
+    rho: finite(value?.rho),
+  };
+}
+
+function addGreek(a: number | null, b: number | null): number | null {
+  if (a == null && b == null) return null;
+  return Number(((a ?? 0) + (b ?? 0)).toFixed(4));
+}
+
+export function aggregateGreeks(positions: RiskPortfolioSnapshot['currentPositions']): RiskGreekSnapshot {
+  return positions.reduce(
+    (acc, position) => ({
+      delta: addGreek(acc.delta, position.greeks.delta),
+      gamma: addGreek(acc.gamma, position.greeks.gamma),
+      theta: addGreek(acc.theta, position.greeks.theta),
+      vega: addGreek(acc.vega, position.greeks.vega),
+      rho: addGreek(acc.rho, position.greeks.rho),
+    }),
+    { delta: null, gamma: null, theta: null, vega: null, rho: null } as RiskGreekSnapshot
+  );
+}
+
+export function estimateGreekImpact(
+  current: RiskGreekSnapshot,
+  add: RiskGreekSnapshot,
+  contracts: number
+): RiskGreekSnapshot {
+  return {
+    delta: addGreek(current.delta, add.delta == null ? null : add.delta * contracts),
+    gamma: addGreek(current.gamma, add.gamma == null ? null : add.gamma * contracts),
+    theta: addGreek(current.theta, add.theta == null ? null : add.theta * contracts),
+    vega: addGreek(current.vega, add.vega == null ? null : add.vega * contracts),
+    rho: addGreek(current.rho, add.rho == null ? null : add.rho * contracts),
+  };
+}

--- a/server/src/features/riskEngine/index.ts
+++ b/server/src/features/riskEngine/index.ts
@@ -1,0 +1,2 @@
+export { riskEngineRouter } from './routes/riskEngine.routes';
+export { startRiskEngineScheduler, stopRiskEngineScheduler } from './scheduler/riskEngineScheduler.service';

--- a/server/src/features/riskEngine/journal/riskJournal.service.ts
+++ b/server/src/features/riskEngine/journal/riskJournal.service.ts
@@ -1,0 +1,39 @@
+import { getRiskRuleSet } from '../limits/riskRules.service';
+import { RiskApprovalModel } from '../storage/riskApproval.model';
+import type { ApprovalPackage, RiskJournalRecord, RiskPortfolioSnapshot, RiskRecommendationInput } from '../types/riskTypes';
+
+export async function appendRiskJournalRecord(
+  recommendation: RiskRecommendationInput,
+  approval: ApprovalPackage,
+  portfolio: RiskPortfolioSnapshot,
+  now = new Date()
+): Promise<RiskJournalRecord> {
+  const rules = getRiskRuleSet(now);
+  const record: RiskJournalRecord = {
+    approvalId: approval.approvalId,
+    timestamp: approval.timestamp,
+    recommendation,
+    approval,
+    rejection: approval.reasons,
+    reasonCodes: approval.reasons.map(reason => reason.code),
+    portfolioSnapshot: portfolio,
+    exposure: portfolio.exposure,
+    greeks: portfolio.greeks,
+    buyingPower: portfolio.buyingPower,
+    riskBudget: portfolio.riskBudget,
+    ruleVersion: rules.ruleVersion,
+    schemaVersion: 1,
+  };
+  return RiskApprovalModel.create(record);
+}
+
+export async function getLatestRiskApproval(): Promise<RiskJournalRecord | null> {
+  return RiskApprovalModel.findOne({}).sort({ timestamp: -1, createdAt: -1 }).lean();
+}
+
+export async function listRiskApprovals(limit = 50): Promise<RiskJournalRecord[]> {
+  return RiskApprovalModel.find({})
+    .sort({ timestamp: -1, createdAt: -1 })
+    .limit(Math.max(1, Math.min(250, limit)))
+    .lean();
+}

--- a/server/src/features/riskEngine/limits/riskRules.service.ts
+++ b/server/src/features/riskEngine/limits/riskRules.service.ts
@@ -1,0 +1,63 @@
+import type { RiskReasonCode, RiskRuleSet } from '../types/riskTypes';
+
+function numEnv(name: string, fallback: number): number {
+  const parsed = Number(process.env[name]);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export function riskEngineEnabled(): boolean {
+  return (process.env.RISK_ENGINE_ENABLED ?? 'true').toLowerCase() !== 'false';
+}
+
+export function riskApprovalRequired(): boolean {
+  return (process.env.RISK_ENGINE_APPROVAL_REQUIRED ?? 'true').toLowerCase() !== 'false';
+}
+
+export function getRiskRuleSet(now = new Date()): RiskRuleSet {
+  return {
+    ruleVersion: process.env.RISK_ENGINE_RULE_VERSION ?? 'risk-v1',
+    maximumContracts: numEnv('RISK_MAX_CONTRACTS', 10),
+    maximumDollarRisk: numEnv('RISK_MAX_DOLLAR_RISK', 750),
+    maximumDailyLoss: numEnv('RISK_MAX_DAILY_LOSS', 1_500),
+    maximumPositionSizePct: numEnv('RISK_MAX_POSITION_SIZE_PCT', 0.05),
+    maximumSectorExposurePct: numEnv('RISK_MAX_SECTOR_EXPOSURE_PCT', 0.35),
+    maximumCorrelation: numEnv('RISK_MAX_CORRELATION', 0.75),
+    maximumGamma: numEnv('RISK_MAX_GAMMA', 0.35),
+    maximumTheta: numEnv('RISK_MAX_THETA_ABS', 300),
+    maximumDelta: numEnv('RISK_MAX_DELTA_ABS', 300),
+    maximumVega: numEnv('RISK_MAX_VEGA_ABS', 500),
+    maximumOpenTrades: numEnv('RISK_MAX_OPEN_TRADES', 8),
+    minimumConfidence: numEnv('RISK_MIN_CONFIDENCE', 0.6),
+    maximumSpreadPct: numEnv('RISK_MAX_SPREAD_PCT', 0.18),
+    minimumVolume: numEnv('RISK_MIN_VOLUME', 100),
+    minimumOpenInterest: numEnv('RISK_MIN_OPEN_INTEREST', 250),
+    maximumIv: numEnv('RISK_MAX_IV', 1.2),
+    newsLockoutImportance: numEnv('RISK_NEWS_LOCKOUT_IMPORTANCE', 98),
+    defaultPortfolioSize: numEnv('RISK_DEFAULT_PORTFOLIO_SIZE', 100_000),
+    defaultContractRisk: numEnv('RISK_DEFAULT_CONTRACT_RISK', 250),
+    createdAt: now.toISOString(),
+    reason: 'Default enterprise risk rules loaded from environment with conservative fallbacks.',
+  };
+}
+
+export const RISK_REASON_EXPLANATIONS: Record<RiskReasonCode, string> = {
+  MAX_SECTOR_EXPOSURE: 'The recommendation would exceed the configured sector exposure limit.',
+  MAX_POSITION_SIZE: 'The recommendation would exceed the maximum single-position allocation.',
+  LOW_LIQUIDITY: 'The contract liquidity is below enterprise requirements.',
+  HIGH_SPREAD: 'The bid/ask spread is too wide for controlled execution risk.',
+  HIGH_IV: 'Implied volatility is above the configured risk ceiling.',
+  LOW_CONFIDENCE: 'The upstream recommendation confidence is below the risk approval threshold.',
+  MAX_DAILY_LOSS: 'Daily realized or unrealized losses have consumed the configured risk budget.',
+  INSUFFICIENT_BUYING_POWER: 'Available buying power is insufficient for the recommended allocation.',
+  HIGH_CORRELATION: 'The recommendation is highly correlated with existing portfolio exposure.',
+  MAX_GAMMA: 'Portfolio gamma would exceed the configured limit.',
+  MAX_DELTA: 'Portfolio delta would exceed the configured limit.',
+  MAX_THETA: 'Portfolio theta decay would exceed the configured limit.',
+  MAX_VEGA: 'Portfolio vega would exceed the configured limit.',
+  MARKET_CLOSED: 'The market is closed or unavailable, so a new risk approval cannot be issued.',
+  NEWS_LOCKOUT: 'A very high-importance event requires operator review before new risk approval.',
+  MAX_OPEN_TRADES: 'The account already has the maximum allowed concurrent open trades.',
+  MAX_DOLLAR_RISK: 'The recommended dollar risk exceeds the configured per-trade risk limit.',
+  NO_ACTIONABLE_RECOMMENDATION: 'The upstream package is not an actionable buy recommendation.',
+  MISSING_LIQUIDITY_DATA: 'Required liquidity data was not supplied, so risk approval cannot verify execution quality.',
+};

--- a/server/src/features/riskEngine/portfolio/riskPortfolio.service.ts
+++ b/server/src/features/riskEngine/portfolio/riskPortfolio.service.ts
@@ -1,0 +1,154 @@
+import mongoose from 'mongoose';
+import { AutomationPositionModel } from '../../automation/models/automationPosition.model';
+import { AutomationSessionModel } from '../../automation/models/automationSession.model';
+import { SECTOR_BY_SYMBOL } from '../../eventIntelligence/classification/classifier.service';
+import { underlyingFromOptionSymbol } from '../../../shared/symbols/optionSymbol';
+import { getRiskRuleSet } from '../limits/riskRules.service';
+import { aggregateGreeks, normalizeGreeks } from '../greeks/greeks.service';
+import type { RiskExposureSnapshot, RiskPortfolioSnapshot } from '../types/riskTypes';
+
+function finite(value: unknown, fallback = 0): number {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function cleanSymbol(value: unknown): string {
+  return String(value ?? '').trim().toUpperCase();
+}
+
+function add(map: Record<string, number>, key: string | null | undefined, value: number): void {
+  const resolved = key || 'Unknown';
+  map[resolved] = Number(((map[resolved] ?? 0) + Math.abs(value)).toFixed(2));
+}
+
+function buildRecommendedExposure(exposure: Record<string, number>, maxPct: number, portfolioSize: number): Record<string, number> {
+  const max = Number((portfolioSize * maxPct).toFixed(2));
+  const out: Record<string, number> = {};
+  for (const sector of Object.keys(exposure)) out[sector] = max;
+  return out;
+}
+
+export async function buildRiskPortfolioSnapshot(now = new Date()): Promise<RiskPortfolioSnapshot> {
+  const rules = getRiskRuleSet(now);
+  if (mongoose.connection?.readyState !== 1) {
+    const exposure: RiskExposureSnapshot = {
+      sectorExposure: {},
+      tickerExposure: {},
+      strategyExposure: {},
+      macroExposure: {},
+      longExposure: 0,
+      shortExposure: 0,
+      cashAllocation: null,
+      maximumConcurrentTrades: rules.maximumOpenTrades,
+      currentOpenTrades: 0,
+      historicalMaximum: {},
+      recommended: {},
+    };
+    return {
+      timestamp: now.toISOString(),
+      portfolioSize: rules.defaultPortfolioSize,
+      buyingPower: null,
+      availableCapital: null,
+      currentPositions: [],
+      exposure,
+      greeks: { delta: null, gamma: null, theta: null, vega: null, rho: null },
+      riskBudget: {
+        dailyRealizedLoss: 0,
+        dailyUnrealizedLoss: 0,
+        riskConsumed: 0,
+        remainingRiskBudget: rules.maximumDailyLoss,
+        maximumConsecutiveLosses: 3,
+        consecutiveLosses: 0,
+        maximumOpenRisk: rules.maximumDollarRisk * rules.maximumOpenTrades,
+        openRisk: 0,
+      },
+    };
+  }
+
+  const [positions, session] = await Promise.all([
+    AutomationPositionModel.find({ status: { $in: ['PENDING_ENTRY', 'OPEN', 'EXITING', 'MANUAL_REVIEW'] } })
+      .sort({ updatedAt: -1 })
+      .limit(200)
+      .lean(),
+    AutomationSessionModel.findOne({ status: { $in: ['READY', 'PAUSED', 'EMERGENCY_STOPPED'] } })
+      .sort({ updatedAt: -1 })
+      .lean()
+      .catch(() => null),
+  ]);
+
+  const currentPositions = positions.map((position: any) => {
+    const optionSymbol = cleanSymbol(position.optionSymbol ?? position.symbol);
+    const underlying = cleanSymbol(position.underlying) || underlyingFromOptionSymbol(optionSymbol) || null;
+    const marketValue = finite(position.currentValue ?? position.marketValue ?? position.avgEntryPrice * position.filledQty * 100);
+    return {
+      symbol: optionSymbol,
+      underlying,
+      sector: underlying ? SECTOR_BY_SYMBOL[underlying] ?? null : null,
+      strategyId: typeof position.strategyVersionId === 'string' ? position.strategyVersionId : null,
+      direction: position.direction === 'BEARISH' ? ('SHORT' as const) : position.direction === 'BULLISH' ? ('LONG' as const) : ('UNKNOWN' as const),
+      quantity: finite(position.filledQty ?? position.orderedQuantity),
+      marketValue,
+      unrealizedPnl: finite(position.unrealizedPnl),
+      greeks: normalizeGreeks(position.greeks),
+    };
+  });
+
+  const exposure: RiskExposureSnapshot = {
+    sectorExposure: {},
+    tickerExposure: {},
+    strategyExposure: {},
+    macroExposure: {},
+    longExposure: 0,
+    shortExposure: 0,
+    cashAllocation: null,
+    maximumConcurrentTrades: rules.maximumOpenTrades,
+    currentOpenTrades: currentPositions.length,
+    historicalMaximum: {},
+    recommended: {},
+  };
+
+  for (const position of currentPositions) {
+    add(exposure.sectorExposure, position.sector, position.marketValue);
+    add(exposure.tickerExposure, position.underlying ?? position.symbol, position.marketValue);
+    add(exposure.strategyExposure, position.strategyId, position.marketValue);
+    if (position.sector && ['Energy', 'Financial', 'Technology'].includes(position.sector)) {
+      add(exposure.macroExposure, position.sector, position.marketValue);
+    }
+    if (position.direction === 'SHORT') exposure.shortExposure += Math.abs(position.marketValue);
+    else exposure.longExposure += Math.abs(position.marketValue);
+  }
+
+  const openRisk = Number(currentPositions.reduce((sum, position) => sum + Math.abs(position.marketValue), 0).toFixed(2));
+  const dailyRealizedLoss = Math.max(0, -finite(session?.dailyRealizedPnl));
+  const dailyUnrealizedLoss = Math.max(0, -currentPositions.reduce((sum, position) => sum + position.unrealizedPnl, 0));
+  const riskConsumed = Number((dailyRealizedLoss + dailyUnrealizedLoss).toFixed(2));
+  const portfolioSize = finite(session?.startingDayEquity ?? session?.peakEquity, rules.defaultPortfolioSize);
+  exposure.cashAllocation = null;
+  exposure.recommended = buildRecommendedExposure(exposure.sectorExposure, rules.maximumSectorExposurePct, portfolioSize);
+  exposure.historicalMaximum = { ...exposure.sectorExposure };
+
+  return {
+    timestamp: now.toISOString(),
+    portfolioSize,
+    buyingPower: null,
+    availableCapital: null,
+    currentPositions,
+    exposure,
+    greeks: aggregateGreeks(currentPositions),
+    riskBudget: {
+      dailyRealizedLoss,
+      dailyUnrealizedLoss,
+      riskConsumed,
+      remainingRiskBudget: Number(Math.max(0, rules.maximumDailyLoss - riskConsumed).toFixed(2)),
+      maximumConsecutiveLosses: 3,
+      consecutiveLosses: finite(session?.consecutiveLossCount),
+      maximumOpenRisk: rules.maximumDollarRisk * rules.maximumOpenTrades,
+      openRisk,
+    },
+  };
+}
+
+export function sectorExposureRatio(snapshot: RiskPortfolioSnapshot, sector: string | null, addedRisk = 0): number {
+  const current = sector ? snapshot.exposure.sectorExposure[sector] ?? 0 : 0;
+  return snapshot.portfolioSize > 0 ? (current + addedRisk) / snapshot.portfolioSize : 0;
+}

--- a/server/src/features/riskEngine/positionSizing/positionSizing.service.ts
+++ b/server/src/features/riskEngine/positionSizing/positionSizing.service.ts
@@ -1,0 +1,40 @@
+import type { MarketRegimeType } from '../../strategyOrchestrator/types/orchestratorTypes';
+import type { PositionSizeResult, RiskPortfolioSnapshot, RiskRecommendationInput, RiskRuleSet } from '../types/riskTypes';
+
+function regimeMultiplier(regime: MarketRegimeType): number {
+  if (regime === 'HIGH_VOLATILITY' || regime === 'RISK_OFF' || regime === 'MACRO_DRIVEN') return 0.55;
+  if (regime === 'NEWS_DRIVEN' || regime === 'SECTOR_ROTATION') return 0.7;
+  if (regime === 'LOW_VOLATILITY' || regime === 'RISK_ON' || regime === 'TRENDING') return 1;
+  return 0.8;
+}
+
+export function calculatePositionSize(
+  input: RiskRecommendationInput,
+  portfolio: RiskPortfolioSnapshot,
+  rules: RiskRuleSet
+): PositionSizeResult {
+  const unitRisk = input.contract?.estimatedUnitRisk && input.contract.estimatedUnitRisk > 0
+    ? input.contract.estimatedUnitRisk
+    : rules.defaultContractRisk;
+  const confidence = Math.max(0, Math.min(1, input.confidence));
+  const expectedReturn = Math.max(0, input.expectedReturn);
+  const heat = portfolio.riskBudget.maximumOpenRisk > 0
+    ? Math.min(1, portfolio.riskBudget.openRisk / portfolio.riskBudget.maximumOpenRisk)
+    : 0;
+  const maxRiskByPortfolio = portfolio.portfolioSize * rules.maximumPositionSizePct;
+  const confidenceBudget = rules.maximumDollarRisk * (0.35 + confidence * 0.65);
+  const returnBudget = confidenceBudget * (1 + Math.min(0.5, expectedReturn));
+  const adjustedBudget = returnBudget * (1 - heat * 0.5) * regimeMultiplier(input.marketRegime.current);
+  const dollarRisk = Number(Math.max(0, Math.min(rules.maximumDollarRisk, maxRiskByPortfolio, adjustedBudget)).toFixed(2));
+  const suggestedContracts = Math.max(0, Math.min(rules.maximumContracts, Math.floor(dollarRisk / unitRisk)));
+  const capitalAllocation = Number((suggestedContracts * unitRisk).toFixed(2));
+  return {
+    suggestedContracts,
+    dollarRisk: capitalAllocation,
+    capitalAllocation,
+    expectedPortfolioImpact: portfolio.portfolioSize > 0 ? Number((capitalAllocation / portfolio.portfolioSize).toFixed(4)) : 0,
+    explanation:
+      `Sizing used confidence ${confidence.toFixed(2)}, expected return ${expectedReturn.toFixed(2)}, ` +
+      `portfolio heat ${heat.toFixed(2)}, ${input.marketRegime.current} regime, and unit risk $${unitRisk.toFixed(2)}.`,
+  };
+}

--- a/server/src/features/riskEngine/routes/riskEngine.routes.ts
+++ b/server/src/features/riskEngine/routes/riskEngine.routes.ts
@@ -1,0 +1,88 @@
+import { Router, type Response } from 'express';
+import {
+  buildRiskApprovalQueue,
+  buildRiskPortfolioSnapshot,
+  getLatestRiskApproval,
+  getRiskEngineStatus,
+  getRiskRuleSet,
+  listRiskApprovals,
+  runRiskReview,
+} from '../controllers/riskEngine.service';
+
+export const riskEngineRouter = Router();
+
+function sendError(res: Response, error: unknown): void {
+  const status = typeof (error as any)?.status === 'number' ? (error as any).status : 500;
+  res.status(status).json({ error: (error as Error)?.message ?? 'risk engine request failed' });
+}
+
+function limitFrom(value: unknown, fallback = 50): number {
+  const parsed = typeof value === 'string' ? Number(value) : fallback;
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+riskEngineRouter.get('/status', async (_req, res) => {
+  try {
+    res.json({ status: await getRiskEngineStatus() });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+riskEngineRouter.get('/portfolio', async (_req, res) => {
+  try {
+    res.json({ portfolio: await buildRiskPortfolioSnapshot() });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+riskEngineRouter.get('/exposure', async (_req, res) => {
+  try {
+    const portfolio = await buildRiskPortfolioSnapshot();
+    res.json({ exposure: portfolio.exposure });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+riskEngineRouter.get('/greeks', async (_req, res) => {
+  try {
+    const portfolio = await buildRiskPortfolioSnapshot();
+    res.json({ greeks: portfolio.greeks, currentPositions: portfolio.currentPositions });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+riskEngineRouter.get('/risk-budget', async (_req, res) => {
+  try {
+    const portfolio = await buildRiskPortfolioSnapshot();
+    res.json({ riskBudget: portfolio.riskBudget });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+riskEngineRouter.get('/rules', (_req, res) => {
+  res.json({ rules: getRiskRuleSet() });
+});
+
+riskEngineRouter.get('/history', async (req, res) => {
+  try {
+    res.json({ history: await listRiskApprovals(limitFrom(req.query.limit, 50)) });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+riskEngineRouter.get('/approval-queue', async (req, res) => {
+  try {
+    const queue = await buildRiskApprovalQueue();
+    const latestApproval = await getLatestRiskApproval();
+    const preview = req.query.preview === 'true' && queue.pending[0] ? await runRiskReview({ recommendation: queue.pending[0], persist: false }) : null;
+    res.json({ queue, latestApproval, preview: preview?.approval ?? null });
+  } catch (error) {
+    sendError(res, error);
+  }
+});

--- a/server/src/features/riskEngine/scheduler/riskEngineScheduler.service.ts
+++ b/server/src/features/riskEngine/scheduler/riskEngineScheduler.service.ts
@@ -1,0 +1,24 @@
+import { runRiskReview } from '../controllers/riskEngine.service';
+
+let timer: NodeJS.Timeout | null = null;
+
+function intervalMs(): number {
+  const parsed = Number(process.env.RISK_ENGINE_INTERVAL_MS ?? 120_000);
+  return Number.isFinite(parsed) ? Math.max(30_000, parsed) : 120_000;
+}
+
+export function startRiskEngineScheduler(): void {
+  if ((process.env.RISK_ENGINE_AUTO_START ?? 'false').toLowerCase() !== 'true') return;
+  if (timer) return;
+  timer = setInterval(() => {
+    runRiskReview().catch(error => {
+      console.warn('[RiskEngine] scheduled review failed', { message: (error as Error)?.message ?? 'unknown error' });
+    });
+  }, intervalMs());
+}
+
+export function stopRiskEngineScheduler(): void {
+  if (!timer) return;
+  clearInterval(timer);
+  timer = null;
+}

--- a/server/src/features/riskEngine/storage/riskApproval.model.ts
+++ b/server/src/features/riskEngine/storage/riskApproval.model.ts
@@ -1,0 +1,27 @@
+import mongoose, { Schema } from 'mongoose';
+import type { RiskJournalRecord } from '../types/riskTypes';
+
+const RiskApprovalSchema = new Schema<RiskJournalRecord>(
+  {
+    approvalId: { type: String, required: true, unique: true, index: true },
+    timestamp: { type: String, required: true, index: true },
+    recommendation: { type: Schema.Types.Mixed, required: true },
+    approval: { type: Schema.Types.Mixed, required: true },
+    rejection: { type: Schema.Types.Mixed, required: true, default: [] },
+    reasonCodes: { type: [String], required: true, default: [] },
+    portfolioSnapshot: { type: Schema.Types.Mixed, required: true },
+    exposure: { type: Schema.Types.Mixed, required: true },
+    greeks: { type: Schema.Types.Mixed, required: true },
+    buyingPower: { type: Number, default: null },
+    riskBudget: { type: Schema.Types.Mixed, required: true },
+    ruleVersion: { type: String, required: true, index: true },
+    schemaVersion: { type: Number, required: true, default: 1 },
+  },
+  { timestamps: true, collection: 'risk_engine_approvals' }
+);
+
+RiskApprovalSchema.index({ timestamp: -1 });
+
+export const RiskApprovalModel =
+  (mongoose.models.RiskEngineApproval as mongoose.Model<RiskJournalRecord>) ||
+  mongoose.model<RiskJournalRecord>('RiskEngineApproval', RiskApprovalSchema);

--- a/server/src/features/riskEngine/types/riskTypes.ts
+++ b/server/src/features/riskEngine/types/riskTypes.ts
@@ -1,0 +1,199 @@
+import type {
+  MarketRegime,
+  RecommendationPackage,
+  StrategyOrchestratorRun,
+} from '../../strategyOrchestrator/types/orchestratorTypes';
+
+export type RiskDecisionStatus = 'APPROVE' | 'REJECT';
+
+export type RiskReasonCode =
+  | 'MAX_SECTOR_EXPOSURE'
+  | 'MAX_POSITION_SIZE'
+  | 'LOW_LIQUIDITY'
+  | 'HIGH_SPREAD'
+  | 'HIGH_IV'
+  | 'LOW_CONFIDENCE'
+  | 'MAX_DAILY_LOSS'
+  | 'INSUFFICIENT_BUYING_POWER'
+  | 'HIGH_CORRELATION'
+  | 'MAX_GAMMA'
+  | 'MAX_DELTA'
+  | 'MAX_THETA'
+  | 'MAX_VEGA'
+  | 'MARKET_CLOSED'
+  | 'NEWS_LOCKOUT'
+  | 'MAX_OPEN_TRADES'
+  | 'MAX_DOLLAR_RISK'
+  | 'NO_ACTIONABLE_RECOMMENDATION'
+  | 'MISSING_LIQUIDITY_DATA';
+
+export type RiskRuleSet = {
+  ruleVersion: string;
+  maximumContracts: number;
+  maximumDollarRisk: number;
+  maximumDailyLoss: number;
+  maximumPositionSizePct: number;
+  maximumSectorExposurePct: number;
+  maximumCorrelation: number;
+  maximumGamma: number;
+  maximumTheta: number;
+  maximumDelta: number;
+  maximumVega: number;
+  maximumOpenTrades: number;
+  minimumConfidence: number;
+  maximumSpreadPct: number;
+  minimumVolume: number;
+  minimumOpenInterest: number;
+  maximumIv: number;
+  newsLockoutImportance: number;
+  defaultPortfolioSize: number;
+  defaultContractRisk: number;
+  createdAt: string;
+  reason: string;
+};
+
+export type RiskLiquidityMetrics = {
+  bid: number | null;
+  ask: number | null;
+  spreadPct: number | null;
+  volume: number | null;
+  openInterest: number | null;
+  impliedVolatility: number | null;
+};
+
+export type RiskRecommendationInput = {
+  recommendationId: string;
+  strategyRunId: string | null;
+  recommendation: RecommendationPackage;
+  symbol: string | null;
+  sector: string | null;
+  strategyId: string | null;
+  direction: 'BULLISH' | 'BEARISH' | 'NEUTRAL';
+  confidence: number;
+  expectedReturn: number;
+  contract?: {
+    symbol: string | null;
+    estimatedUnitRisk: number | null;
+    liquidity: RiskLiquidityMetrics;
+    greeks: RiskGreekSnapshot;
+  };
+  marketRegime: MarketRegime;
+  marketStatus: string;
+  eventContext: StrategyOrchestratorRun['eventContext'];
+  raw: StrategyOrchestratorRun | Record<string, unknown>;
+};
+
+export type RiskExposureSnapshot = {
+  sectorExposure: Record<string, number>;
+  tickerExposure: Record<string, number>;
+  strategyExposure: Record<string, number>;
+  macroExposure: Record<string, number>;
+  longExposure: number;
+  shortExposure: number;
+  cashAllocation: number | null;
+  maximumConcurrentTrades: number;
+  currentOpenTrades: number;
+  historicalMaximum: Record<string, number>;
+  recommended: Record<string, number>;
+};
+
+export type RiskGreekSnapshot = {
+  delta: number | null;
+  gamma: number | null;
+  theta: number | null;
+  vega: number | null;
+  rho: number | null;
+};
+
+export type RiskBudgetSnapshot = {
+  dailyRealizedLoss: number;
+  dailyUnrealizedLoss: number;
+  riskConsumed: number;
+  remainingRiskBudget: number;
+  maximumConsecutiveLosses: number;
+  consecutiveLosses: number;
+  maximumOpenRisk: number;
+  openRisk: number;
+};
+
+export type RiskPortfolioSnapshot = {
+  timestamp: string;
+  portfolioSize: number;
+  buyingPower: number | null;
+  availableCapital: number | null;
+  currentPositions: Array<{
+    symbol: string;
+    underlying: string | null;
+    sector: string | null;
+    strategyId: string | null;
+    direction: 'LONG' | 'SHORT' | 'UNKNOWN';
+    quantity: number;
+    marketValue: number;
+    unrealizedPnl: number;
+    greeks: RiskGreekSnapshot;
+  }>;
+  exposure: RiskExposureSnapshot;
+  greeks: RiskGreekSnapshot;
+  riskBudget: RiskBudgetSnapshot;
+};
+
+export type CorrelationResult = {
+  score: number;
+  correlatedSymbols: string[];
+  explanation: string;
+};
+
+export type PositionSizeResult = {
+  suggestedContracts: number;
+  dollarRisk: number;
+  capitalAllocation: number;
+  expectedPortfolioImpact: number;
+  explanation: string;
+};
+
+export type RiskCheck = {
+  code: RiskReasonCode | 'PASSED';
+  passed: boolean;
+  explanation: string;
+  supportingMetrics: Record<string, number | string | boolean | null>;
+  suggestedImprovement: string | null;
+};
+
+export type ApprovalPackage = {
+  approved: boolean;
+  status: RiskDecisionStatus;
+  approvalId: string;
+  recommendationId: string;
+  suggestedPositionSize: PositionSizeResult;
+  portfolioRisk: RiskBudgetSnapshot;
+  sectorExposure: RiskExposureSnapshot['sectorExposure'];
+  correlationRisk: CorrelationResult;
+  liquidityRisk: RiskCheck;
+  greekRisk: RiskCheck;
+  buyingPowerRisk: RiskCheck;
+  remainingRiskBudget: number;
+  reasons: Array<{
+    code: RiskReasonCode;
+    explanation: string;
+    supportingMetrics: Record<string, number | string | boolean | null>;
+    suggestedImprovement: string | null;
+  }>;
+  warnings: string[];
+  timestamp: string;
+};
+
+export type RiskJournalRecord = {
+  approvalId: string;
+  timestamp: string;
+  recommendation: RiskRecommendationInput;
+  approval: ApprovalPackage;
+  rejection: ApprovalPackage['reasons'];
+  reasonCodes: RiskReasonCode[];
+  portfolioSnapshot: RiskPortfolioSnapshot;
+  exposure: RiskExposureSnapshot;
+  greeks: RiskGreekSnapshot;
+  buyingPower: number | null;
+  riskBudget: RiskBudgetSnapshot;
+  ruleVersion: string;
+  schemaVersion: number;
+};

--- a/server/src/features/strategyOrchestrator/controllers/orchestrator.service.ts
+++ b/server/src/features/strategyOrchestrator/controllers/orchestrator.service.ts
@@ -1,0 +1,125 @@
+import { randomUUID } from 'crypto';
+import { getMarketStatusSnapshot } from '../../market/services/marketStatus';
+import { listWatchlist } from '../../watchlist/watchlist.service';
+import { listEventRecords } from '../../eventIntelligence/storage/eventJournal.service';
+import { getLatestDecisionScan } from '../../decisionEngine/journal.service';
+import { buildPortfolioContext } from '../portfolio/portfolioContext.service';
+import { detectMarketRegime } from '../scheduler/marketRegime.service';
+import { scheduleStrategies } from '../scheduler/strategyScheduler.service';
+import { buildEvidenceScore } from '../ranking/evidence.service';
+import { rankStrategies, resolveStrategyConflicts } from '../ranking/ranking.service';
+import { buildRecommendationPackage } from '../ranking/recommendation.service';
+import { listRegisteredStrategies } from '../strategies/strategyRegistry.service';
+import { appendStrategyRun, getLatestStrategyRun, listStrategyRuns } from '../storage/strategyJournal.service';
+import type { StrategyEvaluationContext, StrategyOrchestratorRun } from '../types/orchestratorTypes';
+
+function eventSentimentValue(value: any): number | string | null {
+  return value?.event?.sentiment?.score ?? value?.event?.sentiment?.label ?? null;
+}
+
+export async function buildStrategyContext(): Promise<StrategyEvaluationContext> {
+  const [events, decision, portfolio, watchlistDocs, marketStatus] = await Promise.all([
+    listEventRecords(25).catch(() => []),
+    getLatestDecisionScan().catch(() => null),
+    buildPortfolioContext(),
+    listWatchlist().catch(() => []),
+    getMarketStatusSnapshot().catch(() => null),
+  ]);
+  const decisionConfidence = decision?.winner?.confidence ?? null;
+  const marketRegime = detectMarketRegime({
+    events,
+    decisionConfidence,
+    rejectedCount: decision?.rejections?.length ?? 0,
+  });
+  return {
+    timestamp: new Date().toISOString(),
+    eventContext: {
+      latestEvents: events.slice(0, 10).map(record => ({
+        id: record.event.id,
+        title: record.event.title,
+        category: record.event.category,
+        importance: record.event.importance,
+        sentiment: eventSentimentValue(record),
+        affectedSymbols: record.impact.affectedSymbols,
+        affectedEtfs: record.impact.affectedEtfs,
+        affectedSectors: record.impact.affectedSectors,
+      })),
+    },
+    decisionContext: {
+      latestScanId: decision?.scanId ?? null,
+      bestOpportunity: decision?.winner
+        ? {
+            symbol: decision.winner.symbol,
+            score: decision.winner.overallScore,
+            confidence: decision.winner.confidence,
+            recommendation: decision.winner.recommendation,
+          }
+        : null,
+      rejectedCount: decision?.rejections?.length ?? 0,
+      noTradeReason: decision?.noTradeReason ?? null,
+    },
+    marketData: {
+      marketStatus: marketStatus?.market ?? 'unknown',
+      trendScore: decision?.winner?.scores?.trend?.score ?? null,
+      momentumScore: decision?.winner?.scores?.momentum?.score ?? null,
+      volatilityScore: decision?.winner?.scores?.volatility?.score ?? null,
+    },
+    portfolio,
+    watchlist: watchlistDocs.filter(item => item.enabled).map(item => item.symbol),
+    news: events.slice(0, 5).map(record => record.event.title),
+    sentiment: {
+      bullish: events.filter(record => record.event.sentiment.label === 'bullish').length,
+      bearish: events.filter(record => record.event.sentiment.label === 'bearish').length,
+      neutral: events.filter(record => record.event.sentiment.label === 'neutral').length,
+    },
+    technicalAnalysis: {
+      trendScore: decision?.winner?.scores?.trend?.score ?? null,
+      momentumScore: decision?.winner?.scores?.momentum?.score ?? null,
+      volatilityScore: decision?.winner?.scores?.volatility?.score ?? null,
+    },
+    marketRegime,
+  };
+}
+
+export async function runStrategyOrchestrator(options: { persist?: boolean } = {}): Promise<StrategyOrchestratorRun> {
+  const context = await buildStrategyContext();
+  const registry = listRegisteredStrategies();
+  const scheduled = scheduleStrategies(registry, context);
+  const evidence = buildEvidenceScore(context);
+  const strategiesEvaluated = scheduled.selected.map(strategy => strategy.evaluate(context));
+  const skippedEvaluations = scheduled.skipped.map(strategy => ({
+    strategyId: strategy.id,
+    name: strategy.name,
+    direction: 'NEUTRAL' as const,
+    confidence: 0,
+    risk: 0,
+    expectedReturn: 0,
+    positionSize: 0,
+    evidenceScore: 0,
+    reasoning: [scheduled.explanation],
+    rejected: true,
+    rejectionReason: 'Skipped by strategy scheduler as unrelated to current event/regime context.',
+  }));
+  const allEvaluations = [...strategiesEvaluated, ...skippedEvaluations];
+  const rankings = rankStrategies(allEvaluations);
+  const conflicts = resolveStrategyConflicts(strategiesEvaluated);
+  const recommendation = buildRecommendationPackage({ rankings, conflicts, evidence });
+  const run: StrategyOrchestratorRun = {
+    runId: randomUUID(),
+    timestamp: context.timestamp,
+    strategiesEvaluated: allEvaluations,
+    rankings,
+    winner: rankings.find(ranking => !ranking.rejected) ?? null,
+    conflicts,
+    recommendation,
+    evidence,
+    marketContext: { regime: context.marketRegime, marketStatus: context.marketData.marketStatus },
+    decisionEngineContext: context.decisionContext,
+    eventContext: context.eventContext,
+    portfolioContext: context.portfolio,
+    schemaVersion: 1,
+  };
+  return options.persist === false ? run : appendStrategyRun(run);
+}
+
+export { getLatestStrategyRun, listStrategyRuns };

--- a/server/src/features/strategyOrchestrator/index.ts
+++ b/server/src/features/strategyOrchestrator/index.ts
@@ -1,0 +1,5 @@
+export { strategyOrchestratorRouter } from './routes/strategyOrchestrator.routes';
+export {
+  startStrategyOrchestratorScheduler,
+  stopStrategyOrchestratorScheduler,
+} from './scheduler/strategyOrchestratorScheduler.service';

--- a/server/src/features/strategyOrchestrator/portfolio/portfolioContext.service.ts
+++ b/server/src/features/strategyOrchestrator/portfolio/portfolioContext.service.ts
@@ -1,0 +1,77 @@
+import { AutomationPositionModel } from '../../automation/models/automationPosition.model';
+import { SECTOR_BY_SYMBOL } from '../../eventIntelligence/classification/classifier.service';
+import type { PortfolioContext } from '../types/orchestratorTypes';
+
+function num(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+export async function buildPortfolioContext(): Promise<PortfolioContext> {
+  try {
+    const positions = await AutomationPositionModel.find({ status: { $in: ['PENDING_ENTRY', 'OPEN', 'EXITING', 'MANUAL_REVIEW'] } })
+      .sort({ updatedAt: -1 })
+      .limit(100)
+      .lean();
+    const currentPositions = positions.map((position: any) => {
+      const underlying = String(position.underlying ?? '').toUpperCase() || null;
+      return {
+        symbol: String(position.optionSymbol ?? position.symbol ?? ''),
+        underlying,
+        sector: underlying ? SECTOR_BY_SYMBOL[underlying] ?? null : null,
+        quantity: num(position.filledQty ?? position.quantity),
+        marketValue: num(position.currentValue ?? position.marketValue),
+        unrealizedPnl: num(position.unrealizedPnl),
+        delta: num(position.greeks?.delta),
+        gamma: num(position.greeks?.gamma),
+        theta: num(position.greeks?.theta),
+        vega: num(position.greeks?.vega),
+      };
+    });
+    const sectorExposure: Record<string, number> = {};
+    for (const position of currentPositions) {
+      const sector = position.sector ?? 'Unknown';
+      sectorExposure[sector] = (sectorExposure[sector] ?? 0) + Math.abs(position.marketValue ?? 0);
+    }
+    const greeks = currentPositions.reduce(
+      (acc, position) => ({
+        delta: acc.delta == null && position.delta == null ? null : (acc.delta ?? 0) + (position.delta ?? 0),
+        gamma: acc.gamma == null && position.gamma == null ? null : (acc.gamma ?? 0) + (position.gamma ?? 0),
+        theta: acc.theta == null && position.theta == null ? null : (acc.theta ?? 0) + (position.theta ?? 0),
+        vega: acc.vega == null && position.vega == null ? null : (acc.vega ?? 0) + (position.vega ?? 0),
+      }),
+      { delta: null, gamma: null, theta: null, vega: null } as PortfolioContext['greeks']
+    );
+    const openRisk = currentPositions.reduce((sum, position) => sum + Math.abs(position.marketValue ?? 0), 0);
+    return {
+      currentPositions,
+      buyingPower: null,
+      sectorExposure,
+      openRisk,
+      greeks,
+      availableCapital: null,
+      maximumDailyLoss: null,
+      adjustmentExplanation: currentPositions.length
+        ? `Portfolio awareness found ${currentPositions.length} open automation positions and ${Object.keys(sectorExposure).length} sector exposures.`
+        : 'No open automation portfolio exposure was found in persisted records.',
+    };
+  } catch (error) {
+    return {
+      currentPositions: [],
+      buyingPower: null,
+      sectorExposure: {},
+      openRisk: null,
+      greeks: { delta: null, gamma: null, theta: null, vega: null },
+      availableCapital: null,
+      maximumDailyLoss: null,
+      adjustmentExplanation: `Portfolio context unavailable: ${(error as Error)?.message ?? 'unknown error'}.`,
+    };
+  }
+}
+
+export function portfolioSectorPenalty(portfolio: PortfolioContext, sectors: string[]): number {
+  const total = Object.values(portfolio.sectorExposure).reduce((sum, value) => sum + value, 0);
+  if (total <= 0) return 0;
+  const exposure = sectors.reduce((sum, sector) => sum + (portfolio.sectorExposure[sector] ?? 0), 0);
+  const ratio = exposure / total;
+  return ratio > 0.35 ? Math.min(20, (ratio - 0.35) * 50) : 0;
+}

--- a/server/src/features/strategyOrchestrator/ranking/evidence.service.ts
+++ b/server/src/features/strategyOrchestrator/ranking/evidence.service.ts
@@ -1,0 +1,20 @@
+import type { EvidenceScore, StrategyEvaluationContext } from '../types/orchestratorTypes';
+
+function clamp(value: number): number {
+  return Math.max(0, Math.min(100, Number(value.toFixed(2))));
+}
+
+export function buildEvidenceScore(context: StrategyEvaluationContext): EvidenceScore {
+  const event = Math.min(25, context.eventContext.latestEvents.reduce((max, item) => Math.max(max, item.importance), 0) * 0.25);
+  const decision = context.decisionContext.bestOpportunity ? context.decisionContext.bestOpportunity.score * 0.25 : 0;
+  const portfolio = context.portfolio.currentPositions.length ? 10 : 15;
+  const sentiment = Math.min(15, context.sentiment.bullish * 4 + context.sentiment.bearish * 4 + context.sentiment.neutral * 2);
+  const regime = context.marketRegime.confidence * 15;
+  const watchlist = Math.min(10, context.watchlist.length);
+  const score = clamp(event + decision + portfolio + sentiment + regime + watchlist);
+  return {
+    score,
+    explanation: `Evidence score ${score}/100 from event impact, decision context, portfolio capacity, sentiment, regime confidence, and watchlist breadth.`,
+    components: { event, decision, portfolio, sentiment, regime, watchlist },
+  };
+}

--- a/server/src/features/strategyOrchestrator/ranking/ranking.service.ts
+++ b/server/src/features/strategyOrchestrator/ranking/ranking.service.ts
@@ -1,0 +1,46 @@
+import type { ConflictSummary, StrategyEvaluation, StrategyRanking, StrategyRecommendationAction } from '../types/orchestratorTypes';
+
+function clamp(value: number): number {
+  return Math.max(0, Math.min(100, Number(value.toFixed(2))));
+}
+
+export function rankStrategies(evaluations: StrategyEvaluation[]): StrategyRanking[] {
+  return evaluations
+    .map(evaluation => ({
+      strategyId: evaluation.strategyId,
+      name: evaluation.name,
+      score: evaluation.rejected
+        ? 0
+        : clamp(evaluation.confidence * 35 + evaluation.expectedReturn * 20 + evaluation.evidenceScore * 0.35 - evaluation.risk * 15),
+      confidence: evaluation.confidence,
+      risk: evaluation.risk,
+      expectedReturn: evaluation.expectedReturn,
+      evidenceScore: evaluation.evidenceScore,
+      rejected: evaluation.rejected,
+      rejectionReason: evaluation.rejectionReason,
+    }))
+    .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
+}
+
+export function resolveStrategyConflicts(evaluations: StrategyEvaluation[]): ConflictSummary {
+  const active = evaluations.filter(evaluation => !evaluation.rejected && evaluation.confidence >= 0.45);
+  const bullishStrategies = active.filter(evaluation => evaluation.direction === 'BULLISH').map(evaluation => evaluation.name);
+  const bearishStrategies = active.filter(evaluation => evaluation.direction === 'BEARISH').map(evaluation => evaluation.name);
+  const neutralStrategies = active.filter(evaluation => evaluation.direction === 'NEUTRAL').map(evaluation => evaluation.name);
+  const hasConflict = bullishStrategies.length > 0 && bearishStrategies.length > 0;
+  const confidenceAdjustment = hasConflict ? -0.18 : neutralStrategies.length > bullishStrategies.length + bearishStrategies.length ? -0.08 : 0;
+  let recommendedAction: StrategyRecommendationAction = 'WATCH';
+  if (hasConflict) recommendedAction = 'WAIT';
+  else if (!active.length) recommendedAction = 'NO_TRADE';
+  return {
+    hasConflict,
+    bullishStrategies,
+    bearishStrategies,
+    neutralStrategies,
+    confidenceAdjustment,
+    recommendedAction,
+    explanation: hasConflict
+      ? `Conflict detected: bullish strategies (${bullishStrategies.join(', ')}) disagree with bearish strategies (${bearishStrategies.join(', ')}).`
+      : `No directional conflict across ${active.length} active strategies.`,
+  };
+}

--- a/server/src/features/strategyOrchestrator/ranking/recommendation.service.ts
+++ b/server/src/features/strategyOrchestrator/ranking/recommendation.service.ts
@@ -1,0 +1,46 @@
+import { randomUUID } from 'crypto';
+import type {
+  ConflictSummary,
+  EvidenceScore,
+  RecommendationPackage,
+  StrategyRanking,
+  StrategyRecommendationAction,
+} from '../types/orchestratorTypes';
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, Number(value.toFixed(4))));
+}
+
+export function buildRecommendationPackage(args: {
+  rankings: StrategyRanking[];
+  conflicts: ConflictSummary;
+  evidence: EvidenceScore;
+}): RecommendationPackage {
+  const winner = args.rankings.find(ranking => !ranking.rejected) ?? null;
+  let action: StrategyRecommendationAction = args.conflicts.recommendedAction;
+  if (!winner) action = 'NO_TRADE';
+  else if (action !== 'WAIT') {
+    if (winner.score >= 75 && args.evidence.score >= 65) action = 'BUY';
+    else if (winner.score >= 55) action = 'WATCH';
+    else if (winner.score >= 40) action = 'WAIT';
+    else action = 'SKIP';
+  }
+  const confidence = clamp01((winner?.confidence ?? 0) + args.conflicts.confidenceAdjustment);
+  const supportingStrategies = args.rankings.filter(ranking => !ranking.rejected).slice(0, 5);
+  const rejectedStrategies = args.rankings.filter(ranking => ranking.rejected);
+  return {
+    action,
+    explanation: winner
+      ? `${action}: ${winner.name} leads with score ${winner.score.toFixed(1)}. ${args.conflicts.explanation} ${args.evidence.explanation}`
+      : `NO_TRADE: no strategy cleared the evidence threshold. ${args.evidence.explanation}`,
+    supportingStrategies,
+    rejectedStrategies,
+    confidence,
+    evidence: args.evidence,
+    riskHandoff: {
+      allowedForRiskReview: action === 'BUY' || action === 'WATCH',
+      message: 'Recommendation package only. Risk Engine must independently approve before any execution path can act.',
+      packageId: randomUUID(),
+    },
+  };
+}

--- a/server/src/features/strategyOrchestrator/routes/strategyOrchestrator.routes.ts
+++ b/server/src/features/strategyOrchestrator/routes/strategyOrchestrator.routes.ts
@@ -1,0 +1,72 @@
+import { Router, type Response } from 'express';
+import { buildStrategyContext, getLatestStrategyRun, listStrategyRuns, runStrategyOrchestrator } from '../controllers/orchestrator.service';
+import { listRegisteredStrategies } from '../strategies/strategyRegistry.service';
+
+export const strategyOrchestratorRouter = Router();
+
+function sendError(res: Response, error: unknown): void {
+  const status = typeof (error as any)?.status === 'number' ? (error as any).status : 500;
+  res.status(status).json({ error: (error as Error)?.message ?? 'strategy orchestrator request failed' });
+}
+
+function limitFrom(value: unknown, fallback = 50): number {
+  const parsed = typeof value === 'string' ? Number(value) : fallback;
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+strategyOrchestratorRouter.get('/status', async (_req, res) => {
+  try {
+    const latest = await getLatestStrategyRun();
+    res.json({
+      status: {
+        available: Boolean(latest),
+        latestRunId: latest?.runId ?? null,
+        latestRecommendation: latest?.recommendation?.action ?? null,
+        currentRegime: latest?.marketContext?.regime?.current ?? null,
+      },
+    });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+strategyOrchestratorRouter.get('/recommendations', async (req, res) => {
+  try {
+    const run = req.query.live === 'true' ? await runStrategyOrchestrator({ persist: false }) : await getLatestStrategyRun();
+    if (!run) {
+      res.status(404).json({ error: 'STRATEGY_RECOMMENDATION_NOT_FOUND' });
+      return;
+    }
+    res.json({ recommendation: run.recommendation, run });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+strategyOrchestratorRouter.get('/strategies', (_req, res) => {
+  const strategies = listRegisteredStrategies().map(strategy => ({
+    id: strategy.id,
+    name: strategy.name,
+    description: strategy.description,
+    requiredInputs: strategy.requiredInputs,
+    supportedAssets: strategy.supportedAssets,
+  }));
+  res.json({ strategies });
+});
+
+strategyOrchestratorRouter.get('/history', async (req, res) => {
+  try {
+    res.json({ history: await listStrategyRuns(limitFrom(req.query.limit, 50)) });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+strategyOrchestratorRouter.get('/evidence', async (_req, res) => {
+  try {
+    const context = await buildStrategyContext();
+    res.json({ context });
+  } catch (error) {
+    sendError(res, error);
+  }
+});

--- a/server/src/features/strategyOrchestrator/scheduler/marketRegime.service.ts
+++ b/server/src/features/strategyOrchestrator/scheduler/marketRegime.service.ts
@@ -1,0 +1,36 @@
+import type { EventIntelligenceRecord } from '../../eventIntelligence/types/eventTypes';
+import type { MarketRegime, MarketRegimeType } from '../types/orchestratorTypes';
+
+export function detectMarketRegime(args: {
+  events: EventIntelligenceRecord[];
+  decisionConfidence: number | null;
+  rejectedCount: number;
+}): MarketRegime {
+  const top = args.events[0];
+  const categories = new Set(args.events.slice(0, 5).map(record => record.event.category));
+  let current: MarketRegimeType = 'UNKNOWN';
+  let confidence = 0.45;
+  const historical: MarketRegimeType[] = [];
+  if (categories.has('Federal Reserve') || categories.has('Economic')) {
+    current = 'MACRO_DRIVEN';
+    confidence = 0.82;
+  } else if (top && top.event.importance >= 75) {
+    current = 'NEWS_DRIVEN';
+    confidence = 0.78;
+  } else if (args.decisionConfidence != null && args.decisionConfidence >= 0.75) {
+    current = 'TRENDING';
+    confidence = 0.7;
+  } else if (args.rejectedCount >= 5) {
+    current = 'RANGE_BOUND';
+    confidence = 0.62;
+  }
+  if (args.events.some(record => record.event.category === 'Oil')) historical.push('SECTOR_ROTATION');
+  if (args.events.some(record => record.event.sentiment.label === 'bearish')) historical.push('RISK_OFF');
+  if (args.events.some(record => record.event.sentiment.label === 'bullish')) historical.push('RISK_ON');
+  return {
+    current,
+    historical: [...new Set(historical)],
+    confidence,
+    explanation: `Regime ${current} derived from ${args.events.length} events, decision confidence ${args.decisionConfidence ?? 'n/a'}, and ${args.rejectedCount} rejected opportunities.`,
+  };
+}

--- a/server/src/features/strategyOrchestrator/scheduler/strategyOrchestratorScheduler.service.ts
+++ b/server/src/features/strategyOrchestrator/scheduler/strategyOrchestratorScheduler.service.ts
@@ -1,0 +1,19 @@
+import { runStrategyOrchestrator } from '../controllers/orchestrator.service';
+
+const INTERVAL_MS = Math.max(60_000, Number(process.env.STRATEGY_ORCHESTRATOR_INTERVAL_MS ?? 180_000));
+let timer: NodeJS.Timeout | null = null;
+
+export function startStrategyOrchestratorScheduler(): void {
+  if (timer || process.env.STRATEGY_ORCHESTRATOR_AUTO_START !== 'true') return;
+  timer = setInterval(() => {
+    runStrategyOrchestrator().catch(error => {
+      console.warn('[strategy-orchestrator] run failed', { error: (error as Error)?.message });
+    });
+  }, INTERVAL_MS);
+}
+
+export function stopStrategyOrchestratorScheduler(): void {
+  if (!timer) return;
+  clearInterval(timer);
+  timer = null;
+}

--- a/server/src/features/strategyOrchestrator/scheduler/strategyScheduler.service.ts
+++ b/server/src/features/strategyOrchestrator/scheduler/strategyScheduler.service.ts
@@ -1,0 +1,35 @@
+import type { StrategyDefinition, StrategyEvaluationContext } from '../types/orchestratorTypes';
+
+const CATEGORY_STRATEGIES: Record<string, string[]> = {
+  'Federal Reserve': ['fed-reaction', 'macro-rotation', 'ai-consensus'],
+  Economic: ['macro-rotation', 'fed-reaction', 'sector-rotation'],
+  Oil: ['oil-commodity', 'sector-rotation', 'news-momentum'],
+  Commodity: ['oil-commodity', 'macro-rotation'],
+  Earnings: ['news-momentum', 'high-volume', 'ai-consensus'],
+  Technology: ['momentum', 'trend-following', 'ai-consensus'],
+  AI: ['ai-consensus', 'momentum', 'gamma-expansion'],
+};
+
+export function scheduleStrategies(
+  registry: StrategyDefinition[],
+  context: StrategyEvaluationContext
+): { selected: StrategyDefinition[]; skipped: StrategyDefinition[]; explanation: string } {
+  const selectedIds = new Set<string>();
+  for (const event of context.eventContext.latestEvents) {
+    for (const id of CATEGORY_STRATEGIES[event.category] ?? ['news-momentum', 'ai-consensus']) selectedIds.add(id);
+  }
+  if (!selectedIds.size) {
+    for (const id of ['momentum', 'trend-following', 'breakout', 'pullback', 'mean-reversion', 'options-flow', 'ai-consensus']) {
+      selectedIds.add(id);
+    }
+  }
+  if (context.marketRegime.current === 'SECTOR_ROTATION') selectedIds.add('sector-rotation');
+  if (context.marketRegime.current === 'MACRO_DRIVEN') selectedIds.add('macro-rotation');
+  const selected = registry.filter(strategy => selectedIds.has(strategy.id));
+  const skipped = registry.filter(strategy => !selectedIds.has(strategy.id));
+  return {
+    selected,
+    skipped,
+    explanation: `Scheduled ${selected.length} strategies from events/regime and skipped ${skipped.length} unrelated strategies.`,
+  };
+}

--- a/server/src/features/strategyOrchestrator/storage/strategyJournal.service.ts
+++ b/server/src/features/strategyOrchestrator/storage/strategyJournal.service.ts
@@ -1,0 +1,41 @@
+import type { StrategyOrchestratorRun } from '../types/orchestratorTypes';
+import { StrategyOrchestratorModel } from './strategyOrchestrator.model';
+
+function serialize(doc: any): StrategyOrchestratorRun {
+  const value = typeof doc.toObject === 'function' ? doc.toObject() : doc;
+  return {
+    runId: value.runId,
+    timestamp: value.timestamp instanceof Date ? value.timestamp.toISOString() : String(value.timestamp),
+    strategiesEvaluated: value.strategiesEvaluated ?? [],
+    rankings: value.rankings ?? [],
+    winner: value.winner ?? null,
+    conflicts: value.conflicts,
+    recommendation: value.recommendation,
+    evidence: value.evidence,
+    marketContext: value.marketContext,
+    decisionEngineContext: value.decisionEngineContext,
+    eventContext: value.eventContext,
+    portfolioContext: value.portfolioContext,
+    schemaVersion: value.schemaVersion ?? 1,
+  };
+}
+
+export async function appendStrategyRun(run: StrategyOrchestratorRun): Promise<StrategyOrchestratorRun> {
+  const created = await StrategyOrchestratorModel.create({
+    ...run,
+    timestamp: new Date(run.timestamp),
+  });
+  return serialize(created);
+}
+
+export async function getLatestStrategyRun(): Promise<StrategyOrchestratorRun | null> {
+  const doc = await StrategyOrchestratorModel.findOne().sort({ timestamp: -1, createdAt: -1 });
+  return doc ? serialize(doc) : null;
+}
+
+export async function listStrategyRuns(limit = 50): Promise<StrategyOrchestratorRun[]> {
+  const docs = await StrategyOrchestratorModel.find()
+    .sort({ timestamp: -1, createdAt: -1 })
+    .limit(Math.max(1, Math.min(250, limit)));
+  return docs.map(serialize);
+}

--- a/server/src/features/strategyOrchestrator/storage/strategyOrchestrator.model.ts
+++ b/server/src/features/strategyOrchestrator/storage/strategyOrchestrator.model.ts
@@ -1,0 +1,33 @@
+import mongoose, { Schema } from 'mongoose';
+import type { StrategyOrchestratorRun } from '../types/orchestratorTypes';
+
+export interface StrategyOrchestratorDocument extends Omit<StrategyOrchestratorRun, 'timestamp'> {
+  timestamp: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const StrategyOrchestratorSchema = new Schema<StrategyOrchestratorDocument>(
+  {
+    runId: { type: String, required: true, unique: true, index: true },
+    timestamp: { type: Date, required: true, index: true },
+    strategiesEvaluated: { type: [Schema.Types.Mixed], required: true, default: [] } as any,
+    rankings: { type: [Schema.Types.Mixed], required: true, default: [] } as any,
+    winner: { type: Schema.Types.Mixed, default: null },
+    conflicts: { type: Schema.Types.Mixed, required: true },
+    recommendation: { type: Schema.Types.Mixed, required: true },
+    evidence: { type: Schema.Types.Mixed, required: true },
+    marketContext: { type: Schema.Types.Mixed, required: true },
+    decisionEngineContext: { type: Schema.Types.Mixed, required: true },
+    eventContext: { type: Schema.Types.Mixed, required: true },
+    portfolioContext: { type: Schema.Types.Mixed, required: true },
+    schemaVersion: { type: Number, required: true, default: 1 },
+  },
+  { timestamps: true, collection: 'strategy_orchestrator_runs' }
+);
+
+StrategyOrchestratorSchema.index({ timestamp: -1, runId: 1 });
+
+export const StrategyOrchestratorModel =
+  (mongoose.models.StrategyOrchestratorRun as mongoose.Model<StrategyOrchestratorDocument>) ||
+  mongoose.model<StrategyOrchestratorDocument>('StrategyOrchestratorRun', StrategyOrchestratorSchema);

--- a/server/src/features/strategyOrchestrator/strategies/strategyRegistry.service.ts
+++ b/server/src/features/strategyOrchestrator/strategies/strategyRegistry.service.ts
@@ -1,0 +1,96 @@
+import type { StrategyDefinition, StrategyEvaluation, StrategyEvaluationContext, StrategyDirection } from '../types/orchestratorTypes';
+import { portfolioSectorPenalty } from '../portfolio/portfolioContext.service';
+
+type StrategyProfile = {
+  id: string;
+  name: string;
+  description: string;
+  keywords: string[];
+  directionBias?: StrategyDirection;
+  sectors?: string[];
+  assets?: StrategyDefinition['supportedAssets'];
+  baseExpectedReturn?: number;
+  baseRisk?: number;
+};
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, Number(value.toFixed(4))));
+}
+
+function eventFit(context: StrategyEvaluationContext, keywords: string[]): number {
+  const text = context.eventContext.latestEvents.map(event => `${event.title} ${event.category}`).join(' ').toLowerCase();
+  if (!text) return 0.35;
+  return keywords.some(keyword => text.includes(keyword.toLowerCase())) ? 0.9 : 0.45;
+}
+
+function directionFromContext(context: StrategyEvaluationContext, bias?: StrategyDirection): StrategyDirection {
+  if (bias) return bias;
+  const bearish = context.sentiment.bearish;
+  const bullish = context.sentiment.bullish;
+  if (bearish > bullish) return 'BEARISH';
+  if (bullish > bearish) return 'BULLISH';
+  return 'NEUTRAL';
+}
+
+function makeStrategy(profile: StrategyProfile): StrategyDefinition {
+  return {
+    id: profile.id,
+    name: profile.name,
+    description: profile.description,
+    requiredInputs: ['eventContext', 'decisionContext', 'portfolio', 'watchlist', 'marketRegime'],
+    supportedAssets: profile.assets ?? ['equity', 'option', 'etf'],
+    evaluate(context: StrategyEvaluationContext): StrategyEvaluation {
+      const fit = eventFit(context, profile.keywords);
+      const decisionBoost = context.decisionContext.bestOpportunity ? context.decisionContext.bestOpportunity.confidence * 0.2 : 0;
+      const regimeBoost = context.marketRegime.confidence * 0.15;
+      const sectorPenalty = portfolioSectorPenalty(context.portfolio, profile.sectors ?? []);
+      const confidence = clamp01(fit * 0.55 + decisionBoost + regimeBoost - sectorPenalty / 100);
+      const evidenceScore = Math.max(0, Math.min(100, confidence * 70 + (context.eventContext.latestEvents[0]?.importance ?? 0) * 0.3));
+      const risk = clamp01((profile.baseRisk ?? 0.35) + sectorPenalty / 100 + (context.portfolio.openRisk ? 0.08 : 0));
+      const expectedReturn = clamp01((profile.baseExpectedReturn ?? 0.45) + confidence * 0.25 - risk * 0.12);
+      const rejected = confidence < 0.38;
+      return {
+        strategyId: profile.id,
+        name: profile.name,
+        direction: directionFromContext(context, profile.directionBias),
+        confidence,
+        risk,
+        expectedReturn,
+        positionSize: rejected ? 0 : clamp01(0.02 + confidence * 0.08 - risk * 0.03),
+        evidenceScore,
+        reasoning: [
+          `${profile.name} event fit is ${(fit * 100).toFixed(1)}%.`,
+          context.marketRegime.explanation,
+          context.portfolio.adjustmentExplanation,
+          sectorPenalty ? `Portfolio sector exposure reduced confidence by ${sectorPenalty.toFixed(1)} points.` : 'No portfolio sector concentration penalty applied.',
+        ],
+        rejected,
+        rejectionReason: rejected ? 'Strategy evidence below attention threshold.' : null,
+      };
+    },
+  };
+}
+
+const PROFILES: StrategyProfile[] = [
+  { id: 'momentum', name: 'Momentum', description: 'Follows broad directional strength.', keywords: ['momentum', 'upgrade', 'record'], baseExpectedReturn: 0.5 },
+  { id: 'trend-following', name: 'Trend Following', description: 'Follows persistent market direction.', keywords: ['trend', 'breakout', 'higher'], baseExpectedReturn: 0.48 },
+  { id: 'breakout', name: 'Breakout', description: 'Targets expansion from a range.', keywords: ['breakout', 'surge', 'volume'], baseRisk: 0.42 },
+  { id: 'pullback', name: 'Pullback', description: 'Waits for continuation after retracement.', keywords: ['pullback', 'dip', 'retest'], directionBias: 'NEUTRAL' },
+  { id: 'mean-reversion', name: 'Mean Reversion', description: 'Looks for stretched moves to normalize.', keywords: ['overbought', 'oversold', 'range'], directionBias: 'NEUTRAL', baseRisk: 0.3 },
+  { id: 'high-volume', name: 'High Volume', description: 'Prioritizes unusual participation.', keywords: ['volume', 'surge', 'earnings'] },
+  { id: 'gamma-expansion', name: 'Gamma Expansion', description: 'Focuses on convexity expansion in options.', keywords: ['gamma', 'options', 'ai'], assets: ['option'], baseRisk: 0.5 },
+  { id: 'volatility-compression', name: 'Volatility Compression', description: 'Watches low volatility setups.', keywords: ['compression', 'low volatility', 'calm'], directionBias: 'NEUTRAL' },
+  { id: 'news-momentum', name: 'News Momentum', description: 'Trades attention after meaningful news.', keywords: ['news', 'ceasefire', 'launch', 'earnings'], baseExpectedReturn: 0.55 },
+  { id: 'macro-rotation', name: 'Macro Rotation', description: 'Rotates based on macro data.', keywords: ['inflation', 'treasury', 'fed', 'macro'], assets: ['etf', 'macro'] },
+  { id: 'oil-commodity', name: 'Oil / Commodity', description: 'Maps oil and commodity events to energy assets.', keywords: ['oil', 'crude', 'opec', 'commodity'], sectors: ['Energy'], assets: ['commodity', 'etf', 'equity'] },
+  { id: 'fed-reaction', name: 'Fed Reaction', description: 'Evaluates Fed-sensitive moves.', keywords: ['fed', 'fomc', 'powell', 'treasury'], assets: ['macro', 'etf'] },
+  { id: 'sector-rotation', name: 'Sector Rotation', description: 'Compares sector-level opportunity.', keywords: ['sector', 'energy', 'financial', 'technology'], assets: ['etf', 'equity'] },
+  { id: 'options-flow', name: 'Options Flow', description: 'Uses decision engine options opportunity context.', keywords: ['options', 'flow', 'contract'], assets: ['option'] },
+  { id: 'ai-consensus', name: 'AI Consensus', description: 'Aggregates agreement from intelligence layers.', keywords: ['ai', 'consensus', 'news', 'macro', 'oil'], baseRisk: 0.28 },
+];
+
+export const STRATEGY_REGISTRY: StrategyDefinition[] = PROFILES.map(makeStrategy);
+
+export function listRegisteredStrategies(): StrategyDefinition[] {
+  return STRATEGY_REGISTRY;
+}

--- a/server/src/features/strategyOrchestrator/types/orchestratorTypes.ts
+++ b/server/src/features/strategyOrchestrator/types/orchestratorTypes.ts
@@ -1,0 +1,158 @@
+export type StrategyAssetClass = 'equity' | 'option' | 'etf' | 'commodity' | 'macro';
+export type StrategyDirection = 'BULLISH' | 'BEARISH' | 'NEUTRAL';
+export type StrategyRecommendationAction = 'BUY' | 'WATCH' | 'WAIT' | 'SKIP' | 'NO_TRADE';
+export type MarketRegimeType =
+  | 'TRENDING'
+  | 'RANGE_BOUND'
+  | 'HIGH_VOLATILITY'
+  | 'LOW_VOLATILITY'
+  | 'RISK_OFF'
+  | 'RISK_ON'
+  | 'MACRO_DRIVEN'
+  | 'NEWS_DRIVEN'
+  | 'SECTOR_ROTATION'
+  | 'UNKNOWN';
+
+export type StrategyEvaluationContext = {
+  timestamp: string;
+  eventContext: {
+    latestEvents: Array<{
+      id: string;
+      title: string;
+      category: string;
+      importance: number;
+      sentiment: number | string | null;
+      affectedSymbols: string[];
+      affectedEtfs: string[];
+      affectedSectors: string[];
+    }>;
+  };
+  decisionContext: {
+    latestScanId: string | null;
+    bestOpportunity: { symbol: string; score: number; confidence: number; recommendation: string } | null;
+    rejectedCount: number;
+    noTradeReason: string | null;
+  };
+  marketData: {
+    marketStatus: string;
+    trendScore: number | null;
+    momentumScore: number | null;
+    volatilityScore: number | null;
+  };
+  portfolio: PortfolioContext;
+  watchlist: string[];
+  news: string[];
+  sentiment: { bullish: number; bearish: number; neutral: number };
+  technicalAnalysis: Record<string, number | string | null>;
+  marketRegime: MarketRegime;
+};
+
+export type PortfolioContext = {
+  currentPositions: Array<{
+    symbol: string;
+    underlying: string | null;
+    sector: string | null;
+    quantity: number | null;
+    marketValue: number | null;
+    unrealizedPnl: number | null;
+    delta: number | null;
+    gamma: number | null;
+    theta: number | null;
+    vega: number | null;
+  }>;
+  buyingPower: number | null;
+  sectorExposure: Record<string, number>;
+  openRisk: number | null;
+  greeks: { delta: number | null; gamma: number | null; theta: number | null; vega: number | null };
+  availableCapital: number | null;
+  maximumDailyLoss: number | null;
+  adjustmentExplanation: string;
+};
+
+export type MarketRegime = {
+  current: MarketRegimeType;
+  historical: MarketRegimeType[];
+  confidence: number;
+  explanation: string;
+};
+
+export type StrategyEvaluation = {
+  strategyId: string;
+  name: string;
+  direction: StrategyDirection;
+  confidence: number;
+  risk: number;
+  expectedReturn: number;
+  positionSize: number;
+  evidenceScore: number;
+  reasoning: string[];
+  rejected: boolean;
+  rejectionReason: string | null;
+};
+
+export type StrategyDefinition = {
+  id: string;
+  name: string;
+  description: string;
+  requiredInputs: string[];
+  supportedAssets: StrategyAssetClass[];
+  evaluate: (context: StrategyEvaluationContext) => StrategyEvaluation;
+};
+
+export type StrategyRanking = {
+  strategyId: string;
+  name: string;
+  score: number;
+  confidence: number;
+  risk: number;
+  expectedReturn: number;
+  evidenceScore: number;
+  rejected: boolean;
+  rejectionReason: string | null;
+};
+
+export type ConflictSummary = {
+  hasConflict: boolean;
+  bullishStrategies: string[];
+  bearishStrategies: string[];
+  neutralStrategies: string[];
+  confidenceAdjustment: number;
+  recommendedAction: StrategyRecommendationAction;
+  explanation: string;
+};
+
+export type EvidenceScore = {
+  score: number;
+  explanation: string;
+  components: Record<string, number>;
+};
+
+export type RecommendationPackage = {
+  action: StrategyRecommendationAction;
+  explanation: string;
+  supportingStrategies: StrategyRanking[];
+  rejectedStrategies: StrategyRanking[];
+  confidence: number;
+  evidence: EvidenceScore;
+  riskHandoff: {
+    allowedForRiskReview: boolean;
+    message: string;
+    packageId: string;
+  };
+};
+
+export type StrategyOrchestratorRun = {
+  runId: string;
+  timestamp: string;
+  strategiesEvaluated: StrategyEvaluation[];
+  rankings: StrategyRanking[];
+  winner: StrategyRanking | null;
+  conflicts: ConflictSummary;
+  recommendation: RecommendationPackage;
+  evidence: EvidenceScore;
+  marketContext: { regime: MarketRegime; marketStatus: string };
+  decisionEngineContext: StrategyEvaluationContext['decisionContext'];
+  eventContext: StrategyEvaluationContext['eventContext'];
+  portfolioContext: PortfolioContext;
+  schemaVersion: number;
+};

--- a/server/src/features/system/systemHealth.routes.ts
+++ b/server/src/features/system/systemHealth.routes.ts
@@ -14,6 +14,7 @@ import { buildMarketDataHealthReport } from '../marketData/optionsDataHealth.ser
 import { getAutomationUniverse, getAutomationUniverseRefreshTtlMs } from '../watchlist/automationUniverseProvider.service';
 import { getAiHealthSnapshot } from '../assistant/agentProxy.routes';
 import { getAllDataQualityMetrics } from '../market/services/chartHub/buffer';
+import { getAutonomousHealth, getAutonomousMetrics, getAutonomousStatus } from '../autonomousTrading/coordinator/autonomousCoordinator.service';
 
 // Sprint 2F — /api/system/health. A single composite health surface for every
 // core component. Fast + read-only: it composes in-process signals and last-known
@@ -180,5 +181,84 @@ systemHealthRouter.get('/health', async (_req: Request, res: Response) => {
         recentDecisions: sched.lastTick?.sessions ?? [],
       },
     },
+  });
+});
+
+systemHealthRouter.get('/status', async (_req: Request, res: Response) => {
+  const now = Date.now();
+  const sched = getSchedulerStatus();
+  const mon = getMonitorStatus();
+  const broker = getBrokerStreamHealth();
+  const mongoConnected = mongoose.connection?.readyState === 1;
+  const [autonomous, health] = mongoConnected
+    ? await Promise.all([
+        getAutonomousStatus().catch(() => null),
+        getAutonomousHealth().catch(() => null),
+      ])
+    : [null, null];
+  const status =
+    health?.overall === 'BLOCKED' || !mongoConnected
+      ? 'BLOCKED'
+      : health?.overall === 'DEGRADED'
+        ? 'DEGRADED'
+        : sched.state === 'ACTIVE' || mon.state === 'ACTIVE'
+          ? 'RUNNING'
+          : 'STOPPED';
+  res.status(status === 'BLOCKED' ? 503 : 200).json({
+    status,
+    generatedAt: new Date(now).toISOString(),
+    summary:
+      autonomous?.currentActivity ??
+      (status === 'RUNNING'
+        ? 'System schedulers are running and autonomous status is available.'
+        : 'System is not fully running. Review component health for the blocking reason.'),
+    system: {
+      mongo: mongoConnected ? 'CONNECTED' : 'DISCONNECTED',
+      automation: isAutomationReady() ? 'READY' : 'NOT_READY',
+      scheduler: sched.state,
+      monitor: mon.state,
+      brokerTruthCurrent: broker.truthCurrent,
+      mode: autonomous?.mode ?? null,
+      market: autonomous?.market ?? null,
+      emergencyStop: autonomous?.emergencyStop ?? null,
+      nextEvaluationAt: autonomous?.nextEvaluationAt ?? sched.nextWindow ?? null,
+    },
+    components: health?.services ?? [],
+  });
+});
+
+systemHealthRouter.get('/metrics', async (_req: Request, res: Response) => {
+  const q = getMassiveRequestStats();
+  const sched = getSchedulerStatus();
+  const mon = getMonitorStatus();
+  const chartMetrics = getAllDataQualityMetrics();
+  const autonomousMetrics = mongoose.connection?.readyState === 1 ? await getAutonomousMetrics().catch(() => null) : null;
+  const memory = process.memoryUsage();
+  res.json({
+    generatedAt: new Date().toISOString(),
+    process: {
+      pid: process.pid,
+      uptimeSec: Math.round(process.uptime()),
+      memoryRss: memory.rss,
+      memoryHeapUsed: memory.heapUsed,
+      memoryHeapTotal: memory.heapTotal,
+    },
+    marketData: {
+      queueDepth: q.queueDepth,
+      activeRequests: q.activeRequests,
+      inflightDeduped: q.inflightDeduped,
+      deduplicatedRequests: q.deduplicatedRequests,
+      responseCacheEntries: q.responseCacheEntries,
+      chartFeeds: chartMetrics.length,
+    },
+    automation: {
+      schedulerState: sched.state,
+      monitorState: mon.state,
+      schedulerLastTickAt: sched.lastTickAt,
+      monitorLastTickAt: mon.lastTickAt,
+      schedulerSubmittedCount: sched.submittedCount,
+      schedulerSkipReasons: sched.skipReasons,
+    },
+    autonomousTrading: autonomousMetrics?.sources ?? [],
   });
 });

--- a/server/src/features/tradeLifecycle/controllers/tradeLifecycle.controller.ts
+++ b/server/src/features/tradeLifecycle/controllers/tradeLifecycle.controller.ts
@@ -1,0 +1,63 @@
+import type { Request, Response, NextFunction } from 'express';
+import {
+  getLifecycleStatus,
+  listLifecycleActive,
+  listLifecycleEvaluations,
+  listLifecycleHistory,
+  listLifecyclePending,
+  listLifecycleTimeline,
+} from '../positionManager/lifecycleOwner.service';
+
+function limitFromQuery(value: unknown, fallback = 100): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export async function getStatus(_req: Request, res: Response, next: NextFunction) {
+  try {
+    res.json(await getLifecycleStatus());
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function getActive(_req: Request, res: Response, next: NextFunction) {
+  try {
+    res.json({ trades: await listLifecycleActive() });
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function getPending(_req: Request, res: Response, next: NextFunction) {
+  try {
+    res.json({ trades: await listLifecyclePending() });
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function getHistory(req: Request, res: Response, next: NextFunction) {
+  try {
+    res.json({ trades: await listLifecycleHistory(limitFromQuery(req.query.limit)) });
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function getTimeline(req: Request, res: Response, next: NextFunction) {
+  try {
+    const tradeId = typeof req.query.tradeId === 'string' ? req.query.tradeId : undefined;
+    res.json({ events: await listLifecycleTimeline(tradeId, limitFromQuery(req.query.limit, 200)) });
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function getEvaluations(req: Request, res: Response, next: NextFunction) {
+  try {
+    res.json({ evaluations: await listLifecycleEvaluations(limitFromQuery(req.query.limit)) });
+  } catch (error) {
+    next(error);
+  }
+}

--- a/server/src/features/tradeLifecycle/docs/README.md
+++ b/server/src/features/tradeLifecycle/docs/README.md
@@ -1,0 +1,5 @@
+# Trade Lifecycle Feature
+
+Implementation package for the Enterprise Trade Lifecycle Manager.
+
+This feature is additive and reuses existing automation execution, broker journal, risk, strategy, event, portfolio, and trade evaluation infrastructure.

--- a/server/src/features/tradeLifecycle/entry/executionRequests.service.ts
+++ b/server/src/features/tradeLifecycle/entry/executionRequests.service.ts
@@ -1,0 +1,36 @@
+import { submitApprovedIntent } from '../../automation/services/orderSubmission.service';
+import { submitExit } from '../../automation/services/positionManager.service';
+import type { PaperBrokerAdapter } from '../../automation/services/brokerAdapter';
+import type { AutomationPositionDocument, ExitReason } from '../../automation/models/automationPosition.model';
+import type { MarketSessionState } from '../../automation/services/marketSession.service';
+import { getTradeLifecycleFlags } from '../types/config';
+
+export async function requestLifecycleEntry(input: {
+  intentId: string;
+  adapter: PaperBrokerAdapter;
+  ownsLease: boolean;
+  marketSession: MarketSessionState;
+}) {
+  const flags = getTradeLifecycleFlags();
+  if (!flags.AUTONOMOUS_ENTRY_ENABLED) {
+    return { submitted: false, refusedReason: 'AUTONOMOUS_ENTRY_ENABLED=false' };
+  }
+  return submitApprovedIntent(input.intentId, input.adapter, {
+    ownsLease: input.ownsLease,
+    marketSession: input.marketSession,
+  });
+}
+
+export async function requestLifecycleExit(input: {
+  position: AutomationPositionDocument;
+  adapter: PaperBrokerAdapter;
+  reason: ExitReason;
+  now?: Date;
+}) {
+  const flags = getTradeLifecycleFlags();
+  if (!flags.AUTONOMOUS_EXIT_ENABLED) {
+    return { submitted: false, refusedReason: 'AUTONOMOUS_EXIT_ENABLED=false' };
+  }
+  const intent = await submitExit(input.position, input.adapter, input.reason, input.now ?? new Date());
+  return { submitted: Boolean(intent), intent };
+}

--- a/server/src/features/tradeLifecycle/exit/exitDecision.service.ts
+++ b/server/src/features/tradeLifecycle/exit/exitDecision.service.ts
@@ -1,0 +1,80 @@
+import type {
+  LifecycleEvaluationInput,
+  LifecycleMonitoringDecision,
+  MonitoringAction,
+} from '../types/lifecycleTypes';
+import { buildCurrentConfidence } from '../monitor/confidence.service';
+
+function hasMeaningfulExitReason(input: LifecycleEvaluationInput, confidenceDelta: number | null): string | null {
+  const reasons: string[] = [];
+  if (input.updatedThesis && input.originalThesis && input.updatedThesis !== input.originalThesis) {
+    reasons.push('updated thesis no longer matches original thesis');
+  }
+  if (input.strategyChanged) reasons.push('strategy winner changed');
+  if (input.riskChanged) reasons.push('risk profile changed');
+  if (input.eventRisk) reasons.push(`event intelligence risk: ${input.eventRisk}`);
+  if (input.daysToExpiration != null && input.daysToExpiration <= 1) reasons.push('time decay risk is elevated');
+  if (input.spreadPct != null && input.spreadPct > 25) reasons.push('spread is too wide for clean management');
+  if (confidenceDelta != null && confidenceDelta <= -20) reasons.push('confidence weakened materially');
+  if (input.volatility != null && input.volatility > 0.75) reasons.push('volatility regime changed');
+  return reasons.length ? reasons.join('; ') : null;
+}
+
+export function evaluateLifecycleExit(input: LifecycleEvaluationInput): LifecycleMonitoringDecision {
+  const returnPct = input.returnPct;
+  const confidence = buildCurrentConfidence({
+    entryConfidence: input.entryConfidence,
+    returnPct,
+    spreadPct: input.spreadPct,
+    daysToExpiration: input.daysToExpiration,
+    quoteFresh: null,
+    riskChanged: input.riskChanged,
+    strategyChanged: input.strategyChanged,
+  });
+  const reasoning: string[] = [];
+  const thesisReason = hasMeaningfulExitReason(input, confidence.delta);
+  let action: MonitoringAction = 'HOLD';
+  let exitRequired = false;
+  let exitReason: string | null = null;
+
+  if (input.state === 'PENDING_ENTRY' || input.state === 'ENTRY_SUBMITTED') {
+    action = 'WAIT';
+    reasoning.push('Entry is not broker-filled yet.');
+  } else if (input.state === 'EXIT_PENDING' || input.state === 'PARTIAL_EXIT') {
+    action = 'WAIT';
+    reasoning.push('Exit lifecycle is already in progress through the existing execution path.');
+  } else if (input.state === 'MONITORING') {
+    if (thesisReason && returnPct != null && returnPct < -20) {
+      action = 'EXIT';
+      exitRequired = true;
+      exitReason = thesisReason;
+    } else if (thesisReason && confidence.trend === 'Weakening') {
+      action = 'SCALE_OUT';
+      reasoning.push(thesisReason);
+    } else if (returnPct != null && returnPct >= 30 && confidence.trend !== 'Weakening') {
+      action = 'TAKE_PROFIT';
+      reasoning.push('Profit target zone reached while thesis confidence remains intact.');
+    } else if (returnPct != null && returnPct <= -15 && confidence.trend === 'Weakening') {
+      action = 'MOVE_STOP';
+      reasoning.push('Loss is expanding and confidence is weakening; stop should tighten.');
+    } else {
+      action = 'HOLD';
+      reasoning.push('No combined thesis, risk, liquidity, time-decay, or confidence trigger requires action.');
+    }
+  } else {
+    action = 'NO_ACTION';
+    reasoning.push('Trade is outside active monitoring state.');
+  }
+
+  if (action === 'EXIT' && !exitReason) {
+    exitReason = thesisReason ?? 'multi-factor exit condition';
+  }
+  if (action === 'EXIT') {
+    reasoning.push(`Exit requires multi-factor reasoning: ${exitReason}.`);
+  }
+  if (confidence.trend !== 'Unknown') {
+    reasoning.push(`Confidence trend is ${confidence.trend} (${confidence.entry ?? 'n/a'} -> ${confidence.current ?? 'n/a'}).`);
+  }
+
+  return { action, confidence, reasoning, exitRequired, exitReason };
+}

--- a/server/src/features/tradeLifecycle/index.ts
+++ b/server/src/features/tradeLifecycle/index.ts
@@ -1,0 +1,7 @@
+export { tradeLifecycleRouter } from './routes/tradeLifecycle.routes';
+export { startTradeLifecycleScheduler, stopTradeLifecycleScheduler } from './scheduler/tradeLifecycleScheduler.service';
+export { syncTradeLifecycle } from './positionManager/lifecycleOwner.service';
+export { evaluateLifecycleMonitoring } from './monitor/lifecycleMonitor.service';
+export { evaluateLifecycleExit } from './exit/exitDecision.service';
+export { getTradeLifecycleFlags } from './types/config';
+export * from './types/lifecycleTypes';

--- a/server/src/features/tradeLifecycle/journal/lifecycleJournal.service.ts
+++ b/server/src/features/tradeLifecycle/journal/lifecycleJournal.service.ts
@@ -1,0 +1,42 @@
+import {
+  TradeLifecycleJournalModel,
+  type TradeLifecycleDocument,
+} from '../storage/tradeLifecycle.model';
+import type { TradeLifecycleState } from '../types/lifecycleTypes';
+
+export async function appendLifecycleJournal(input: {
+  tradeId: string;
+  eventType: string;
+  state: TradeLifecycleState;
+  previousState: TradeLifecycleState | null;
+  source: string;
+  reason: string;
+  confidence: TradeLifecycleDocument['confidence'];
+  payload?: Record<string, unknown>;
+  at?: Date;
+}) {
+  return TradeLifecycleJournalModel.create({
+    tradeId: input.tradeId,
+    at: input.at ?? new Date(),
+    eventType: input.eventType,
+    state: input.state,
+    previousState: input.previousState,
+    source: input.source,
+    reason: input.reason,
+    confidence: {
+      entry: input.confidence.entry,
+      current: input.confidence.current,
+      trend: input.confidence.trend,
+      delta: input.confidence.delta,
+    },
+    payload: input.payload ?? {},
+  });
+}
+
+export async function listLifecycleJournal(tradeId?: string, limit = 200) {
+  const query = tradeId ? { tradeId } : {};
+  return TradeLifecycleJournalModel.find(query)
+    .sort({ at: -1 })
+    .limit(Math.min(Math.max(limit, 1), 500))
+    .lean();
+}

--- a/server/src/features/tradeLifecycle/monitor/confidence.service.ts
+++ b/server/src/features/tradeLifecycle/monitor/confidence.service.ts
@@ -1,0 +1,57 @@
+import type { ConfidenceTrend, LifecycleConfidence } from '../types/lifecycleTypes';
+
+function finite(value: unknown): number | null {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function clampConfidence(value: number | null): number | null {
+  if (value == null) return null;
+  return Math.min(100, Math.max(0, Math.round(value)));
+}
+
+export function extractEntryConfidence(candidate: any | null, fallback: number | null = null): number | null {
+  const conditions = candidate?.conditions ?? {};
+  const raw =
+    finite(conditions.confidence) ??
+    finite(conditions.score) ??
+    finite(conditions.flowScore) ??
+    finite(candidate?.score) ??
+    fallback;
+  if (raw == null) return null;
+  return clampConfidence(raw <= 1 ? raw * 100 : raw);
+}
+
+export function classifyConfidenceTrend(entry: number | null, current: number | null): ConfidenceTrend {
+  if (entry == null || current == null) return 'Unknown';
+  const delta = current - entry;
+  if (delta >= 5) return 'Improving';
+  if (delta <= -5) return 'Weakening';
+  return 'Stable';
+}
+
+export function buildCurrentConfidence(args: {
+  entryConfidence: number | null;
+  returnPct: number | null;
+  spreadPct: number | null;
+  daysToExpiration: number | null;
+  quoteFresh: boolean | null;
+  riskChanged: boolean;
+  strategyChanged: boolean;
+}): LifecycleConfidence {
+  let score = args.entryConfidence ?? 50;
+  if (args.returnPct != null) score += Math.max(-12, Math.min(12, args.returnPct / 3));
+  if (args.spreadPct != null && args.spreadPct > 15) score -= 8;
+  if (args.daysToExpiration != null && args.daysToExpiration <= 2) score -= 10;
+  if (args.quoteFresh === false) score -= 10;
+  if (args.riskChanged) score -= 12;
+  if (args.strategyChanged) score -= 15;
+  const current = clampConfidence(score);
+  return {
+    entry: args.entryConfidence,
+    current,
+    trend: classifyConfidenceTrend(args.entryConfidence, current),
+    delta: args.entryConfidence != null && current != null ? current - args.entryConfidence : null,
+    changedAt: new Date(),
+  };
+}

--- a/server/src/features/tradeLifecycle/monitor/lifecycleMonitor.service.ts
+++ b/server/src/features/tradeLifecycle/monitor/lifecycleMonitor.service.ts
@@ -1,0 +1,6 @@
+import { evaluateLifecycleExit } from '../exit/exitDecision.service';
+import type { LifecycleEvaluationInput, LifecycleMonitoringDecision } from '../types/lifecycleTypes';
+
+export function evaluateLifecycleMonitoring(input: LifecycleEvaluationInput): LifecycleMonitoringDecision {
+  return evaluateLifecycleExit(input);
+}

--- a/server/src/features/tradeLifecycle/positionManager/lifecycleOwner.service.ts
+++ b/server/src/features/tradeLifecycle/positionManager/lifecycleOwner.service.ts
@@ -1,0 +1,389 @@
+import mongoose from 'mongoose';
+import { AutomationPositionModel } from '../../automation/models/automationPosition.model';
+import { OrderIntentModel } from '../../automation/models/orderIntent.model';
+import { RiskDecisionModel } from '../../automation/models/riskDecision.model';
+import { TradeCandidateModel } from '../../automation/models/tradeCandidate.model';
+import { UniverseEvaluationModel } from '../../automation/models/universeEvaluation.model';
+import { AutomationEventModel } from '../../automation/models/automationEvent.model';
+import { getMonitorStatus } from '../../automation/services/monitorController.service';
+import { getSchedulerStatus } from '../../automation/services/schedulerController.service';
+import { getAutomationHealth } from '../../automation/services/automationHealth.service';
+import { generateTradeReportForTrade, getTradeReportById } from '../../intelligence/services/tradeReportGenerator.service';
+import { expirationFromOptionSymbol } from '../../../shared/symbols/optionSymbol';
+import { computeDteEt } from '../../../shared/time/tradingCalendar';
+import { TradeLifecycleModel, type TradeLifecycleDocument } from '../storage/tradeLifecycle.model';
+import { appendLifecycleJournal, listLifecycleJournal } from '../journal/lifecycleJournal.service';
+import { extractEntryConfidence } from '../monitor/confidence.service';
+import { evaluateLifecycleMonitoring } from '../monitor/lifecycleMonitor.service';
+import { getTradeLifecycleFlags, getTradeLifecycleScheduleMs } from '../types/config';
+import type {
+  LifecycleEvaluationInput,
+  LifecycleMonitoringDecision,
+  TradeLifecycleState,
+} from '../types/lifecycleTypes';
+import {
+  compareLifecycleStates,
+  nextLifecycleStates,
+  targetStateFromAutomationPosition,
+} from './stateMachine.service';
+
+function finite(value: unknown): number | null {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function iso(value: unknown): string | null {
+  if (!value) return null;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? new Date(parsed).toISOString() : value;
+  }
+  if (typeof (value as any)?.toISOString === 'function') return (value as any).toISOString();
+  return null;
+}
+
+function minutesBetween(start: unknown, end: Date): number | null {
+  const started = Date.parse(iso(start) ?? '');
+  if (!Number.isFinite(started)) return null;
+  return Math.max(0, Math.round((end.getTime() - started) / 60_000));
+}
+
+function deriveReturnPct(position: any): number | null {
+  const pnl = finite(position.unrealizedPnl) ?? finite(position.realizedPnl);
+  const entry = finite(position.avgEntryPrice);
+  const qty = finite(position.filledQty) ?? finite(position.orderedQuantity);
+  const cost = entry != null && qty != null ? Math.abs(entry * qty * 100) : null;
+  if (pnl == null || !cost) return finite(position.returnPct);
+  return (pnl / cost) * 100;
+}
+
+async function upsertLifecycleRecord(position: any, candidate: any | null): Promise<TradeLifecycleDocument> {
+  const tradeId = String(position._id);
+  const existing = await TradeLifecycleModel.findOne({ tradeId });
+  if (existing) {
+    existing.automationPositionId = tradeId;
+    existing.automationSessionId = position.automationSessionId ?? existing.automationSessionId;
+    existing.strategyVersionId = position.strategyVersionId ?? existing.strategyVersionId;
+    existing.underlying = position.underlying;
+    existing.optionSymbol = position.optionSymbol;
+    existing.entryIntentId = position.entryIntentId ?? existing.entryIntentId;
+    existing.exitIntentId = position.exitIntentId ?? existing.exitIntentId;
+    existing.riskDecisionId = position.riskDecisionId ?? existing.riskDecisionId;
+    existing.recommendationId = position.universeEvaluationId ?? existing.recommendationId;
+    return existing;
+  }
+
+  const entryConfidence = extractEntryConfidence(candidate);
+  const created = await TradeLifecycleModel.create({
+    tradeId,
+    automationPositionId: tradeId,
+    automationSessionId: position.automationSessionId ?? null,
+    strategyVersionId: position.strategyVersionId ?? null,
+    underlying: position.underlying,
+    optionSymbol: position.optionSymbol,
+    state: 'NEW',
+    previousState: null,
+    entryIntentId: position.entryIntentId ?? null,
+    exitIntentId: position.exitIntentId ?? null,
+    riskDecisionId: position.riskDecisionId ?? null,
+    recommendationId: position.universeEvaluationId ?? null,
+    confidence: {
+      entry: entryConfidence,
+      current: entryConfidence,
+      trend: 'Unknown',
+      delta: 0,
+      changedAt: new Date(),
+    },
+    currentAction: 'NO_ACTION',
+    reasoning: ['Lifecycle record created for automation-approved paper trade.'],
+  });
+  await appendLifecycleJournal({
+    tradeId,
+    eventType: 'LIFECYCLE_CREATED',
+    state: 'NEW',
+    previousState: null,
+    source: 'trade-lifecycle',
+    reason: 'Created lifecycle ownership record from existing automation position.',
+    confidence: created.confidence,
+    payload: { automationPositionId: tradeId, entryIntentId: created.entryIntentId },
+  });
+  return created;
+}
+
+async function advanceLifecycle(
+  lifecycle: TradeLifecycleDocument,
+  target: TradeLifecycleState,
+  payload: Record<string, unknown>
+): Promise<void> {
+  if (compareLifecycleStates(lifecycle.state, target) >= 0) return;
+  for (const next of nextLifecycleStates(lifecycle.state, target)) {
+    const previous = lifecycle.state;
+    lifecycle.previousState = previous;
+    lifecycle.state = next;
+    if (next === 'ARCHIVED') lifecycle.archivedAt = lifecycle.archivedAt ?? new Date();
+    await lifecycle.save();
+    await appendLifecycleJournal({
+      tradeId: lifecycle.tradeId,
+      eventType: 'STATE_TRANSITION',
+      state: next,
+      previousState: previous,
+      source: 'trade-lifecycle',
+      reason: `Advanced lifecycle from ${previous} to ${next}.`,
+      confidence: lifecycle.confidence,
+      payload,
+    });
+  }
+}
+
+function buildEvaluationInput(args: {
+  lifecycle: TradeLifecycleDocument;
+  position: any;
+  candidate: any | null;
+  evaluation: any | null;
+  risk: any | null;
+  now: Date;
+}): LifecycleEvaluationInput {
+  const { lifecycle, position, candidate, evaluation, risk, now } = args;
+  const returnPct = deriveReturnPct(position);
+  const spreadPct =
+    finite((evaluation?.ranking ?? []).find((item: any) => item?.contractSymbol === position.optionSymbol)?.spreadPct) ??
+    null;
+  const conditions = candidate?.conditions ?? {};
+  const originalThesis = [candidate?.signalDirection, conditions.trend, conditions.regime].filter(Boolean).join(' ') || null;
+  const updatedThesis = originalThesis;
+  const marketRegime = String(evaluation?.marketClockDecision?.state ?? conditions.regime ?? '') || null;
+  const riskChanged = Boolean(risk?.approved === false || (risk?.reasonCodes ?? []).length > 0);
+  return {
+    tradeId: lifecycle.tradeId,
+    symbol: position.optionSymbol,
+    state: lifecycle.state,
+    entryConfidence: lifecycle.confidence.entry,
+    currentConfidence: lifecycle.confidence.current,
+    currentProfit: Math.max(0, finite(position.unrealizedPnl) ?? finite(position.realizedPnl) ?? 0),
+    currentLoss: Math.min(0, finite(position.unrealizedPnl) ?? finite(position.realizedPnl) ?? 0),
+    returnPct,
+    spreadPct,
+    liquidityScore: null,
+    daysToExpiration: computeDteEt(expirationFromOptionSymbol(position.optionSymbol), now.getTime()),
+    timeHeldMinutes: minutesBetween(position.openedAt ?? position.createdAt, now),
+    eventRisk: null,
+    originalThesis,
+    updatedThesis,
+    strategyChanged: false,
+    riskChanged,
+    marketRegime,
+    volatility: finite(conditions.volatility),
+  };
+}
+
+async function maybeRunEvaluation(lifecycle: TradeLifecycleDocument, position: any): Promise<void> {
+  if (position.status !== 'CLOSED') return;
+  if (lifecycle.evaluationReportId) return;
+  try {
+    const result = await generateTradeReportForTrade(String(position._id));
+    const report: any = result.report;
+    lifecycle.evaluationReportId = result.report.reportId;
+    lifecycle.evaluationSummary = {
+      reportId: report.reportId,
+      idempotent: result.idempotent,
+      winLoss:
+        Number(report.performance?.realizedPnl ?? 0) > 0
+          ? 'WIN'
+          : Number(report.performance?.realizedPnl ?? 0) < 0
+            ? 'LOSS'
+            : 'FLAT',
+      return: report.performance?.returnPct ?? null,
+      maximumFavorableExcursion: report.performance?.maxFavorableExcursion ?? null,
+      maximumAdverseExcursion: report.performance?.maxAdverseExcursion ?? null,
+      exitQuality: report.grades?.exit?.grade ?? null,
+      strategyPerformance: report.grades?.entry?.grade ?? null,
+      riskPerformance: report.grades?.risk?.grade ?? null,
+      marketRegime: report.marketContext?.marketRegime ?? null,
+      eventContext: report.marketContext ?? null,
+    };
+    await appendLifecycleJournal({
+      tradeId: lifecycle.tradeId,
+      eventType: 'EVALUATION_COMPLETED',
+      state: lifecycle.state,
+      previousState: lifecycle.previousState,
+      source: 'trade-evaluation',
+      reason: 'Existing trade evaluation engine generated the post-trade report.',
+      confidence: lifecycle.confidence,
+      payload: lifecycle.evaluationSummary ?? {},
+    });
+  } catch (error: any) {
+    lifecycle.evaluationSummary = {
+      status: 'UNAVAILABLE',
+      reason: String(error?.message ?? error).slice(0, 300),
+    };
+  }
+}
+
+async function applyMonitoringDecision(
+  lifecycle: TradeLifecycleDocument,
+  decision: LifecycleMonitoringDecision,
+  nextEvaluationAt: Date
+): Promise<void> {
+  const confidenceChanged =
+    lifecycle.confidence.current !== decision.confidence.current ||
+    lifecycle.confidence.trend !== decision.confidence.trend;
+  lifecycle.confidence = decision.confidence as any;
+  lifecycle.currentAction = decision.action;
+  lifecycle.reasoning = decision.reasoning;
+  lifecycle.exitReason = decision.exitReason;
+  lifecycle.lastEvaluatedAt = new Date();
+  lifecycle.nextEvaluationAt = nextEvaluationAt;
+  await lifecycle.save();
+  await appendLifecycleJournal({
+    tradeId: lifecycle.tradeId,
+    eventType: 'MONITORING_DECISION',
+    state: lifecycle.state,
+    previousState: lifecycle.previousState,
+    source: 'trade-lifecycle-monitor',
+    reason: decision.reasoning.join(' '),
+    confidence: lifecycle.confidence,
+    payload: {
+      action: decision.action,
+      exitRequired: decision.exitRequired,
+      exitReason: decision.exitReason,
+    },
+  });
+  if (confidenceChanged) {
+    await appendLifecycleJournal({
+      tradeId: lifecycle.tradeId,
+      eventType: 'CONFIDENCE_CHANGED',
+      state: lifecycle.state,
+      previousState: lifecycle.previousState,
+      source: 'trade-lifecycle-monitor',
+      reason: `Confidence trend is ${decision.confidence.trend}.`,
+      confidence: lifecycle.confidence,
+      payload: { confidence: decision.confidence },
+    });
+  }
+}
+
+export async function syncTradeLifecycle(now = new Date()) {
+  const flags = getTradeLifecycleFlags();
+  if (!flags.TRADE_LIFECYCLE_ENABLED || mongoose.connection?.readyState !== 1) {
+    return { synced: 0, skipped: true, reason: !flags.TRADE_LIFECYCLE_ENABLED ? 'TRADE_LIFECYCLE_DISABLED' : 'MONGO_UNAVAILABLE' };
+  }
+
+  const positions = await AutomationPositionModel.find({
+    status: { $in: ['PENDING_ENTRY', 'OPEN', 'EXITING', 'CLOSED', 'MANUAL_REVIEW'] },
+  })
+    .sort({ updatedAt: -1 })
+    .limit(500)
+    .lean();
+
+  let synced = 0;
+  const nextEvaluationAt = new Date(now.getTime() + getTradeLifecycleScheduleMs());
+  for (const position of positions as any[]) {
+    const [entryIntent, candidate, evaluation, risk] = await Promise.all([
+      position.entryIntentId ? OrderIntentModel.findById(position.entryIntentId).lean() : Promise.resolve(null),
+      position.tradeCandidateId ? TradeCandidateModel.findById(position.tradeCandidateId).lean() : Promise.resolve(null),
+      position.universeEvaluationId ? UniverseEvaluationModel.findById(position.universeEvaluationId).lean() : Promise.resolve(null),
+      position.riskDecisionId ? RiskDecisionModel.findById(position.riskDecisionId).lean() : Promise.resolve(null),
+    ]);
+    const lifecycle = await upsertLifecycleRecord(position, candidate);
+    const target = targetStateFromAutomationPosition(position, entryIntent);
+    await advanceLifecycle(lifecycle, target, {
+      automationPositionStatus: position.status,
+      entryIntentStatus: entryIntent?.status ?? null,
+      exitIntentId: position.exitIntentId ?? null,
+    });
+    if (position.status === 'CLOSED') {
+      await maybeRunEvaluation(lifecycle, position);
+      await advanceLifecycle(lifecycle, 'ARCHIVED', { closedAt: iso(position.closedAt), exitReason: position.exitReason ?? null });
+    }
+    const input = buildEvaluationInput({ lifecycle, position, candidate, evaluation, risk, now });
+    const decision = evaluateLifecycleMonitoring(input);
+    await applyMonitoringDecision(lifecycle, decision, nextEvaluationAt);
+    synced += 1;
+  }
+  return { synced, skipped: false, reason: null };
+}
+
+export async function getLifecycleStatus() {
+  const flags = getTradeLifecycleFlags();
+  const [health, counts, latestDecision] = await Promise.all([
+    getAutomationHealth().catch(() => null),
+    TradeLifecycleModel.aggregate([{ $group: { _id: '$state', count: { $sum: 1 } } }]).catch(() => []),
+    TradeLifecycleModel.findOne({}).sort({ lastEvaluatedAt: -1, updatedAt: -1 }).lean().catch(() => null),
+  ]);
+  return {
+    generatedAt: new Date().toISOString(),
+    flags,
+    aiStatus: health?.automationReady ? 'READY' : 'UNAVAILABLE',
+    paperTrading: true,
+    market: health?.gates?.marketClock?.state ?? 'UNKNOWN',
+    currentStrategy: latestDecision?.strategyVersionId ?? null,
+    currentRegime: latestDecision?.evaluationSummary?.marketRegime ?? null,
+    nextEvaluation: iso(latestDecision?.nextEvaluationAt),
+    currentDecision: latestDecision
+      ? {
+          watching: latestDecision.optionSymbol,
+          recommendation: latestDecision.currentAction,
+          confidence: latestDecision.confidence.current,
+          reason: latestDecision.reasoning.join(' '),
+        }
+      : null,
+    counts: Object.fromEntries((counts as any[]).map((row) => [row._id, row.count])),
+    schedulers: {
+      evaluation: getSchedulerStatus(),
+      monitor: getMonitorStatus(),
+    },
+  };
+}
+
+export async function listLifecycleActive() {
+  await syncTradeLifecycle();
+  return TradeLifecycleModel.find({ state: { $in: ['PENDING_ENTRY', 'ENTRY_SUBMITTED', 'ENTRY_FILLED', 'MONITORING', 'PARTIAL_EXIT', 'EXIT_PENDING'] } })
+    .sort({ updatedAt: -1 })
+    .lean();
+}
+
+export async function listLifecyclePending() {
+  await syncTradeLifecycle();
+  return TradeLifecycleModel.find({ state: { $in: ['NEW', 'PENDING_ENTRY', 'ENTRY_SUBMITTED'] } })
+    .sort({ updatedAt: -1 })
+    .lean();
+}
+
+export async function listLifecycleHistory(limit = 100) {
+  await syncTradeLifecycle();
+  return TradeLifecycleModel.find({ state: { $in: ['EXIT_FILLED', 'EVALUATION', 'ARCHIVED'] } })
+    .sort({ archivedAt: -1, updatedAt: -1 })
+    .limit(Math.min(Math.max(limit, 1), 500))
+    .lean();
+}
+
+export async function listLifecycleTimeline(tradeId?: string, limit = 200) {
+  const lifecycleEvents = await listLifecycleJournal(tradeId, limit);
+  if (tradeId) return lifecycleEvents;
+  const automationEvents = await AutomationEventModel.find({})
+    .sort({ timestamp: -1 })
+    .limit(Math.min(Math.max(limit, 1), 500))
+    .lean()
+    .catch(() => []);
+  return [...lifecycleEvents, ...automationEvents].sort((a: any, b: any) => {
+    const aTime = Date.parse(iso(a.at ?? a.timestamp) ?? '');
+    const bTime = Date.parse(iso(b.at ?? b.timestamp) ?? '');
+    return bTime - aTime;
+  }).slice(0, limit);
+}
+
+export async function listLifecycleEvaluations(limit = 100) {
+  await syncTradeLifecycle();
+  const records = await TradeLifecycleModel.find({ evaluationSummary: { $ne: null } })
+    .sort({ updatedAt: -1 })
+    .limit(Math.min(Math.max(limit, 1), 500))
+    .lean();
+  const reports = await Promise.all(
+    records.map(async (record: any) => {
+      if (!record.evaluationReportId) return null;
+      return getTradeReportById(record.tradeId).catch(() => null);
+    })
+  );
+  return records.map((record, index) => ({ lifecycle: record, report: reports[index] }));
+}

--- a/server/src/features/tradeLifecycle/positionManager/stateMachine.service.ts
+++ b/server/src/features/tradeLifecycle/positionManager/stateMachine.service.ts
@@ -1,0 +1,45 @@
+import type { TradeLifecycleState } from '../types/lifecycleTypes';
+
+export const STATE_ORDER: TradeLifecycleState[] = [
+  'NEW',
+  'PENDING_ENTRY',
+  'ENTRY_SUBMITTED',
+  'ENTRY_FILLED',
+  'MONITORING',
+  'PARTIAL_EXIT',
+  'EXIT_PENDING',
+  'EXIT_FILLED',
+  'EVALUATION',
+  'ARCHIVED',
+];
+
+const stateRank = new Map<TradeLifecycleState, number>(STATE_ORDER.map((state, index) => [state, index]));
+
+export function compareLifecycleStates(a: TradeLifecycleState, b: TradeLifecycleState): number {
+  return (stateRank.get(a) ?? 0) - (stateRank.get(b) ?? 0);
+}
+
+export function nextLifecycleStates(from: TradeLifecycleState, to: TradeLifecycleState): TradeLifecycleState[] {
+  const start = stateRank.get(from);
+  const end = stateRank.get(to);
+  if (start == null || end == null || end <= start) return [];
+  return STATE_ORDER.slice(start + 1, end + 1);
+}
+
+export function isLifecycleTerminal(state: TradeLifecycleState): boolean {
+  return state === 'ARCHIVED';
+}
+
+export function targetStateFromAutomationPosition(position: any, intent?: any | null): TradeLifecycleState {
+  const status = String(position?.status ?? '');
+  if (status === 'CLOSED') return 'ARCHIVED';
+  if (status === 'EXITING' || status === 'MANUAL_REVIEW') return 'EXIT_PENDING';
+  if (status === 'OPEN') return 'MONITORING';
+  if (status === 'PENDING_ENTRY') {
+    if (position?.entryBrokerOrderId || intent?.brokerOrderId || ['SUBMITTING', 'SUBMITTED'].includes(String(intent?.status))) {
+      return 'ENTRY_SUBMITTED';
+    }
+    return 'PENDING_ENTRY';
+  }
+  return 'NEW';
+}

--- a/server/src/features/tradeLifecycle/routes/tradeLifecycle.routes.ts
+++ b/server/src/features/tradeLifecycle/routes/tradeLifecycle.routes.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import {
+  getActive,
+  getEvaluations,
+  getHistory,
+  getPending,
+  getStatus,
+  getTimeline,
+} from '../controllers/tradeLifecycle.controller';
+
+export const tradeLifecycleRouter = Router();
+
+tradeLifecycleRouter.get('/status', getStatus);
+tradeLifecycleRouter.get('/active', getActive);
+tradeLifecycleRouter.get('/pending', getPending);
+tradeLifecycleRouter.get('/history', getHistory);
+tradeLifecycleRouter.get('/timeline', getTimeline);
+tradeLifecycleRouter.get('/evaluations', getEvaluations);

--- a/server/src/features/tradeLifecycle/scheduler/tradeLifecycleScheduler.service.ts
+++ b/server/src/features/tradeLifecycle/scheduler/tradeLifecycleScheduler.service.ts
@@ -1,0 +1,69 @@
+import { randomUUID } from 'crypto';
+import { syncTradeLifecycle } from '../positionManager/lifecycleOwner.service';
+import { getTradeLifecycleFlags, getTradeLifecycleScheduleMs } from '../types/config';
+
+type Runtime = {
+  state: 'STOPPED' | 'ACTIVE' | 'STOPPING';
+  ownerId: string | null;
+  timer: ReturnType<typeof setInterval> | null;
+  startedAt: Date | null;
+  lastTickAt: Date | null;
+  lastError: string | null;
+  lastResult: unknown;
+};
+
+const runtime: Runtime = {
+  state: 'STOPPED',
+  ownerId: null,
+  timer: null,
+  startedAt: null,
+  lastTickAt: null,
+  lastError: null,
+  lastResult: null,
+};
+
+export function getTradeLifecycleSchedulerStatus() {
+  return {
+    state: runtime.state,
+    ownerId: runtime.ownerId,
+    startedAt: runtime.startedAt?.toISOString() ?? null,
+    lastTickAt: runtime.lastTickAt?.toISOString() ?? null,
+    lastError: runtime.lastError,
+    intervalMs: getTradeLifecycleScheduleMs(),
+    lastResult: runtime.lastResult,
+  };
+}
+
+export function startTradeLifecycleScheduler(): boolean {
+  const flags = getTradeLifecycleFlags();
+  if (!flags.TRADE_LIFECYCLE_ENABLED || !flags.TRADE_LIFECYCLE_AUTOSTART || !flags.AUTONOMOUS_MONITORING) {
+    return false;
+  }
+  if (runtime.state !== 'STOPPED') return false;
+  runtime.state = 'ACTIVE';
+  runtime.ownerId = randomUUID();
+  runtime.startedAt = new Date();
+  runtime.lastError = null;
+  const tick = () => {
+    if (runtime.state !== 'ACTIVE') return;
+    runtime.lastTickAt = new Date();
+    syncTradeLifecycle()
+      .then(result => {
+        runtime.lastResult = result;
+        runtime.lastError = null;
+      })
+      .catch(error => {
+        runtime.lastError = String(error?.message ?? error);
+      });
+  };
+  tick();
+  runtime.timer = setInterval(tick, getTradeLifecycleScheduleMs());
+  return true;
+}
+
+export async function stopTradeLifecycleScheduler(): Promise<void> {
+  if (runtime.timer) clearInterval(runtime.timer);
+  runtime.timer = null;
+  runtime.state = 'STOPPED';
+  runtime.ownerId = null;
+}

--- a/server/src/features/tradeLifecycle/storage/tradeLifecycle.model.ts
+++ b/server/src/features/tradeLifecycle/storage/tradeLifecycle.model.ts
@@ -1,0 +1,137 @@
+import mongoose, { Document, Schema } from 'mongoose';
+import {
+  MONITORING_ACTIONS,
+  TRADE_LIFECYCLE_STATES,
+  type ConfidenceTrend,
+  type MonitoringAction,
+  type TradeLifecycleState,
+} from '../types/lifecycleTypes';
+
+export interface TradeLifecycleDocument extends Document {
+  tradeId: string;
+  automationPositionId: string | null;
+  automationSessionId: string | null;
+  strategyVersionId: string | null;
+  underlying: string;
+  optionSymbol: string;
+  state: TradeLifecycleState;
+  previousState: TradeLifecycleState | null;
+  entryIntentId: string | null;
+  exitIntentId: string | null;
+  riskDecisionId: string | null;
+  recommendationId: string | null;
+  evaluationReportId: string | null;
+  confidence: {
+    entry: number | null;
+    current: number | null;
+    trend: ConfidenceTrend;
+    delta: number | null;
+    changedAt: Date | null;
+  };
+  currentAction: MonitoringAction;
+  reasoning: string[];
+  exitReason: string | null;
+  evaluationSummary: Record<string, unknown> | null;
+  lastEvaluatedAt: Date | null;
+  nextEvaluationAt: Date | null;
+  archivedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface TradeLifecycleJournalDocument extends Document {
+  tradeId: string;
+  at: Date;
+  eventType: string;
+  state: TradeLifecycleState;
+  previousState: TradeLifecycleState | null;
+  source: string;
+  reason: string;
+  confidence: {
+    entry: number | null;
+    current: number | null;
+    trend: ConfidenceTrend;
+    delta: number | null;
+  };
+  payload: Record<string, unknown>;
+}
+
+const ConfidenceSchema = new Schema(
+  {
+    entry: { type: Number, default: null },
+    current: { type: Number, default: null },
+    trend: { type: String, enum: ['Improving', 'Weakening', 'Stable', 'Unknown'], required: true, default: 'Unknown' },
+    delta: { type: Number, default: null },
+    changedAt: { type: Date, default: null },
+  },
+  { _id: false }
+);
+
+const TradeLifecycleSchema = new Schema<TradeLifecycleDocument>(
+  {
+    tradeId: { type: String, required: true, unique: true, index: true },
+    automationPositionId: { type: String, default: null, index: true },
+    automationSessionId: { type: String, default: null, index: true },
+    strategyVersionId: { type: String, default: null },
+    underlying: { type: String, required: true, uppercase: true, trim: true },
+    optionSymbol: { type: String, required: true, uppercase: true, trim: true },
+    state: { type: String, enum: TRADE_LIFECYCLE_STATES, required: true, default: 'NEW', index: true },
+    previousState: { type: String, enum: [...TRADE_LIFECYCLE_STATES, null], default: null },
+    entryIntentId: { type: String, default: null },
+    exitIntentId: { type: String, default: null },
+    riskDecisionId: { type: String, default: null },
+    recommendationId: { type: String, default: null },
+    evaluationReportId: { type: String, default: null },
+    confidence: { type: ConfidenceSchema, required: true, default: () => ({}) },
+    currentAction: { type: String, enum: MONITORING_ACTIONS, required: true, default: 'NO_ACTION' },
+    reasoning: { type: [String], default: [] },
+    exitReason: { type: String, default: null },
+    evaluationSummary: { type: Schema.Types.Mixed, default: null },
+    lastEvaluatedAt: { type: Date, default: null },
+    nextEvaluationAt: { type: Date, default: null },
+    archivedAt: { type: Date, default: null },
+  },
+  { timestamps: true, collection: 'trade_lifecycle_records' }
+);
+
+TradeLifecycleSchema.index({ state: 1, updatedAt: -1 });
+TradeLifecycleSchema.index({ automationSessionId: 1, state: 1 });
+
+const JournalConfidenceSchema = new Schema(
+  {
+    entry: { type: Number, default: null },
+    current: { type: Number, default: null },
+    trend: { type: String, enum: ['Improving', 'Weakening', 'Stable', 'Unknown'], required: true, default: 'Unknown' },
+    delta: { type: Number, default: null },
+  },
+  { _id: false }
+);
+
+const TradeLifecycleJournalSchema = new Schema<TradeLifecycleJournalDocument>(
+  {
+    tradeId: { type: String, required: true, index: true },
+    at: { type: Date, required: true, default: () => new Date(), index: true },
+    eventType: { type: String, required: true, index: true },
+    state: { type: String, enum: TRADE_LIFECYCLE_STATES, required: true },
+    previousState: { type: String, enum: [...TRADE_LIFECYCLE_STATES, null], default: null },
+    source: { type: String, required: true },
+    reason: { type: String, required: true },
+    confidence: { type: JournalConfidenceSchema, required: true, default: () => ({}) },
+    payload: { type: Schema.Types.Mixed, default: {} },
+  },
+  { collection: 'trade_lifecycle_journal', versionKey: false }
+);
+
+TradeLifecycleJournalSchema.index({ tradeId: 1, at: 1 });
+
+TradeLifecycleJournalSchema.pre(['findOneAndUpdate', 'updateOne', 'updateMany', 'deleteOne', 'deleteMany'], function preventMutation() {
+  throw new Error('trade lifecycle journal is append only');
+});
+
+export const TradeLifecycleModel =
+  (mongoose.models.TradeLifecycle as mongoose.Model<TradeLifecycleDocument>) ||
+  mongoose.model<TradeLifecycleDocument>('TradeLifecycle', TradeLifecycleSchema);
+
+export const TradeLifecycleJournalModel =
+  (mongoose.models.TradeLifecycleJournal as mongoose.Model<TradeLifecycleJournalDocument>) ||
+  mongoose.model<TradeLifecycleJournalDocument>('TradeLifecycleJournal', TradeLifecycleJournalSchema);

--- a/server/src/features/tradeLifecycle/types/config.ts
+++ b/server/src/features/tradeLifecycle/types/config.ts
@@ -1,0 +1,28 @@
+import type { TradeLifecycleFlags } from './lifecycleTypes';
+
+function envBool(name: keyof TradeLifecycleFlags, fallback: boolean): boolean {
+  const raw = process.env[name];
+  if (raw == null || raw.trim() === '') return fallback;
+  return ['1', 'true', 'yes', 'on'].includes(raw.trim().toLowerCase());
+}
+
+function envNumber(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw == null || raw.trim() === '') return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export function getTradeLifecycleFlags(): TradeLifecycleFlags {
+  return {
+    TRADE_LIFECYCLE_ENABLED: envBool('TRADE_LIFECYCLE_ENABLED', true),
+    TRADE_LIFECYCLE_AUTOSTART: envBool('TRADE_LIFECYCLE_AUTOSTART', false),
+    AUTONOMOUS_MONITORING: envBool('AUTONOMOUS_MONITORING', true),
+    AUTONOMOUS_ENTRY_ENABLED: envBool('AUTONOMOUS_ENTRY_ENABLED', false),
+    AUTONOMOUS_EXIT_ENABLED: envBool('AUTONOMOUS_EXIT_ENABLED', false),
+  };
+}
+
+export function getTradeLifecycleScheduleMs(): number {
+  return Math.max(5_000, envNumber('TRADE_LIFECYCLE_EVALUATION_INTERVAL_MS', 30_000));
+}

--- a/server/src/features/tradeLifecycle/types/lifecycleTypes.ts
+++ b/server/src/features/tradeLifecycle/types/lifecycleTypes.ts
@@ -1,0 +1,75 @@
+export const TRADE_LIFECYCLE_STATES = [
+  'NEW',
+  'PENDING_ENTRY',
+  'ENTRY_SUBMITTED',
+  'ENTRY_FILLED',
+  'MONITORING',
+  'PARTIAL_EXIT',
+  'EXIT_PENDING',
+  'EXIT_FILLED',
+  'EVALUATION',
+  'ARCHIVED',
+] as const;
+
+export type TradeLifecycleState = (typeof TRADE_LIFECYCLE_STATES)[number];
+
+export const MONITORING_ACTIONS = [
+  'HOLD',
+  'SCALE_IN',
+  'SCALE_OUT',
+  'MOVE_STOP',
+  'TAKE_PROFIT',
+  'EXIT',
+  'WAIT',
+  'NO_ACTION',
+] as const;
+
+export type MonitoringAction = (typeof MONITORING_ACTIONS)[number];
+
+export type ConfidenceTrend = 'Improving' | 'Weakening' | 'Stable' | 'Unknown';
+
+export type TradeLifecycleFlags = {
+  TRADE_LIFECYCLE_ENABLED: boolean;
+  TRADE_LIFECYCLE_AUTOSTART: boolean;
+  AUTONOMOUS_MONITORING: boolean;
+  AUTONOMOUS_ENTRY_ENABLED: boolean;
+  AUTONOMOUS_EXIT_ENABLED: boolean;
+};
+
+export type LifecycleConfidence = {
+  entry: number | null;
+  current: number | null;
+  trend: ConfidenceTrend;
+  delta: number | null;
+  changedAt: Date | null;
+};
+
+export type LifecycleEvaluationInput = {
+  tradeId: string;
+  symbol: string;
+  state: TradeLifecycleState;
+  entryConfidence: number | null;
+  currentConfidence: number | null;
+  currentProfit: number | null;
+  currentLoss: number | null;
+  returnPct: number | null;
+  spreadPct: number | null;
+  liquidityScore: number | null;
+  daysToExpiration: number | null;
+  timeHeldMinutes: number | null;
+  eventRisk: string | null;
+  originalThesis: string | null;
+  updatedThesis: string | null;
+  strategyChanged: boolean;
+  riskChanged: boolean;
+  marketRegime: string | null;
+  volatility: number | null;
+};
+
+export type LifecycleMonitoringDecision = {
+  action: MonitoringAction;
+  confidence: LifecycleConfidence;
+  reasoning: string[];
+  exitRequired: boolean;
+  exitReason: string | null;
+};

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -63,6 +63,7 @@ import {
   stopTradeLifecycleScheduler,
 } from './features/tradeLifecycle';
 import { autonomousTradingRouter } from './features/autonomousTrading';
+import { learningRouter, startLearningScheduler, stopLearningScheduler } from './features/learning';
 import { initializeAutomation } from './features/automation/services/sessionRecovery.service';
 import { initMongo } from './shared/db/mongo';
 import { createRequestIdentityMiddleware } from './shared/auth/requestIdentity';
@@ -210,6 +211,7 @@ app.use('/api/strategy-orchestrator', strategyOrchestratorRouter);
 app.use('/api/risk-engine', riskEngineRouter);
 app.use('/api/trade-lifecycle', tradeLifecycleRouter);
 app.use('/api/autonomous-trading', autonomousTradingRouter);
+app.use('/api/learning', learningRouter);
 
 app.use((error: any, req: RequestWithContext, res: express.Response, _next: express.NextFunction) => {
   writeStructuredLog({
@@ -314,6 +316,7 @@ async function start() {
     startEventIntelligenceScanner();
     startStrategyOrchestratorScheduler();
     startRiskEngineScheduler();
+    startLearningScheduler();
   });
 
   // Automation safety foundation (Phase 2A): fail-closed init AFTER the HTTP
@@ -397,6 +400,7 @@ async function gracefulShutdown(signal: string) {
   stopEventIntelligenceScanner();
   stopStrategyOrchestratorScheduler();
   stopRiskEngineScheduler();
+  stopLearningScheduler();
   await stopTradeLifecycleScheduler().catch(() => undefined);
   stopAutomationVisibilityBroadcaster();
   stopOrderReconciliationWorker();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -48,7 +48,21 @@ import {
   shutdownOptionsStream,
 } from './features/marketData/optionsSubscriptionManager.service';
 import { intelligenceRouter } from './features/intelligence/intelligence.routes';
+import { decisionEngineRouter, startDecisionEngineScanner, stopDecisionEngineScanner } from './features/decisionEngine';
+import { eventIntelligenceRouter, startEventIntelligenceScanner, stopEventIntelligenceScanner } from './features/eventIntelligence';
+import {
+  strategyOrchestratorRouter,
+  startStrategyOrchestratorScheduler,
+  stopStrategyOrchestratorScheduler,
+} from './features/strategyOrchestrator';
+import { riskEngineRouter, startRiskEngineScheduler, stopRiskEngineScheduler } from './features/riskEngine';
 import { optionsRouter } from './features/options/options.routes';
+import {
+  tradeLifecycleRouter,
+  startTradeLifecycleScheduler,
+  stopTradeLifecycleScheduler,
+} from './features/tradeLifecycle';
+import { autonomousTradingRouter } from './features/autonomousTrading';
 import { initializeAutomation } from './features/automation/services/sessionRecovery.service';
 import { initMongo } from './shared/db/mongo';
 import { createRequestIdentityMiddleware } from './shared/auth/requestIdentity';
@@ -190,6 +204,12 @@ app.use('/api/system', systemHealthRouter);
 app.use('/api/portfolio', portfolioRouter);
 app.use('/api/market-data', marketDataRouter);
 app.use('/api/intelligence', intelligenceRouter);
+app.use('/api/decision-engine', decisionEngineRouter);
+app.use('/api/event-intelligence', eventIntelligenceRouter);
+app.use('/api/strategy-orchestrator', strategyOrchestratorRouter);
+app.use('/api/risk-engine', riskEngineRouter);
+app.use('/api/trade-lifecycle', tradeLifecycleRouter);
+app.use('/api/autonomous-trading', autonomousTradingRouter);
 
 app.use((error: any, req: RequestWithContext, res: express.Response, _next: express.NextFunction) => {
   writeStructuredLog({
@@ -290,6 +310,10 @@ async function start() {
     console.log(`[SERVER] API listening on :${PORT}`);
     startAgentWarmup();
     scheduleOptionsStreamOwnerStartup();
+    startDecisionEngineScanner();
+    startEventIntelligenceScanner();
+    startStrategyOrchestratorScheduler();
+    startRiskEngineScheduler();
   });
 
   // Automation safety foundation (Phase 2A): fail-closed init AFTER the HTTP
@@ -312,6 +336,7 @@ async function start() {
         if (adapter) startOrderReconciliationWorker(adapter);
         startAutomationScheduler();
         startMonitorScheduler();
+        startTradeLifecycleScheduler();
       }
     })
     .catch(error => {
@@ -368,6 +393,11 @@ async function gracefulShutdown(signal: string) {
   }
   shutdownOptionsStream();
   stopAgentWarmup();
+  stopDecisionEngineScanner();
+  stopEventIntelligenceScanner();
+  stopStrategyOrchestratorScheduler();
+  stopRiskEngineScheduler();
+  await stopTradeLifecycleScheduler().catch(() => undefined);
   stopAutomationVisibilityBroadcaster();
   stopOrderReconciliationWorker();
   await Promise.all([

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -51,6 +51,7 @@ import { intelligenceRouter } from './features/intelligence/intelligence.routes'
 import { optionsRouter } from './features/options/options.routes';
 import { initializeAutomation } from './features/automation/services/sessionRecovery.service';
 import { initMongo } from './shared/db/mongo';
+import { createRequestIdentityMiddleware } from './shared/auth/requestIdentity';
 import { serializeErrorForLog, writeStructuredLog } from './shared/logging/safeLogging';
 import { ensureMarketCacheIndexes } from './features/market/services/marketCache';
 import { startAggregatesWorker } from './features/market/services/aggregatesWorker';
@@ -69,7 +70,14 @@ const corsOptions: CorsOptions = {
   origin: corsOrigin,
   credentials: false,
   methods: ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE', 'OPTIONS'],
-  allowedHeaders: ['Content-Type', 'Authorization', 'X-Request-Id'],
+  allowedHeaders: [
+    'Content-Type',
+    'Authorization',
+    'X-Request-Id',
+    'X-AI-Trader-Actor-Id',
+    'X-AI-Trader-Account-Id',
+    'X-AI-Trader-Roles',
+  ],
   exposedHeaders: ['X-Request-Id'],
   optionsSuccessStatus: 204,
 };
@@ -113,19 +121,6 @@ writeStructuredLog({
   },
 });
 
-// Proxy: Python Screener Service
-// Must be placed before bodyParser/express.json() to stream requests correctly
-const SCREENER_URL = process.env.SCREENER_URL || 'http://localhost:8001';
-app.use(
-  ['/api/screen', '/api/scan', '/api/lab/backtest', '/api/lab/screener'],
-  createProxyMiddleware({
-    target: SCREENER_URL,
-    changeOrigin: true,
-  })
-);
-
-app.use(express.json({ limit: process.env.JSON_BODY_LIMIT || '25mb' }));
-
 type RequestWithContext = express.Request & { requestId?: string };
 
 app.use((req: RequestWithContext, res, next) => {
@@ -147,6 +142,20 @@ app.use((req: RequestWithContext, res, next) => {
   });
   next();
 });
+app.use(createRequestIdentityMiddleware());
+
+// Proxy: Python Screener Service
+// Must be placed before bodyParser/express.json() to stream requests correctly
+const SCREENER_URL = process.env.SCREENER_URL || 'http://localhost:8001';
+app.use(
+  ['/api/screen', '/api/scan', '/api/lab/backtest', '/api/lab/screener'],
+  createProxyMiddleware({
+    target: SCREENER_URL,
+    changeOrigin: true,
+  })
+);
+
+app.use(express.json({ limit: process.env.JSON_BODY_LIMIT || '25mb' }));
 
 app.get(['/health', '/api/health'], (_req, res) => {
   writeStructuredLog({

--- a/server/src/shared/auth/requestIdentity.ts
+++ b/server/src/shared/auth/requestIdentity.ts
@@ -1,0 +1,148 @@
+import type { NextFunction, Request, Response } from 'express';
+import { timingSafeEqual } from 'crypto';
+import { writeStructuredLog } from '../logging/safeLogging';
+
+export type AuthRole = 'viewer' | 'trader' | 'operator' | 'administrator';
+
+export type AuthEnforcementMode = 'observe' | 'required';
+
+export type RequestAuthContext = {
+  authenticated: boolean;
+  actorId: string;
+  accountId: string;
+  roles: AuthRole[];
+  authMethod: 'bearer' | 'legacy-compatible';
+  enforcementMode: AuthEnforcementMode;
+};
+
+export type RequestIdentityConfig = {
+  enforcementMode: AuthEnforcementMode;
+  staticToken: string | null;
+  defaultActorId: string;
+  defaultAccountId: string;
+  defaultRoles: AuthRole[];
+};
+
+type RequestWithContext = Request & {
+  requestId?: string;
+  auth?: RequestAuthContext;
+};
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    auth?: RequestAuthContext;
+  }
+}
+
+const UNSAFE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+const ROLE_SET = new Set<AuthRole>(['viewer', 'trader', 'operator', 'administrator']);
+
+export function createRequestIdentityMiddleware(config = resolveRequestIdentityConfig()) {
+  return (req: RequestWithContext, res: Response, next: NextFunction): void => {
+    const identity = resolveRequestIdentity(req, config);
+    req.auth = identity;
+
+    if (shouldRequireAuthentication(req, config) && !identity.authenticated) {
+      const missingConfig = !config.staticToken;
+      const status = missingConfig ? 503 : 401;
+      const error = missingConfig ? 'AUTH_CONFIGURATION_REQUIRED' : 'AUTH_REQUIRED';
+      writeStructuredLog({
+        component: 'server',
+        module: 'auth',
+        event: 'AUTH_REQUEST_REJECTED',
+        severity: missingConfig ? 'error' : 'warning',
+        requestId: req.requestId,
+        context: {
+          method: req.method,
+          path: req.originalUrl,
+          reason: error,
+          actorId: identity.actorId,
+          accountId: identity.accountId,
+        },
+      });
+      res.status(status).json({ error });
+      return;
+    }
+
+    next();
+  };
+}
+
+export function resolveRequestIdentityConfig(env: NodeJS.ProcessEnv = process.env): RequestIdentityConfig {
+  const mode = normalizeMode(env.AI_TRADER_AUTH_ENFORCEMENT ?? env.AI_TRADER_AUTH_MODE);
+  return {
+    enforcementMode: mode,
+    staticToken: normalizeOptionalSecret(env.AI_TRADER_AUTH_TOKEN ?? env.AI_TRADER_OPERATOR_TOKEN),
+    defaultActorId: normalizeIdentifier(env.AI_TRADER_DEFAULT_ACTOR_ID, 'legacy-operator'),
+    defaultAccountId: normalizeIdentifier(env.AI_TRADER_DEFAULT_ACCOUNT_ID, 'paper-default'),
+    defaultRoles: parseRoles(env.AI_TRADER_DEFAULT_ROLES, ['administrator']),
+  };
+}
+
+export function resolveRequestIdentity(req: Request, config: RequestIdentityConfig): RequestAuthContext {
+  const providedToken = extractBearerToken(req.header('authorization'));
+  if (providedToken && config.staticToken && tokenEquals(providedToken, config.staticToken)) {
+    return {
+      authenticated: true,
+      actorId: normalizeIdentifier(req.header('x-ai-trader-actor-id'), config.defaultActorId),
+      accountId: normalizeIdentifier(req.header('x-ai-trader-account-id'), config.defaultAccountId),
+      roles: parseRoles(req.header('x-ai-trader-roles'), config.defaultRoles),
+      authMethod: 'bearer',
+      enforcementMode: config.enforcementMode,
+    };
+  }
+
+  return {
+    authenticated: false,
+    actorId: config.defaultActorId,
+    accountId: config.defaultAccountId,
+    roles: config.defaultRoles,
+    authMethod: 'legacy-compatible',
+    enforcementMode: config.enforcementMode,
+  };
+}
+
+export function shouldRequireAuthentication(req: Request, config: RequestIdentityConfig): boolean {
+  if (config.enforcementMode !== 'required') return false;
+  if (!UNSAFE_METHODS.has(req.method.toUpperCase())) return false;
+  const path = req.originalUrl || req.path || '';
+  return path === '/api' || path.startsWith('/api/');
+}
+
+function normalizeMode(value: string | undefined): AuthEnforcementMode {
+  const normalized = String(value ?? '').trim().toLowerCase();
+  return normalized === 'required' || normalized === 'enforced' || normalized === 'true' || normalized === '1'
+    ? 'required'
+    : 'observe';
+}
+
+function normalizeOptionalSecret(value: string | undefined): string | null {
+  const normalized = String(value ?? '').trim();
+  return normalized.length ? normalized : null;
+}
+
+function extractBearerToken(header: string | undefined): string | null {
+  const match = String(header ?? '').match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() || null;
+}
+
+function tokenEquals(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  if (leftBuffer.length !== rightBuffer.length) return false;
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function normalizeIdentifier(value: string | undefined, fallback: string): string {
+  const normalized = String(value ?? '').trim();
+  if (!normalized) return fallback;
+  return normalized.replace(/[^\w.:@-]/g, '_').slice(0, 128) || fallback;
+}
+
+function parseRoles(value: string | undefined, fallback: AuthRole[]): AuthRole[] {
+  const roles = String(value ?? '')
+    .split(',')
+    .map(role => role.trim().toLowerCase())
+    .filter((role): role is AuthRole => ROLE_SET.has(role as AuthRole));
+  return roles.length ? Array.from(new Set(roles)) : fallback;
+}

--- a/server/tests/auth.foundation.test.mjs
+++ b/server/tests/auth.foundation.test.mjs
@@ -1,0 +1,126 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import http from 'node:http';
+
+const authModule = await import('../dist/shared/auth/requestIdentity.js');
+const { createRequestIdentityMiddleware } = authModule;
+
+const requiredConfig = {
+  enforcementMode: 'required',
+  staticToken: 'test-token',
+  defaultActorId: 'legacy-operator',
+  defaultAccountId: 'paper-default',
+  defaultRoles: ['viewer'],
+};
+
+function startServer(handler) {
+  const server = http.createServer(handler);
+  return new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({ server, port: server.address().port });
+    });
+  });
+}
+
+function closeServer(server) {
+  return new Promise(resolve => {
+    if (!server?.listening) {
+      resolve();
+      return;
+    }
+    server.close(() => resolve());
+  });
+}
+
+async function withAuthApp(config, assertions) {
+  const app = express();
+  app.use(createRequestIdentityMiddleware(config));
+  app.get('/api/read', (req, res) => {
+    res.json({ auth: req.auth });
+  });
+  app.post('/api/write', (req, res) => {
+    res.json({ auth: req.auth });
+  });
+  app.post('/internal/write', (req, res) => {
+    res.json({ auth: req.auth });
+  });
+
+  const routeServer = await startServer(app);
+  try {
+    await assertions(`http://127.0.0.1:${routeServer.port}`);
+  } finally {
+    await closeServer(routeServer.server);
+  }
+}
+
+test('required auth mode rejects unauthenticated state-changing API requests', async () => {
+  await withAuthApp(requiredConfig, async base => {
+    const response = await fetch(`${base}/api/write`, { method: 'POST' });
+    assert.equal(response.status, 401);
+    assert.deepEqual(await response.json(), { error: 'AUTH_REQUIRED' });
+  });
+});
+
+test('required auth mode fails closed when no bootstrap token is configured', async () => {
+  await withAuthApp({ ...requiredConfig, staticToken: null }, async base => {
+    const response = await fetch(`${base}/api/write`, { method: 'POST' });
+    assert.equal(response.status, 503);
+    assert.deepEqual(await response.json(), { error: 'AUTH_CONFIGURATION_REQUIRED' });
+  });
+});
+
+test('required auth mode accepts bearer token and propagates actor identity', async () => {
+  await withAuthApp(requiredConfig, async base => {
+    const response = await fetch(`${base}/api/write`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-token',
+        'x-ai-trader-actor-id': 'operator@example.com',
+        'x-ai-trader-account-id': 'paper-account-1',
+        'x-ai-trader-roles': 'operator,trader,unknown',
+      },
+    });
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.auth.authenticated, true);
+    assert.equal(payload.auth.actorId, 'operator@example.com');
+    assert.equal(payload.auth.accountId, 'paper-account-1');
+    assert.deepEqual(payload.auth.roles, ['operator', 'trader']);
+    assert.equal(payload.auth.authMethod, 'bearer');
+    assert.equal(payload.auth.enforcementMode, 'required');
+  });
+});
+
+test('required auth mode keeps read-only API requests compatible', async () => {
+  await withAuthApp(requiredConfig, async base => {
+    const response = await fetch(`${base}/api/read`);
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.auth.authenticated, false);
+    assert.equal(payload.auth.actorId, 'legacy-operator');
+    assert.equal(payload.auth.accountId, 'paper-default');
+    assert.deepEqual(payload.auth.roles, ['viewer']);
+    assert.equal(payload.auth.authMethod, 'legacy-compatible');
+  });
+});
+
+test('observe auth mode does not block legacy state-changing requests', async () => {
+  await withAuthApp({ ...requiredConfig, enforcementMode: 'observe' }, async base => {
+    const response = await fetch(`${base}/api/write`, { method: 'POST' });
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.auth.authenticated, false);
+    assert.equal(payload.auth.actorId, 'legacy-operator');
+    assert.equal(payload.auth.enforcementMode, 'observe');
+  });
+});
+
+test('auth enforcement is scoped to API routes', async () => {
+  await withAuthApp(requiredConfig, async base => {
+    const response = await fetch(`${base}/internal/write`, { method: 'POST' });
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.auth.authenticated, false);
+  });
+});

--- a/server/tests/autonomousTrading.test.mjs
+++ b/server/tests/autonomousTrading.test.mjs
@@ -1,0 +1,127 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { startTestMongo, stopTestMongo } from './automation.helpers.mjs';
+
+const gate = await import('../dist/features/autonomousTrading/contracts/entryGate.js');
+const state = await import('../dist/features/autonomousTrading/state/pipelineStateMachine.js');
+const shadow = await import('../dist/features/autonomousTrading/shadow/shadowExecutionAdapter.js');
+const contract = await import('../dist/features/autonomousTrading/contracts/pipelineContract.js');
+const storage = await import('../dist/features/autonomousTrading/storage/autonomousPipelineJournal.service.js');
+const { AutonomousPipelineModel } = await import('../dist/features/autonomousTrading/storage/autonomousPipeline.model.js');
+
+const passingGate = {
+  autonomousTradingEnabled: true,
+  autonomousEntryEnabled: true,
+  mode: 'AUTONOMOUS_PAPER',
+  alpacaPaperConfirmed: true,
+  marketOpen: true,
+  automationReady: true,
+  mongoConnected: true,
+  brokerTruthCurrent: true,
+  executionLeaseOwned: true,
+  emergencyStopActive: false,
+  riskApprovalExists: true,
+  riskApproved: true,
+  riskApprovalExpired: false,
+  recommendationMatchesApproval: true,
+  lifecycleAlreadyExists: false,
+  duplicateOrderIntentExists: false,
+  positionAndOrderLimitsPermitEntry: true,
+};
+
+test('autonomous entry gate fails closed for every required condition', () => {
+  assert.equal(gate.evaluateAutonomousEntryGate(passingGate).allowed, true);
+
+  const rejected = gate.evaluateAutonomousEntryGate({
+    ...passingGate,
+    autonomousEntryEnabled: false,
+    marketOpen: false,
+    brokerTruthCurrent: false,
+    duplicateOrderIntentExists: true,
+  });
+  assert.equal(rejected.allowed, false);
+  assert.deepEqual(rejected.reasonCodes, [
+    'AUTONOMOUS_ENTRY_DISABLED',
+    'MARKET_NOT_OPEN',
+    'BROKER_TRUTH_STALE',
+    'DUPLICATE_ORDER_INTENT',
+  ]);
+  assert.match(rejected.explanation, /Autonomous paper entries are disabled/);
+});
+
+test('autonomous state machine validates append-only transitions', () => {
+  assert.equal(state.canTransition('OBSERVING', 'EVENT_DETECTED'), true);
+  assert.equal(state.canTransition('RISK_REVIEW', 'RISK_REJECTED'), true);
+  assert.equal(state.canTransition('RISK_REJECTED', 'ENTRY_REQUESTED'), false);
+  assert.throws(
+    () =>
+      state.buildPipelineTransition({
+        from: 'RISK_REJECTED',
+        to: 'ENTRY_REQUESTED',
+        actor: 'test',
+        reason: 'invalid',
+      }),
+    /INVALID_AUTONOMOUS_PIPELINE_TRANSITION/
+  );
+});
+
+test('shadow execution simulates fills without broker order identifiers', () => {
+  const record = shadow.createShadowExecution({
+    pipelineId: 'pipe-1',
+    symbol: 'OXY',
+    optionContract: 'O:OXY260724C00060000',
+    quantity: 1,
+    bid: 1,
+    ask: 1.2,
+    stopPrice: 0.75,
+    targetPrice: 1.55,
+    slippagePct: 0.05,
+    requestedAt: new Date('2026-07-24T14:30:00.000Z'),
+  });
+  assert.equal(record.source, 'SHADOW_SIMULATION');
+  assert.equal(record.status, 'SIMULATED_FILLED');
+  assert.equal(record.mid, 1.1);
+  assert.equal(record.simulatedFillPrice, 1.16);
+  assert.match(record.reason, /No broker order was submitted/);
+});
+
+test('autonomous pipeline persistence is idempotent by pipeline id', async (t) => {
+  await startTestMongo();
+  t.after(async () => stopTestMongo());
+  await AutonomousPipelineModel.deleteMany({});
+
+  const pipelineId = contract.stablePipelineId({
+    mode: 'SHADOW',
+    symbol: 'SPY',
+    eventIds: ['event-1'],
+    scanId: 'scan-1',
+    strategyRunId: 'strategy-1',
+    recommendationId: 'risk-pkg-1',
+  });
+  const now = new Date('2026-07-24T14:30:00.000Z').toISOString();
+  const record = contract.emptyPipelineRecord({
+    pipelineId,
+    mode: 'SHADOW',
+    symbol: 'SPY',
+    optionContract: 'O:SPY260724C00600000',
+    idempotencyKey: pipelineId,
+    now,
+  });
+  record.eventContext.eventIds = ['event-1'];
+  record.decisionContext.scanId = 'scan-1';
+  record.strategyContext.runId = 'strategy-1';
+  record.riskContext.approvalId = 'approval-1';
+  record.riskContext.approved = false;
+  record.riskContext.reasonCodes = ['MAX_SECTOR_EXPOSURE'];
+  record.state = 'RISK_REJECTED';
+
+  await storage.upsertAutonomousPipeline(record);
+  await storage.upsertAutonomousPipeline({ ...record, plainLanguageStatus: 'Risk rejected due to sector exposure.' });
+
+  const count = await AutonomousPipelineModel.countDocuments({});
+  const saved = await storage.getAutonomousPipeline(pipelineId);
+  assert.equal(count, 1);
+  assert.equal(saved.plainLanguageStatus, 'Risk rejected due to sector exposure.');
+  assert.equal(saved.riskContext.approved, false);
+});
+

--- a/server/tests/decisionEngine.test.mjs
+++ b/server/tests/decisionEngine.test.mjs
@@ -1,0 +1,121 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { startTestMongo, stopTestMongo } from './automation.helpers.mjs';
+
+async function loadDecisionEngineDist() {
+  const [scanner, ranking, journal, model] = await Promise.all([
+    import('../dist/features/decisionEngine/scanner.service.js'),
+    import('../dist/features/decisionEngine/ranking.service.js'),
+    import('../dist/features/decisionEngine/journal.service.js'),
+    import('../dist/features/decisionEngine/decisionScanJournal.model.js'),
+  ]);
+  return { ...scanner, ...ranking, ...journal, ...model };
+}
+
+function contract(overrides = {}) {
+  return {
+    symbol: overrides.symbol ?? 'O:SPY260821C00500000',
+    type: overrides.type ?? 'call',
+    strike: 500,
+    expiration: '2026-08-21',
+    dte: 10,
+    bid: overrides.bid ?? 4.9,
+    ask: overrides.ask ?? 5.0,
+    mid: overrides.mid ?? 4.95,
+    spread: overrides.spread ?? 0.1,
+    spreadPct: overrides.spreadPct ?? 0.0202,
+    volume: overrides.volume ?? 1200,
+    openInterest: overrides.openInterest ?? 2500,
+    iv: overrides.iv ?? 0.31,
+    delta: overrides.delta ?? 0.52,
+    gamma: 0.03,
+    theta: -0.04,
+    vega: 0.11,
+    quoteTimestamp: '2026-08-10T14:35:00.000Z',
+  };
+}
+
+function scanInput(overrides = {}) {
+  return {
+    now: Date.parse('2026-08-10T14:35:00.000Z'),
+    marketStatus: overrides.marketStatus ?? 'open',
+    watchlist: [
+      {
+        symbol: 'SPY',
+        priority: 1,
+        minConfidence: 0.5,
+        maxSpreadPercent: 8,
+        minimumOpenInterest: 200,
+        minimumVolume: 50,
+        maximumIV: 0.8,
+      },
+    ],
+    chains: {
+      SPY: {
+        underlyingPrice: 501.25,
+        underlyingTimeframe: 'DELAYED',
+        complete: overrides.complete ?? true,
+        contracts: overrides.contracts ?? [contract()],
+      },
+    },
+  };
+}
+
+test('decision engine scores accepted candidates with explainable score components and JSON research', async () => {
+  const mods = await loadDecisionEngineDist();
+  const scan = mods.buildDecisionScan(scanInput());
+  assert.equal(scan.candidates.length, 1);
+  assert.equal(scan.winner.contract.symbol, 'O:SPY260821C00500000');
+  assert.equal(scan.ranking.bestOpportunity.id, scan.winner.id);
+  assert.equal(scan.candidates[0].rejectionCodes.length, 0);
+  assert.ok(scan.candidates[0].scores.liquidity.explanation.includes('volume'));
+  assert.equal(scan.aiReasoning[0].contract, 'O:SPY260821C00500000');
+  assert.equal(scan.aiReasoning[0].expectedMove.source, 'SUPPLIED_IV');
+});
+
+test('decision engine rejects weak candidates with reason codes and explanations', async () => {
+  const mods = await loadDecisionEngineDist();
+  const scan = mods.buildDecisionScan(scanInput({
+    contracts: [
+      contract({
+        symbol: 'O:SPY260821C00450000',
+        bid: 1,
+        ask: 1.4,
+        mid: 1.2,
+        spread: 0.4,
+        spreadPct: 0.3333,
+        volume: 2,
+        openInterest: 10,
+        iv: 1.2,
+      }),
+    ],
+  }));
+  assert.equal(scan.winner, null);
+  assert.equal(scan.noTradeReason, 'No candidate cleared all decision-engine gates.');
+  assert.ok(scan.rejections[0].reasonCode);
+  assert.ok(scan.rejections[0].explanation.includes('rejected'));
+  assert.ok(scan.candidates[0].rejectionCodes.includes('LOW_VOLUME'));
+  assert.ok(scan.candidates[0].rejectionCodes.includes('HIGH_SPREAD'));
+});
+
+test('decision engine journal is append-only and latest scan is replayable', async () => {
+  const mongod = await startTestMongo();
+  try {
+    const mods = await loadDecisionEngineDist();
+    await mods.DecisionScanJournalModel.deleteMany({});
+    await mods.DecisionScanJournalModel.syncIndexes();
+    const first = await mods.runDecisionEngineScan(scanInput());
+    const second = await mods.runDecisionEngineScan(scanInput({
+      contracts: [contract({ symbol: 'O:SPY260821P00500000', type: 'put' })],
+    }));
+    assert.notEqual(first.scanId, second.scanId);
+    const scans = await mods.listDecisionScans(10);
+    assert.equal(scans.length, 2);
+    assert.equal(scans[0].scanId, second.scanId);
+    const replay = await mods.getDecisionScanById(first.scanId);
+    assert.equal(replay.scanId, first.scanId);
+    assert.equal(replay.schemaVersion, 1);
+  } finally {
+    await stopTestMongo(mongod);
+  }
+});

--- a/server/tests/eventIntelligence.test.mjs
+++ b/server/tests/eventIntelligence.test.mjs
@@ -1,0 +1,200 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import { startTestMongo, stopTestMongo } from './automation.helpers.mjs';
+
+async function loadEventDist() {
+  const [
+    classifier,
+    impact,
+    importance,
+    processor,
+    history,
+    trigger,
+    journal,
+    model,
+    routes,
+    decisionScanner,
+    decisionJournalModel,
+    tradeReportModel,
+  ] = await Promise.all([
+    import('../dist/features/eventIntelligence/classification/classifier.service.js'),
+    import('../dist/features/eventIntelligence/impact/impact.service.js'),
+    import('../dist/features/eventIntelligence/impact/importance.service.js'),
+    import('../dist/features/eventIntelligence/events/eventProcessor.service.js'),
+    import('../dist/features/eventIntelligence/storage/historicalSimilarity.service.js'),
+    import('../dist/features/eventIntelligence/events/decisionTrigger.service.js'),
+    import('../dist/features/eventIntelligence/storage/eventJournal.service.js'),
+    import('../dist/features/eventIntelligence/storage/eventIntelligence.model.js'),
+    import('../dist/features/eventIntelligence/routes/eventIntelligence.routes.js'),
+    import('../dist/features/decisionEngine/scanner.service.js'),
+    import('../dist/features/intelligence/models/decisionJournal.model.js'),
+    import('../dist/features/intelligence/models/tradeReport.model.js'),
+  ]);
+  return {
+    ...classifier,
+    ...impact,
+    ...importance,
+    ...processor,
+    ...history,
+    ...trigger,
+    ...journal,
+    ...model,
+    ...routes,
+    ...decisionScanner,
+    ...decisionJournalModel,
+    ...tradeReportModel,
+  };
+}
+
+function event(overrides = {}) {
+  return {
+    id: overrides.id ?? 'event:test:iran-ceasefire',
+    provider: 'massive-market-news',
+    timestamp: overrides.timestamp ?? '2026-07-25T14:00:00.000Z',
+    title: overrides.title ?? 'Iran ceasefire sends crude oil lower',
+    summary: overrides.summary ?? 'Energy markets react as oil volatility moves lower.',
+    category: overrides.category ?? 'News',
+    sentiment: overrides.sentiment ?? { label: 'bullish', score: 0.91, explanation: 'supplied' },
+    symbols: overrides.symbols ?? ['OXY'],
+    sectors: overrides.sectors ?? [],
+    confidence: overrides.confidence ?? 0.8,
+    importance: overrides.importance ?? 0,
+    importanceExplanation: 'pending',
+    source: 'Unit test',
+    url: null,
+    raw: {},
+  };
+}
+
+test('event classification identifies oil/geopolitical context and sectors', async () => {
+  const mods = await loadEventDist();
+  const classified = mods.enrichEventClassification(event());
+  assert.equal(classified.category, 'Oil');
+  assert.ok(classified.sectors.includes('Energy'));
+  assert.ok(classified.confidence >= 0.8);
+});
+
+test('event impact and importance explain affected assets', async () => {
+  const mods = await loadEventDist();
+  const classified = mods.enrichEventClassification(event());
+  const impact = mods.estimateMarketImpact(classified);
+  const scored = mods.scoreEventImportance({
+    event: { ...classified, timestamp: new Date().toISOString() },
+    impact,
+    historicalSimilarity: { similarEvents: [{ decisionId: 'd1' }] },
+  });
+  assert.ok(impact.affectedSymbols.includes('OXY'));
+  assert.ok(impact.affectedEtfs.includes('XLE'));
+  assert.ok(impact.affectedCommodities.includes('Oil'));
+  assert.ok(scored.importance > 50);
+  assert.ok(scored.explanation.includes('Importance'));
+});
+
+test('historical lookup reads decision journal and trade reports without mutation', async () => {
+  const mongod = await startTestMongo();
+  try {
+    const mods = await loadEventDist();
+    await mods.DecisionJournalModel.collection.insertOne({
+      decisionId: 'decision:oil:1',
+      timestamp: new Date('2026-07-20T14:00:00.000Z'),
+      context: { symbol: 'OXY', contract: 'OXY260821C00060000' },
+      reasonSummary: { humanSummary: 'Oil event affected energy trade.' },
+    });
+    await mods.TradeReportModel.collection.insertOne({
+      tradeId: 'trade:oil:1',
+      identity: { underlying: 'OXY' },
+      lifecycle: { holdTimeMinutes: 42 },
+      performance: { realizedPnl: 12, returnPct: 0.08 },
+      createdAt: new Date('2026-07-20T15:00:00.000Z'),
+    });
+    const classified = mods.enrichEventClassification(event());
+    const impact = mods.estimateMarketImpact(classified);
+    const history = await mods.findHistoricalSimilarity(classified, impact);
+    assert.equal(history.similarEvents.length, 1);
+    assert.equal(history.previousTrades, 1);
+    assert.equal(history.historicalWinRate, 1);
+    assert.equal(history.averageHoldingTimeMinutes, 42);
+  } finally {
+    await stopTestMongo(mongod);
+  }
+});
+
+test('processing normalizes, journals, and marks high-importance events as decision triggers', async () => {
+  const mongod = await startTestMongo();
+  try {
+    const mods = await loadEventDist();
+    await mods.EventIntelligenceModel.deleteMany({});
+    const record = await mods.processMarketEvent({
+      ...event({ timestamp: new Date().toISOString() }),
+      confidence: 0.95,
+      symbols: ['OXY', 'CVX'],
+    }, { persist: true, triggerDecisionEngine: false });
+    assert.equal(record.decisionTrigger.status, 'TRIGGERED');
+    assert.equal(record.decisionTrigger.decisionScanId, null);
+    const latest = await mods.getLatestEventRecord();
+    assert.equal(latest.event.id, record.event.id);
+    assert.ok(latest.event.importance >= 80);
+  } finally {
+    await stopTestMongo(mongod);
+  }
+});
+
+test('event intelligence read-only API exposes events, symbol, sector, and context', async () => {
+  const mongod = await startTestMongo();
+  let server;
+  try {
+    const mods = await loadEventDist();
+    await mods.EventIntelligenceModel.deleteMany({});
+    await mods.processMarketEvent({
+      ...event({ timestamp: new Date().toISOString() }),
+      confidence: 0.95,
+      symbols: ['OXY', 'CVX'],
+    }, { persist: true, triggerDecisionEngine: false });
+    const app = express();
+    app.use('/api/event-intelligence', mods.eventIntelligenceRouter);
+    server = await new Promise(resolve => {
+      const s = app.listen(0, '127.0.0.1', () => resolve(s));
+    });
+    const base = `http://127.0.0.1:${server.address().port}`;
+    const [eventsRes, latestRes, symbolRes, sectorRes, contextRes] = await Promise.all([
+      fetch(`${base}/api/event-intelligence/events`),
+      fetch(`${base}/api/event-intelligence/latest`),
+      fetch(`${base}/api/event-intelligence/symbol/OXY`),
+      fetch(`${base}/api/event-intelligence/sector/Energy`),
+      fetch(`${base}/api/event-intelligence/context`),
+    ]);
+    assert.equal(eventsRes.status, 200);
+    assert.equal(latestRes.status, 200);
+    assert.equal(symbolRes.status, 200);
+    assert.equal(sectorRes.status, 200);
+    assert.equal(contextRes.status, 200);
+    const context = await contextRes.json();
+    assert.ok(context.context.affectedSymbols.includes('OXY'));
+  } finally {
+    if (server) await new Promise(resolve => server.close(resolve));
+    await stopTestMongo(mongod);
+  }
+});
+
+test('decision scan records related event context for journal replay', async () => {
+  const mods = await loadEventDist();
+  const scan = mods.buildDecisionScan({
+    now: Date.parse('2026-07-25T14:00:00.000Z'),
+    marketStatus: 'open',
+    eventContext: [{
+      eventId: 'event:test:1',
+      title: 'Iran ceasefire sends crude lower',
+      category: 'Oil',
+      importance: 95,
+      sentiment: 0.91,
+      triggeredReevaluation: true,
+      marketContext: { affectedSymbols: ['OXY'], affectedSectors: ['Energy'] },
+      historicalSimilarity: { historicalWinRate: 1 },
+    }],
+    watchlist: [{ symbol: 'OXY' }],
+    chains: { OXY: { underlyingPrice: 60, contracts: [] } },
+  });
+  assert.equal(scan.relatedEvents.length, 1);
+  assert.equal(scan.relatedEvents[0].eventId, 'event:test:1');
+});

--- a/server/tests/learning.test.mjs
+++ b/server/tests/learning.test.mjs
@@ -1,0 +1,207 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import { startTestMongo, stopTestMongo } from './automation.helpers.mjs';
+
+function grade(score = 80, reason = 'Captured from persisted evidence') {
+  return { grade: 'B', score, reasons: [reason], unavailableInputs: [] };
+}
+
+function report(overrides = {}) {
+  const now = new Date('2026-07-16T15:00:00.000Z');
+  const close = new Date('2026-07-16T15:42:00.000Z');
+  const realizedPnl = overrides.realizedPnl ?? 120;
+  const returnPct = overrides.returnPct ?? 4.2;
+  const strategy = overrides.strategy ?? 'Momentum';
+  const tradeId = overrides.tradeId ?? 'trade-learning-1';
+  const reportId = overrides.reportId ?? `report:${tradeId}`;
+  return {
+    reportId,
+    tradeId,
+    sessionId: 'session-learning',
+    automationSessionId: 'automation-learning',
+    status: 'GENERATED',
+    environment: 'PAPER',
+    tradingDate: '2026-07-16',
+    identity: {
+      underlying: overrides.underlying ?? 'SPY',
+      optionSymbol: overrides.optionSymbol ?? 'SPY260821C00450000',
+      direction: overrides.direction ?? 'BULLISH',
+      strategyVersionId: `${strategy.toLowerCase().replace(/\s+/g, '-')}-v1`,
+      strategy,
+      contractType: 'call',
+      contractStrike: 450,
+      contractExpiration: '2026-08-21',
+    },
+    lifecycle: {
+      openedAt: now,
+      closedAt: close,
+      holdTimeMinutes: 42,
+      exitReason: overrides.exitReason ?? 'PROFIT_TARGET',
+      overnightRecoveryRequired: false,
+      manualReviewReason: null,
+    },
+    execution: {
+      entryOrder: null,
+      exitOrder: null,
+      entryIntent: { estimatedReward: 180 },
+      exitIntent: null,
+      fillCount: 2,
+      partialFillCount: 0,
+      cancellationCount: 0,
+      rejectionCount: 0,
+      retryCount: 0,
+      entrySlippage: 0.01,
+      exitSlippage: 0.02,
+      totalEstimatedSlippage: 0.03,
+      fillQuality: 'Good',
+    },
+    marketContext: {
+      marketStatus: 'OPEN',
+      underlyingPriceAtSelection: 450,
+      spyContext: null,
+      sectorContext: { sector: overrides.sector ?? 'Technology' },
+      vixContext: null,
+      trend: overrides.trend ?? 'TRENDING',
+      marketRegime: overrides.marketRegime ?? 'TRENDING',
+      liquidity: { spreadPct: 0.08 },
+    },
+    greeks: { delta: 0.42, theta: -0.08, gamma: 0.03, vega: 0.11, iv: 0.22 },
+    signal: {
+      confidence: overrides.confidence ?? 0.72,
+      flowScore: 0.8,
+      momentumScore: 0.84,
+      trendScore: 0.78,
+      riskScore: 0.7,
+      candidateRank: 1,
+      candidateStatus: 'APPROVED',
+      riskApproved: true,
+      riskReasonCodes: [],
+      selectedContractScore: 0.82,
+      selectedContractRank: 1,
+    },
+    performance: {
+      entryPrice: 1.25,
+      exitPrice: 1.78,
+      contracts: 1,
+      realizedPnl,
+      returnPct,
+      maxFavorableExcursion: 5.1,
+      maxAdverseExcursion: -1.2,
+      drawdown: -1.2,
+      fees: 1.3,
+    },
+    grades: {
+      entry: grade(85, 'Entry followed the winning setup.'),
+      exit: grade(82, 'Exit followed lifecycle plan.'),
+      risk: grade(80, 'Risk package was approved.'),
+      execution: grade(81, 'Paper fill quality was acceptable.'),
+      market: grade(84, 'Market regime supported the thesis.'),
+      overall: grade(83, 'Trade followed the plan.'),
+    },
+    lessons: {
+      strengths: realizedPnl > 0 ? ['Trend continued after entry.'] : [],
+      weaknesses: realizedPnl < 0 ? ['Entry was late after the signal.'] : [],
+      improvementSuggestions: ['Compare confidence against realized event performance.'],
+    },
+    timeline: [
+      { at: now, label: 'Position opened', source: 'TradeReport', sourceId: reportId, severity: 'info', details: null },
+      { at: close, label: 'Position closed', source: 'TradeReport', sourceId: reportId, severity: realizedPnl < 0 ? 'warning' : 'info', details: null },
+    ],
+    evidence: {
+      positionId: `position:${tradeId}`,
+      tradingSessionId: 'session-learning',
+      brokerOrderIds: [],
+      orderIntentIds: [],
+      riskDecisionId: `risk:${tradeId}`,
+      tradeCandidateId: `candidate:${tradeId}`,
+      contractSelectionId: `selection:${tradeId}`,
+      universeEvaluationIds: [`universe:${tradeId}`],
+      eventIds: overrides.eventIds ?? ['fed:fomc'],
+    },
+    warnings: [],
+    generation: {
+      schemaVersion: 1,
+      generatorVersion: 'test',
+      generatedBy: 'test',
+      sourceWindowStart: now,
+      sourceWindowEnd: close,
+      generatedAt: close,
+      generatedFromPersistedEvidence: true,
+    },
+  };
+}
+
+test('learning intelligence creates append-only artifacts and exposes read-only APIs', async (t) => {
+  await startTestMongo();
+  t.after(async () => stopTestMongo());
+
+  const [
+    { learningRouter, synchronizeLearningArtifacts },
+    { LearningTradeReviewModel },
+    { LearningDatasetModel },
+    { TradeReportModel },
+  ] = await Promise.all([
+    import('../dist/features/learning/index.js'),
+    import('../dist/features/learning/storage/learningTradeReview.model.js'),
+    import('../dist/features/learning/storage/learningDataset.model.js'),
+    import('../dist/features/intelligence/models/tradeReport.model.js'),
+  ]);
+
+  await Promise.all([
+    TradeReportModel.syncIndexes(),
+    LearningTradeReviewModel.syncIndexes(),
+    LearningDatasetModel.syncIndexes(),
+  ]);
+
+  await TradeReportModel.create([
+    report(),
+    report({
+      tradeId: 'trade-learning-2',
+      reportId: 'report:trade-learning-2',
+      strategy: 'Fed Reaction',
+      underlying: 'XLE',
+      optionSymbol: 'XLE260821C00095000',
+      sector: 'Energy',
+      marketRegime: 'NEWS_DRIVEN',
+      realizedPnl: -65,
+      returnPct: -2.4,
+      confidence: 0.9,
+      eventIds: ['oil:inventory', 'fed:fomc'],
+      exitReason: 'STRATEGY_INVALIDATION',
+    }),
+  ]);
+
+  const first = await synchronizeLearningArtifacts(50);
+  const second = await synchronizeLearningArtifacts(50);
+  assert.equal(first.scanned, 2);
+  assert.equal(first.reviewsCreated, 2);
+  assert.equal(first.datasetsCreated, 2);
+  assert.equal(second.reviewsCreated, 0);
+  assert.equal(second.datasetsCreated, 0);
+  assert.equal(await LearningTradeReviewModel.countDocuments({}), 2);
+  assert.equal(await LearningDatasetModel.countDocuments({}), 2);
+
+  const saved = await LearningTradeReviewModel.findOne({ sourceTradeId: 'trade-learning-1' });
+  assert.ok(saved);
+  saved.actualReturn = 99;
+  await assert.rejects(() => saved.save(), /LEARNING_TRADE_REVIEW_APPEND_ONLY/);
+
+  const app = express();
+  app.use('/api/learning', learningRouter);
+  const server = app.listen(0, '127.0.0.1');
+  await new Promise(resolve => server.once('listening', resolve));
+  t.after(() => new Promise(resolve => server.close(resolve)));
+  const base = `http://127.0.0.1:${server.address().port}/api/learning`;
+  for (const path of ['status', 'trades', 'scorecards', 'calibration', 'regimes', 'events', 'datasets']) {
+    const response = await fetch(`${base}/${path}`);
+    assert.equal(response.status, 200, path);
+    const payload = await response.json();
+    assert.equal(typeof payload.generatedAt, 'string', path);
+  }
+
+  const scorecards = await (await fetch(`${base}/scorecards`)).json();
+  assert.ok(scorecards.scorecards.some(card => card.key === 'Momentum'));
+  const events = await (await fetch(`${base}/events`)).json();
+  assert.ok(events.events.some(event => event.event === 'Fed'));
+});

--- a/server/tests/learningPerformance.test.mjs
+++ b/server/tests/learningPerformance.test.mjs
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import { startTestMongo, stopTestMongo } from './automation.helpers.mjs';
+
+test('learning and performance endpoints expose read-only empty-state datasets', async (t) => {
+  await startTestMongo();
+  t.after(async () => stopTestMongo());
+  const { intelligenceRouter } = await import('../dist/features/intelligence/intelligence.routes.js');
+  const app = express();
+  app.use('/api/intelligence', intelligenceRouter);
+  const server = app.listen(0, '127.0.0.1');
+  await new Promise(resolve => server.once('listening', resolve));
+  t.after(() => new Promise(resolve => server.close(resolve)));
+  const base = `http://127.0.0.1:${server.address().port}/api/intelligence`;
+  const paths = [
+    '/learning/trade-review',
+    '/learning/confidence-calibration',
+    '/learning/strategy-scorecards',
+    '/learning/dataset',
+    '/performance/historical',
+    '/performance/market-regime',
+    '/performance/event',
+    '/performance/sector',
+    '/performance/fed',
+    '/performance/options-flow',
+  ];
+  for (const path of paths) {
+    const response = await fetch(`${base}${path}`);
+    assert.equal(response.status, 200, path);
+    const payload = await response.json();
+    assert.equal(typeof payload.generatedAt, 'string', path);
+  }
+});
+

--- a/server/tests/riskEngine.test.mjs
+++ b/server/tests/riskEngine.test.mjs
@@ -1,0 +1,203 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import { startTestMongo, stopTestMongo } from './automation.helpers.mjs';
+
+async function loadRiskDist() {
+  const modules = await Promise.all([
+    import('../dist/features/riskEngine/approval/riskApproval.service.js'),
+    import('../dist/features/riskEngine/controllers/riskEngine.service.js'),
+    import('../dist/features/riskEngine/correlation/correlation.service.js'),
+    import('../dist/features/riskEngine/greeks/greeks.service.js'),
+    import('../dist/features/riskEngine/journal/riskJournal.service.js'),
+    import('../dist/features/riskEngine/limits/riskRules.service.js'),
+    import('../dist/features/riskEngine/positionSizing/positionSizing.service.js'),
+    import('../dist/features/riskEngine/routes/riskEngine.routes.js'),
+    import('../dist/features/riskEngine/storage/riskApproval.model.js'),
+  ]);
+  return Object.assign({}, ...modules);
+}
+
+function recommendation(overrides = {}) {
+  return {
+    recommendationId: overrides.recommendationId ?? 'risk-package:test',
+    strategyRunId: 'strategy-run:test',
+    recommendation: {
+      action: overrides.action ?? 'BUY',
+      explanation: 'Strategy orchestrator selected a risk-reviewable opportunity.',
+      supportingStrategies: [],
+      rejectedStrategies: [],
+      confidence: overrides.confidence ?? 0.82,
+      evidence: { score: 86, explanation: 'Strong evidence.', components: {} },
+      riskHandoff: { allowedForRiskReview: true, message: 'Risk Engine must independently approve.', packageId: 'risk-package:test' },
+    },
+    symbol: overrides.symbol ?? 'OXY',
+    sector: overrides.sector ?? 'Energy',
+    strategyId: overrides.strategyId ?? 'oil-commodity',
+    direction: overrides.direction ?? 'BULLISH',
+    confidence: overrides.confidence ?? 0.82,
+    expectedReturn: overrides.expectedReturn ?? 0.42,
+    contract: {
+      symbol: 'O:OXY260821C00065000',
+      estimatedUnitRisk: overrides.estimatedUnitRisk ?? 175,
+      liquidity: {
+        bid: overrides.bid ?? 1.65,
+        ask: overrides.ask ?? 1.75,
+        spreadPct: overrides.spreadPct ?? 0.058,
+        volume: overrides.volume ?? 1800,
+        openInterest: overrides.openInterest ?? 6400,
+        impliedVolatility: overrides.impliedVolatility ?? 0.56,
+      },
+      greeks: {
+        delta: overrides.delta ?? 0.42,
+        gamma: overrides.gamma ?? 0.04,
+        theta: overrides.theta ?? -4,
+        vega: overrides.vega ?? 8,
+        rho: overrides.rho ?? 0.02,
+      },
+    },
+    marketRegime: {
+      current: overrides.regime ?? 'NEWS_DRIVEN',
+      historical: ['SECTOR_ROTATION'],
+      confidence: 0.74,
+      explanation: 'Test market regime.',
+    },
+    marketStatus: overrides.marketStatus ?? 'open',
+    eventContext: {
+      latestEvents: [{
+        id: 'event:test',
+        title: 'Oil supply event affects energy equities',
+        category: 'Oil',
+        importance: overrides.eventImportance ?? 88,
+        sentiment: 0.7,
+        affectedSymbols: ['OXY', 'CVX'],
+        affectedEtfs: ['XLE', 'USO'],
+        affectedSectors: ['Energy'],
+      }],
+    },
+    raw: {},
+  };
+}
+
+function portfolio(overrides = {}) {
+  return {
+    timestamp: '2026-07-25T14:00:00.000Z',
+    portfolioSize: overrides.portfolioSize ?? 100000,
+    buyingPower: overrides.buyingPower ?? null,
+    availableCapital: null,
+    currentPositions: overrides.currentPositions ?? [],
+    exposure: {
+      sectorExposure: overrides.sectorExposure ?? {},
+      tickerExposure: overrides.tickerExposure ?? {},
+      strategyExposure: {},
+      macroExposure: {},
+      longExposure: 0,
+      shortExposure: 0,
+      cashAllocation: null,
+      maximumConcurrentTrades: 8,
+      currentOpenTrades: overrides.currentOpenTrades ?? 0,
+      historicalMaximum: {},
+      recommended: {},
+    },
+    greeks: overrides.greeks ?? { delta: null, gamma: null, theta: null, vega: null, rho: null },
+    riskBudget: {
+      dailyRealizedLoss: overrides.dailyRealizedLoss ?? 0,
+      dailyUnrealizedLoss: overrides.dailyUnrealizedLoss ?? 0,
+      riskConsumed: overrides.riskConsumed ?? 0,
+      remainingRiskBudget: overrides.remainingRiskBudget ?? 1500,
+      maximumConsecutiveLosses: 3,
+      consecutiveLosses: 0,
+      maximumOpenRisk: 6000,
+      openRisk: overrides.openRisk ?? 0,
+    },
+  };
+}
+
+test('position sizing scales by confidence, market regime, and portfolio heat', async () => {
+  const mods = await loadRiskDist();
+  const rules = mods.getRiskRuleSet(new Date('2026-07-25T14:00:00.000Z'));
+  const calm = mods.calculatePositionSize(recommendation({ regime: 'TRENDING' }), portfolio(), rules);
+  const stressed = mods.calculatePositionSize(recommendation({ regime: 'HIGH_VOLATILITY' }), portfolio({ openRisk: 5000 }), rules);
+  assert.ok(calm.suggestedContracts > stressed.suggestedContracts);
+  assert.ok(calm.explanation.includes('confidence'));
+});
+
+test('greeks aggregation and correlation explain portfolio risk', async () => {
+  const mods = await loadRiskDist();
+  const positions = [
+    {
+      symbol: 'O:XLE260821C00090000',
+      underlying: 'XLE',
+      sector: 'Energy',
+      strategyId: 'oil-commodity',
+      direction: 'LONG',
+      quantity: 2,
+      marketValue: 1200,
+      unrealizedPnl: 0,
+      greeks: { delta: 0.8, gamma: 0.05, theta: -9, vega: 18, rho: 0.01 },
+    },
+  ];
+  const greeks = mods.aggregateGreeks(positions);
+  const corr = mods.estimateCorrelationRisk(
+    recommendation({ symbol: 'OXY', sector: 'Energy' }),
+    portfolio({ currentPositions: positions, tickerExposure: { XLE: 1200 } })
+  );
+  assert.equal(greeks.delta, 0.8);
+  assert.ok(corr.score > 0);
+  assert.ok(corr.correlatedSymbols.includes('XLE'));
+});
+
+test('risk approval approves clean actionable recommendations without execution', async () => {
+  const mods = await loadRiskDist();
+  const approval = mods.evaluateRiskApproval(recommendation(), portfolio(), new Date('2026-07-25T14:00:00.000Z'));
+  assert.equal(approval.status, 'APPROVE');
+  assert.equal(approval.approved, true);
+  assert.ok(approval.suggestedPositionSize.suggestedContracts > 1);
+  assert.equal(approval.reasons.length, 0);
+});
+
+test('risk approval rejects liquidity, confidence, daily loss, and market violations with reason codes', async () => {
+  const mods = await loadRiskDist();
+  const approval = mods.evaluateRiskApproval(
+    recommendation({ confidence: 0.3, spreadPct: 0.4, marketStatus: 'closed' }),
+    portfolio({ remainingRiskBudget: 50 }),
+    new Date('2026-07-25T14:00:00.000Z')
+  );
+  const codes = approval.reasons.map(reason => reason.code);
+  assert.equal(approval.status, 'REJECT');
+  assert.ok(codes.includes('LOW_CONFIDENCE'));
+  assert.ok(codes.includes('HIGH_SPREAD'));
+  assert.ok(codes.includes('MARKET_CLOSED'));
+  assert.ok(codes.includes('MAX_DAILY_LOSS'));
+  assert.ok(approval.reasons.every(reason => reason.explanation && reason.suggestedImprovement));
+});
+
+test('risk journal is append-only and read-only API exposes risk state', async () => {
+  const mongod = await startTestMongo();
+  let server;
+  try {
+    const mods = await loadRiskDist();
+    await mods.RiskApprovalModel.deleteMany({});
+    const first = await mods.runRiskReview({ recommendation: recommendation({ recommendationId: 'risk:1' }) });
+    const second = await mods.runRiskReview({ recommendation: recommendation({ recommendationId: 'risk:2', marketStatus: 'closed' }) });
+    assert.notEqual(first.approval.approvalId, second.approval.approvalId);
+    const history = await mods.listRiskApprovals(10);
+    assert.equal(history.length, 2);
+    assert.equal(history[0].approvalId, second.approval.approvalId);
+
+    const app = express();
+    app.use('/api/risk-engine', mods.riskEngineRouter);
+    server = await new Promise(resolve => {
+      const s = app.listen(0, '127.0.0.1', () => resolve(s));
+    });
+    const base = `http://127.0.0.1:${server.address().port}`;
+    const paths = ['status', 'portfolio', 'exposure', 'greeks', 'risk-budget', 'rules', 'history', 'approval-queue'];
+    const responses = await Promise.all(paths.map(path => fetch(`${base}/api/risk-engine/${path}`)));
+    assert.deepEqual(responses.map(response => response.status), Array(paths.length).fill(200));
+    const status = await responses[0].json();
+    assert.equal(status.status.latestApprovalId, second.approval.approvalId);
+  } finally {
+    if (server) await new Promise(resolve => server.close(resolve));
+    await stopTestMongo(mongod);
+  }
+});

--- a/server/tests/security.headers.test.mjs
+++ b/server/tests/security.headers.test.mjs
@@ -68,3 +68,25 @@ test('system health exposes additive runtime telemetry fields', async () => {
     await closeServer(routeServer.server);
   }
 });
+
+test('system status and metrics expose read-only operations summaries', async () => {
+  const routeServer = await startServer(app);
+  try {
+    const [statusResponse, metricsResponse] = await Promise.all([
+      fetch(`http://127.0.0.1:${routeServer.port}/api/system/status`),
+      fetch(`http://127.0.0.1:${routeServer.port}/api/system/metrics`),
+    ]);
+    assert.ok([200, 503].includes(statusResponse.status));
+    assert.equal(metricsResponse.status, 200);
+    const status = await statusResponse.json();
+    const metrics = await metricsResponse.json();
+    assert.equal(typeof status.generatedAt, 'string');
+    assert.ok(['RUNNING', 'DEGRADED', 'BLOCKED', 'STOPPED'].includes(status.status));
+    assert.ok('brokerTruthCurrent' in status.system);
+    assert.equal(typeof metrics.marketData.queueDepth, 'number');
+    assert.equal(typeof metrics.process.uptimeSec, 'number');
+    assert.ok(Array.isArray(metrics.autonomousTrading));
+  } finally {
+    await closeServer(routeServer.server);
+  }
+});

--- a/server/tests/strategyOrchestrator.test.mjs
+++ b/server/tests/strategyOrchestrator.test.mjs
@@ -1,0 +1,151 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import { startTestMongo, stopTestMongo } from './automation.helpers.mjs';
+
+async function loadStrategyDist() {
+  const modules = await Promise.all([
+    import('../dist/features/strategyOrchestrator/strategies/strategyRegistry.service.js'),
+    import('../dist/features/strategyOrchestrator/scheduler/strategyScheduler.service.js'),
+    import('../dist/features/strategyOrchestrator/scheduler/marketRegime.service.js'),
+    import('../dist/features/strategyOrchestrator/ranking/evidence.service.js'),
+    import('../dist/features/strategyOrchestrator/ranking/ranking.service.js'),
+    import('../dist/features/strategyOrchestrator/ranking/recommendation.service.js'),
+    import('../dist/features/strategyOrchestrator/controllers/orchestrator.service.js'),
+    import('../dist/features/strategyOrchestrator/storage/strategyJournal.service.js'),
+    import('../dist/features/strategyOrchestrator/storage/strategyOrchestrator.model.js'),
+    import('../dist/features/strategyOrchestrator/routes/strategyOrchestrator.routes.js'),
+  ]);
+  return Object.assign({}, ...modules);
+}
+
+function context(overrides = {}) {
+  return {
+    timestamp: '2026-07-25T14:00:00.000Z',
+    eventContext: {
+      latestEvents: overrides.events ?? [{
+        id: 'event:oil',
+        title: 'Iran ceasefire sends crude oil lower',
+        category: 'Oil',
+        importance: 95,
+        sentiment: 0.91,
+        affectedSymbols: ['OXY', 'CVX'],
+        affectedEtfs: ['USO', 'XLE'],
+        affectedSectors: ['Energy'],
+      }],
+    },
+    decisionContext: {
+      latestScanId: 'scan:1',
+      bestOpportunity: { symbol: 'OXY', score: 82, confidence: 0.8, recommendation: 'BUY_CALL' },
+      rejectedCount: 2,
+      noTradeReason: null,
+    },
+    marketData: { marketStatus: 'open', trendScore: 74, momentumScore: 80, volatilityScore: 62 },
+    portfolio: {
+      currentPositions: [],
+      buyingPower: null,
+      sectorExposure: overrides.sectorExposure ?? {},
+      openRisk: null,
+      greeks: { delta: null, gamma: null, theta: null, vega: null },
+      availableCapital: null,
+      maximumDailyLoss: null,
+      adjustmentExplanation: 'No open automation portfolio exposure was found in persisted records.',
+    },
+    watchlist: ['OXY', 'CVX', 'SPY'],
+    news: ['Iran ceasefire sends crude oil lower'],
+    sentiment: { bullish: 1, bearish: 0, neutral: 0 },
+    technicalAnalysis: { trendScore: 74, momentumScore: 80, volatilityScore: 62 },
+    marketRegime: {
+      current: 'NEWS_DRIVEN',
+      historical: ['SECTOR_ROTATION'],
+      confidence: 0.78,
+      explanation: 'News driven test regime.',
+    },
+  };
+}
+
+test('strategy registry exposes all initial strategies with evaluate contracts', async () => {
+  const mods = await loadStrategyDist();
+  const strategies = mods.listRegisteredStrategies();
+  assert.equal(strategies.length, 15);
+  for (const strategy of strategies) {
+    assert.ok(strategy.id);
+    assert.ok(strategy.requiredInputs.includes('eventContext'));
+    const result = strategy.evaluate(context());
+    assert.equal(result.strategyId, strategy.id);
+    assert.equal(typeof result.confidence, 'number');
+    assert.ok(Array.isArray(result.reasoning));
+  }
+});
+
+test('scheduler selects oil strategies and skips unrelated fed strategy', async () => {
+  const mods = await loadStrategyDist();
+  const scheduled = mods.scheduleStrategies(mods.listRegisteredStrategies(), context());
+  const selectedIds = scheduled.selected.map(strategy => strategy.id);
+  assert.ok(selectedIds.includes('oil-commodity'));
+  assert.ok(selectedIds.includes('sector-rotation'));
+  assert.equal(selectedIds.includes('fed-reaction'), false);
+});
+
+test('evidence, ranking, conflict resolution, and recommendation are explainable', async () => {
+  const mods = await loadStrategyDist();
+  const ctx = context();
+  const evidence = mods.buildEvidenceScore(ctx);
+  const evals = [
+    { strategyId: 'a', name: 'Momentum', direction: 'BULLISH', confidence: 0.9, risk: 0.2, expectedReturn: 0.6, positionSize: 0.05, evidenceScore: 90, reasoning: [], rejected: false, rejectionReason: null },
+    { strategyId: 'b', name: 'Macro', direction: 'BEARISH', confidence: 0.75, risk: 0.25, expectedReturn: 0.55, positionSize: 0.04, evidenceScore: 85, reasoning: [], rejected: false, rejectionReason: null },
+  ];
+  const rankings = mods.rankStrategies(evals);
+  const conflicts = mods.resolveStrategyConflicts(evals);
+  const recommendation = mods.buildRecommendationPackage({ rankings, conflicts, evidence });
+  assert.ok(evidence.score > 50);
+  assert.equal(conflicts.hasConflict, true);
+  assert.equal(recommendation.action, 'WAIT');
+  assert.ok(recommendation.explanation.includes('Conflict'));
+});
+
+test('portfolio sector concentration reduces oil strategy confidence', async () => {
+  const mods = await loadStrategyDist();
+  const oil = mods.listRegisteredStrategies().find(strategy => strategy.id === 'oil-commodity');
+  const normal = oil.evaluate(context());
+  const heavyEnergy = oil.evaluate(context({ sectorExposure: { Energy: 100000, Technology: 10000 } }));
+  assert.ok(heavyEnergy.confidence < normal.confidence);
+  assert.ok(heavyEnergy.reasoning.some(line => line.includes('reduced confidence')));
+});
+
+test('orchestrator journal is append-only and read-only API exposes state', async () => {
+  const mongod = await startTestMongo();
+  let server;
+  try {
+    const mods = await loadStrategyDist();
+    await mods.StrategyOrchestratorModel.deleteMany({});
+    const first = await mods.runStrategyOrchestrator();
+    const second = await mods.runStrategyOrchestrator();
+    assert.notEqual(first.runId, second.runId);
+    const history = await mods.listStrategyRuns(10);
+    assert.equal(history.length, 2);
+    assert.equal(history[0].runId, second.runId);
+
+    const app = express();
+    app.use('/api/strategy-orchestrator', mods.strategyOrchestratorRouter);
+    server = await new Promise(resolve => {
+      const s = app.listen(0, '127.0.0.1', () => resolve(s));
+    });
+    const base = `http://127.0.0.1:${server.address().port}`;
+    const [status, recommendations, strategies, evidence] = await Promise.all([
+      fetch(`${base}/api/strategy-orchestrator/status`),
+      fetch(`${base}/api/strategy-orchestrator/recommendations`),
+      fetch(`${base}/api/strategy-orchestrator/strategies`),
+      fetch(`${base}/api/strategy-orchestrator/evidence`),
+    ]);
+    assert.equal(status.status, 200);
+    assert.equal(recommendations.status, 200);
+    assert.equal(strategies.status, 200);
+    assert.equal(evidence.status, 200);
+    const rec = await recommendations.json();
+    assert.ok(rec.recommendation.riskHandoff.message.includes('Risk Engine'));
+  } finally {
+    if (server) await new Promise(resolve => server.close(resolve));
+    await stopTestMongo(mongod);
+  }
+});

--- a/server/tests/tradeLifecycle.test.mjs
+++ b/server/tests/tradeLifecycle.test.mjs
@@ -1,0 +1,181 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import mongoose from 'mongoose';
+import { startTestMongo, stopTestMongo } from './automation.helpers.mjs';
+
+async function loadLifecycleDist() {
+  const [
+    sessionModel,
+    intentModel,
+    candidateModel,
+    positionModel,
+    lifecycleModel,
+    lifecycleService,
+    monitorService,
+    config,
+  ] = await Promise.all([
+    import('../dist/features/automation/models/automationSession.model.js'),
+    import('../dist/features/automation/models/orderIntent.model.js'),
+    import('../dist/features/automation/models/tradeCandidate.model.js'),
+    import('../dist/features/automation/models/automationPosition.model.js'),
+    import('../dist/features/tradeLifecycle/storage/tradeLifecycle.model.js'),
+    import('../dist/features/tradeLifecycle/positionManager/lifecycleOwner.service.js'),
+    import('../dist/features/tradeLifecycle/monitor/lifecycleMonitor.service.js'),
+    import('../dist/features/tradeLifecycle/types/config.js'),
+  ]);
+  return {
+    ...sessionModel,
+    ...intentModel,
+    ...candidateModel,
+    ...positionModel,
+    ...lifecycleModel,
+    ...lifecycleService,
+    ...monitorService,
+    ...config,
+  };
+}
+
+async function resetDb() {
+  const db = mongoose.connection?.db;
+  const collections = await db.listCollections().toArray();
+  for (const { name } of collections) await db.collection(name).deleteMany({});
+}
+
+test.before(async () => {
+  await startTestMongo();
+});
+
+test.after(async () => {
+  await stopTestMongo();
+});
+
+test('trade lifecycle records every intermediate state for an already-open automation position', async () => {
+  const mods = await loadLifecycleDist();
+  await resetDb();
+
+  const session = await mods.AutomationSessionModel.create({
+    mode: 'paper',
+    strategyVersionId: 'sv-lifecycle',
+    underlying: 'SPY',
+    status: 'READY',
+    healthStatus: 'HEALTHY',
+    reconciliationStatus: 'CLEAN',
+  });
+  const candidate = await mods.TradeCandidateModel.create({
+    automationSessionId: String(session._id),
+    strategyVersionId: 'sv-lifecycle',
+    underlying: 'SPY',
+    barTimestamp: new Date('2026-07-24T14:35:00.000Z'),
+    signalDirection: 'BULLISH',
+    status: 'RISK_APPROVED',
+    reasonCodes: [],
+    strategyConfigSnapshot: {},
+    conditions: { confidence: 0.82, trend: 'UP', regime: 'REGULAR_SESSION' },
+  });
+  const intent = await mods.OrderIntentModel.create({
+    automationSessionId: String(session._id),
+    strategyVersionId: 'sv-lifecycle',
+    underlying: 'SPY',
+    optionSymbol: 'SPY260821C00450000',
+    intentType: 'ENTRY',
+    direction: 'BUY',
+    quantity: 1,
+    orderType: 'limit',
+    limitPrice: 5,
+    timeInForce: 'day',
+    status: 'SUBMITTED',
+    idempotencyKey: 'tl-entry-key',
+    clientOrderId: 'at2a-tl-entry',
+    idempotencyInputs: {
+      automationSessionId: String(session._id),
+      strategyVersionId: 'sv-lifecycle',
+      underlying: 'SPY',
+      signalDirection: 'BUY',
+      closedBarTimestamp: '2026-07-24T14:35:00.000Z',
+      intentType: 'ENTRY',
+      idempotencyScope: null,
+    },
+    brokerOrderId: 'broker-entry',
+    submittedAt: new Date('2026-07-24T14:36:00.000Z'),
+  });
+  const position = await mods.AutomationPositionModel.create({
+    source: 'AUTOMATION',
+    automationSessionId: String(session._id),
+    strategyVersionId: 'sv-lifecycle',
+    tradeCandidateId: String(candidate._id),
+    riskDecisionId: null,
+    underlying: 'SPY',
+    optionSymbol: 'SPY260821C00450000',
+    direction: 'BULLISH',
+    entryIntentId: String(intent._id),
+    entryBrokerOrderId: 'broker-entry',
+    entryClientOrderId: 'at2a-tl-entry',
+    status: 'OPEN',
+    orderedQuantity: 1,
+    filledQty: 1,
+    avgEntryPrice: 5,
+    currentMark: 5.4,
+    unrealizedPnl: 40,
+    openedAt: new Date('2026-07-24T14:37:00.000Z'),
+  });
+
+  const result = await mods.syncTradeLifecycle(new Date('2026-07-24T15:00:00.000Z'));
+  assert.equal(result.synced, 1);
+  const record = await mods.TradeLifecycleModel.findOne({ tradeId: String(position._id) }).lean();
+  assert.equal(record.state, 'MONITORING');
+  assert.equal(record.confidence.entry, 82);
+  const transitions = await mods.TradeLifecycleJournalModel.find({ tradeId: String(position._id), eventType: 'STATE_TRANSITION' })
+    .sort({ at: 1 })
+    .lean();
+  assert.deepEqual(
+    transitions.map(event => event.state),
+    ['PENDING_ENTRY', 'ENTRY_SUBMITTED', 'ENTRY_FILLED', 'MONITORING']
+  );
+});
+
+test('exit recommendation requires more than P/L alone', async () => {
+  const mods = await loadLifecycleDist();
+  const input = {
+    tradeId: 't1',
+    symbol: 'SPY260821C00450000',
+    state: 'MONITORING',
+    entryConfidence: 90,
+    currentConfidence: 90,
+    currentProfit: 0,
+    currentLoss: -250,
+    returnPct: -40,
+    spreadPct: 5,
+    liquidityScore: null,
+    daysToExpiration: 10,
+    timeHeldMinutes: 30,
+    eventRisk: null,
+    originalThesis: 'UP',
+    updatedThesis: 'UP',
+    strategyChanged: false,
+    riskChanged: false,
+    marketRegime: 'OPEN',
+    volatility: null,
+  };
+  const pnlOnly = mods.evaluateLifecycleMonitoring(input);
+  assert.notEqual(pnlOnly.action, 'EXIT');
+
+  const thesisAndRisk = mods.evaluateLifecycleMonitoring({
+    ...input,
+    riskChanged: true,
+  });
+  assert.equal(thesisAndRisk.action, 'EXIT');
+  assert.match(thesisAndRisk.exitReason, /risk profile changed/);
+});
+
+test('trade lifecycle feature flags default to paper-safe settings', async () => {
+  const mods = await loadLifecycleDist();
+  delete process.env.AUTONOMOUS_ENTRY_ENABLED;
+  delete process.env.AUTONOMOUS_EXIT_ENABLED;
+  delete process.env.TRADE_LIFECYCLE_AUTOSTART;
+  const flags = mods.getTradeLifecycleFlags();
+  assert.equal(flags.TRADE_LIFECYCLE_ENABLED, true);
+  assert.equal(flags.TRADE_LIFECYCLE_AUTOSTART, false);
+  assert.equal(flags.AUTONOMOUS_MONITORING, true);
+  assert.equal(flags.AUTONOMOUS_ENTRY_ENABLED, false);
+  assert.equal(flags.AUTONOMOUS_EXIT_ENABLED, false);
+});


### PR DESCRIPTION
## Executive summary

First production **release candidate** for the AI-Trader Enterprise stack
(`v2.0.0-enterprise`). Adds the full enterprise intelligence pipeline —
Authentication foundation, Decision Intelligence, Event Intelligence, Strategy
Orchestrator, Enterprise Risk Engine, Trade Lifecycle Manager, Autonomous
Trading Coordinator, Learning Intelligence, System status/metrics — plus Vercel
Analytics + Speed Insights and an operator Cockpit, on top of the existing
Massive market-data and Alpaca **paper** execution platform.

Full report: `docs/release/AI_TRADER_ENTERPRISE_RC1.md`.

## Architecture modules

`Massive → Event → Decision → Strategy → Risk → Lifecycle → Autonomous Coordinator → Shadow/Block → Execution Gateway → Alpaca Paper → Evaluation → Learning`

Each new engine is advisory/read-model and delegates any execution to the single
existing Execution Gateway. One Socket.IO server; one Massive options-WS owner;
30 route base paths mounted once (plus the intentional `/api/automation` split
and `futuresRouter` alias).

## Operator UI changes

- New Cockpit panels for each enterprise module (Autonomous, Decision, Event,
  Strategy, Risk, Lifecycle, Learning) + System Operations.
- UI polish: the Autonomous "Controls and Safety" chips are now clearly
  read-only reference indicators (dashed/muted), pointing operators to the live
  Mission Control actions, so inert indicators no longer mimic real controls.

## Safety guarantees

- **Paper only**: single Alpaca paper client; `assertPaperConfiguration()`
  blocks any live-money path at construction and before every submit/close.
- **AI has no direct order authority** (ADR-002); one submission owner reached
  only via two risk-gated lanes; legacy direct broker route fail-closed (410).
- **Inert by default**: every new scheduler auto-starts OFF; autonomous mode
  defaults to `shadow` (submits nothing); entries/exits disabled.
- **Auth** runs in `observe` mode for this single-operator release (frontend
  sends no bearer token; `required` mode would break the UI). Unsafe actions
  stay constrained by the gateway, paper guard, ownership leases, Risk Engine,
  and Emergency Stop.

## Tests and validation

- `npm run lint` ✅ · `npm run build` ✅ (guard: single HTTP/socket client, no
  backend origin in bundle)
- server tests **460/460** ✅ · client tests **144/144** ✅
- Hygiene: no conflict markers, no tracked secrets, no duplicate
  routes/schedulers/WS owners.

## Deployment configuration

See `docs/release/AI_TRADER_ENTERPRISE_RC1.md` §7 and the corrected
`server/.env.example` / `client/.env.example` (phantom env vars removed; real
staged-auth + enterprise-module flags documented with safe defaults). Set
`MONGO_OPTIONAL=false` on the durable-state backend.

## Known limitations

- Massive sentiment (`/v1/sentiment/{ticker}`) and earnings-financials
  (`/vX/reference/financials`) are BEST_EFFORT — undocumented/legacy endpoints
  that degrade silently to empty; to be re-pointed to documented endpoints.
- Pre-existing cross-feature circular-import web (tracked tech debt; not
  introduced by this PR).

## Rollback plan

Revert the merge commit (`git revert -m 1 <sha>`) → Render + Vercel redeploy
prior build; Learning data is append-only. Instant kill: `AUTONOMOUS_TRADING_MODE=off`
/ keep `*_AUTO_START=false` / Emergency Stop.

## Production verification plan

Post-merge: poll new `/api/system/status` + engine `/status` endpoints (currently
404 on old prod) until they return 200; verify frontend load, Analytics/Speed
Insights, same-origin routing, Massive market-status, Alpaca paper reachability,
Mongo connectivity, and a stability window before tagging `v2.0.0-enterprise`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
