### PR TITLE
V2-UI-002 — Production Trading Workspace Alignment

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,6 +2,9 @@ import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } fro
 import { ChevronRight, Info, RotateCcw, X } from 'lucide-react';
 import type { Socket } from 'socket.io-client';
 import { Toaster } from 'sonner';
+// Lazy so the markdown vendor chunk stays out of the initial trading bundle —
+// it loads on demand only when an AI desk note actually needs rendering.
+const ReactMarkdown = lazy(() => import('react-markdown'));
 import { getSharedSocket } from './lib/socket';
 import {
   publishQuote,
@@ -2804,9 +2807,24 @@ function App() {
         <div className="space-y-2.5">
           <div className="ai-glass-panel-soft rounded-md px-3 py-2 shadow-none">
             <p className="ai-section-title font-mono text-[11px] text-intel-ai">Summary</p>
-            <p className="mt-1 text-sm leading-relaxed text-intel-ink whitespace-pre-line">
-              {deskSummary || `No notes yet. Open the AI desk to ask about ${deskInsightSymbol} or any spread.`}
-            </p>
+            {deskSummary ? (
+              // Render the desk note as markdown so the model's own section
+              // hierarchy (thesis, bull/bear, catalysts, risks) reads as headings
+              // and lists instead of raw ** ** text. Display only — no AI logic.
+              <Suspense
+                fallback={
+                  <p className="mt-1 whitespace-pre-line text-sm leading-relaxed text-intel-ink">{deskSummary}</p>
+                }
+              >
+                <div className="desk-markdown mt-1">
+                  <ReactMarkdown>{deskSummary}</ReactMarkdown>
+                </div>
+              </Suspense>
+            ) : (
+              <p className="mt-1 text-sm leading-relaxed text-intel-ink2">
+                No notes yet. Open the AI desk to ask about {deskInsightSymbol} or any spread.
+              </p>
+            )}
           </div>
           {(sentimentText || fedEvent) && (
             <div className="flex flex-wrap gap-1.5 text-[11px]">

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -21,6 +21,7 @@ import type { MobileTab } from './components/layout/MobileTabBar';
 import { MarketContextBar } from './components/layout/MarketContextBar';
 import { SystemStatusControl } from './components/layout/SystemStatusControl';
 import { DiagnosticsDrawer } from './components/layout/DiagnosticsDrawer';
+import { CollapsibleSection } from './components/shared/CollapsibleSection';
 import { setActiveSymbol, setActiveContract, useActivePosition, useLinkedMode } from './lib/workspaceContextStore';
 import { CommandPalette } from './components/layout/CommandPalette';
 import { ChatBot } from './components/chat/ChatBot';
@@ -2984,22 +2985,26 @@ function App() {
         {deskInsightPanel}
       </div>
       <div className="lg:col-span-2 min-w-0">
-        <GreeksPanel
-          contract={contractDetail}
-          leg={selectedLeg}
-          label={displayTicker}
-          underlyingPrice={greeksUnderlyingPrice}
-          insight={deskInsight}
-          selection={contractSelection}
-          selectionLoading={contractSelectionLoading}
-          onRequestSelection={handleContractSelectionRequest}
-          selectionDisabled={!contractSelectionAllowed}
-          analysisRequestId={contractAnalysisRequestId}
-          analysisDisabled={!contractAnalysisAllowed}
-        />
+        <CollapsibleSection title="Greeks & contract analysis" hint="Advanced">
+          <GreeksPanel
+            contract={contractDetail}
+            leg={selectedLeg}
+            label={displayTicker}
+            underlyingPrice={greeksUnderlyingPrice}
+            insight={deskInsight}
+            selection={contractSelection}
+            selectionLoading={contractSelectionLoading}
+            onRequestSelection={handleContractSelectionRequest}
+            selectionDisabled={!contractSelectionAllowed}
+            analysisRequestId={contractAnalysisRequestId}
+            analysisDisabled={!contractAnalysisAllowed}
+          />
+        </CollapsibleSection>
       </div>
       <div className="lg:col-span-3 min-w-0">
-        {scannerPanelEl}
+        <CollapsibleSection title="Scanner" hint="Watchlist analysis · entry checklist">
+          {scannerPanelEl}
+        </CollapsibleSection>
       </div>
     </div>
   );

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -21,7 +21,7 @@ import type { MobileTab } from './components/layout/MobileTabBar';
 import { MarketContextBar } from './components/layout/MarketContextBar';
 import { SystemStatusControl } from './components/layout/SystemStatusControl';
 import { DiagnosticsDrawer } from './components/layout/DiagnosticsDrawer';
-import { setActiveSymbol, setActiveContract } from './lib/workspaceContextStore';
+import { setActiveSymbol, setActiveContract, useActivePosition, useLinkedMode } from './lib/workspaceContextStore';
 import { CommandPalette } from './components/layout/CommandPalette';
 import { ChatBot } from './components/chat/ChatBot';
 import { useIsMobile } from './hooks/useMediaQuery';
@@ -539,6 +539,20 @@ function App() {
   useEffect(() => {
     setActiveContract(selectedLeg);
   }, [selectedLeg]);
+
+  // Linked Mode (Deliverable 4/5): when the operator selects an open position
+  // and Linked Mode is on, re-center the chart underlying and the options matrix
+  // on that position's contract. Uses the existing setters (setTicker /
+  // setDesiredContract) so chart, matrix, Greeks, and AI context all follow —
+  // no new fetch or subscription. When Linked Mode is off, a selection never
+  // interrupts a symbol the operator is researching.
+  const linkedActivePosition = useActivePosition();
+  const linkedMode = useLinkedMode();
+  useEffect(() => {
+    if (!linkedMode || !linkedActivePosition) return;
+    if (linkedActivePosition.underlying) setTicker(linkedActivePosition.underlying);
+    if (linkedActivePosition.optionSymbol) setDesiredContract(linkedActivePosition.optionSymbol);
+  }, [linkedMode, linkedActivePosition]);
 
   const [contractDetail, setContractDetail] = useState<OptionContractDetail | null>(null);
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,6 +20,7 @@ import { MobileShell } from './components/layout/MobileShell';
 import type { MobileTab } from './components/layout/MobileTabBar';
 import { MarketContextBar } from './components/layout/MarketContextBar';
 import { SystemStatusControl } from './components/layout/SystemStatusControl';
+import { DiagnosticsDrawer } from './components/layout/DiagnosticsDrawer';
 import { setActiveSymbol, setActiveContract } from './lib/workspaceContextStore';
 import { CommandPalette } from './components/layout/CommandPalette';
 import { ChatBot } from './components/chat/ChatBot';
@@ -462,6 +463,7 @@ function App() {
 
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
 
   // Phone companion shell: an entirely separate layout below `md`, not a
   // squeezed workstation. Desktop state (view) is untouched by mobile tabs.
@@ -3182,7 +3184,7 @@ function App() {
       <SystemStatusControl
         marketClosed={Boolean(marketSessionMeta?.marketClosed)}
         chartErrored={Boolean(marketError)}
-        onOpenDiagnostics={() => setView('operations')}
+        onOpenDiagnostics={() => setDiagnosticsOpen(true)}
       />
       <MarketContextBar />
       {settingsOpen && (
@@ -3375,6 +3377,8 @@ function App() {
         onViewChange={setView}
         onTickerSubmit={handleHeaderTickerSubmit}
       />
+
+      <DiagnosticsDrawer open={diagnosticsOpen} onClose={() => setDiagnosticsOpen(false)} />
 
       <ChatDock
         isOpen={isChatOpen && chatAllowed}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -19,7 +19,8 @@ import { NavRail } from './components/layout/NavRail';
 import { MobileShell } from './components/layout/MobileShell';
 import type { MobileTab } from './components/layout/MobileTabBar';
 import { MarketContextBar } from './components/layout/MarketContextBar';
-import { SystemStatusBar } from './components/layout/SystemStatusBar';
+import { SystemStatusControl } from './components/layout/SystemStatusControl';
+import { setActiveSymbol, setActiveContract } from './lib/workspaceContextStore';
 import { CommandPalette } from './components/layout/CommandPalette';
 import { ChatBot } from './components/chat/ChatBot';
 import { useIsMobile } from './hooks/useMediaQuery';
@@ -524,6 +525,18 @@ function App() {
   const [desiredContract, setDesiredContract] = useState<string | null>(null);
   const activeContractSymbol = selectedLeg?.ticker ?? null;
   const activeContractSymbolRef = useRef<string | null>(null);
+
+  // Publish the operator's current focus onto the shared workspace context bus
+  // so downstream panels (chart, matrix, Greeks, risk, AI) can subscribe to one
+  // source of truth instead of receiving the same value threaded through props.
+  // This is a thin mirror of existing selection state — it opens no sockets and
+  // fetches nothing, so it can never create a duplicate subscription.
+  useEffect(() => {
+    setActiveSymbol(normalizedTicker);
+  }, [normalizedTicker]);
+  useEffect(() => {
+    setActiveContract(selectedLeg);
+  }, [selectedLeg]);
 
   const [contractDetail, setContractDetail] = useState<OptionContractDetail | null>(null);
 
@@ -3166,7 +3179,11 @@ function App() {
         chatDisabled={!chatAllowed}
         onOpenCommandPalette={() => setCommandPaletteOpen(true)}
       />
-      <SystemStatusBar marketClosed={Boolean(marketSessionMeta?.marketClosed)} chartErrored={Boolean(marketError)} />
+      <SystemStatusControl
+        marketClosed={Boolean(marketSessionMeta?.marketClosed)}
+        chartErrored={Boolean(marketError)}
+        onOpenDiagnostics={() => setView('operations')}
+      />
       <MarketContextBar />
       {settingsOpen && (
         <div

--- a/client/src/__tests__/activityFeedOperator.test.ts
+++ b/client/src/__tests__/activityFeedOperator.test.ts
@@ -24,6 +24,13 @@ describe('activityFeed operator/engineering split', () => {
     expect(isOperatorEvent(ev('EVALUATED'))).toBe(false);
   });
 
+  it('keeps reconciliation in diagnostics even when the name contains an operator token', () => {
+    // Engineering classification must win over an operator-token substring so
+    // reconciliation noise never leaks onto the operator timeline.
+    expect(isOperatorEvent(ev('RECONCILE_POSITION_CLOSED'))).toBe(false);
+    expect(isOperatorEvent(ev('RECONCILIATION_EXIT_SYNC'))).toBe(false);
+  });
+
   it('always surfaces critical-severity events to the operator', () => {
     expect(isOperatorEvent(ev('MONITOR_HEARTBEAT', { severity: 'critical' }))).toBe(true);
   });

--- a/client/src/__tests__/activityFeedOperator.test.ts
+++ b/client/src/__tests__/activityFeedOperator.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { isOperatorEvent, splitOperatorEvents } from '../lib/activityFeed';
+import type { AutomationVisibilityEvent } from '../api/portfolio';
+
+function ev(event: string, extra: Partial<AutomationVisibilityEvent> = {}): AutomationVisibilityEvent {
+  return { event, timestamp: '2026-07-26T10:00:00Z', ...extra };
+}
+
+describe('activityFeed operator/engineering split', () => {
+  it('keeps trading, order, and risk events on the operator timeline', () => {
+    expect(isOperatorEvent(ev('POSITION_FILLED'))).toBe(true);
+    expect(isOperatorEvent(ev('ORDER_SUBMITTED'))).toBe(true);
+    expect(isOperatorEvent(ev('EXIT_FILLED'))).toBe(true);
+    expect(isOperatorEvent(ev('RISK_REJECTED'))).toBe(true);
+    expect(isOperatorEvent(ev('BROKER_DISCONNECTED'))).toBe(true);
+    expect(isOperatorEvent(ev('EMERGENCY_STOP'))).toBe(true);
+  });
+
+  it('routes engineering telemetry to diagnostics, not the operator timeline', () => {
+    expect(isOperatorEvent(ev('MONITOR_HEARTBEAT'))).toBe(false);
+    expect(isOperatorEvent(ev('RECONCILIATION_RUN'))).toBe(false);
+    expect(isOperatorEvent(ev('SCHEDULER_LEASE_RENEWED'))).toBe(false);
+    expect(isOperatorEvent(ev('WATCHLIST_CACHE_HIT'))).toBe(false);
+    expect(isOperatorEvent(ev('EVALUATED'))).toBe(false);
+  });
+
+  it('always surfaces critical-severity events to the operator', () => {
+    expect(isOperatorEvent(ev('MONITOR_HEARTBEAT', { severity: 'critical' }))).toBe(true);
+  });
+
+  it('partitions a stream without dropping any event', () => {
+    const events = [
+      ev('MONITOR_HEARTBEAT'),
+      ev('ORDER_SUBMITTED'),
+      ev('CACHE_HIT'),
+      ev('POSITION_CLOSED'),
+      ev('RECONCILIATION_RUN'),
+    ];
+    const { operator, engineering } = splitOperatorEvents(events);
+    expect(operator).toHaveLength(2);
+    expect(engineering).toHaveLength(3);
+    expect(operator.length + engineering.length).toBe(events.length);
+  });
+});

--- a/client/src/__tests__/positionManagerPanel.test.tsx
+++ b/client/src/__tests__/positionManagerPanel.test.tsx
@@ -66,6 +66,21 @@ describe('PositionManagerPanel', () => {
     expect(screen.getByText('AMD')).toBeInTheDocument();
   });
 
+  it('never polls the live endpoint for manual positions (no wasted 3s requests)', async () => {
+    setActivePosition({
+      id: 'O:SPY260101C00450000',
+      underlying: 'SPY',
+      optionSymbol: 'O:SPY260101C00450000',
+      source: 'MANUAL',
+    });
+    render(<PositionManagerPanel />);
+    await waitFor(() => expect(screen.getByText('SPY')).toBeInTheDocument());
+    expect(getPositionLive).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(/Live Greeks require an automation-tracked position/i)
+    ).toBeInTheDocument();
+  });
+
   it('toggles Linked Mode from the panel and clears the selection', async () => {
     setLinkedMode(true);
     setActivePosition({ id: 'p1', underlying: 'AMD', optionSymbol: 'O:AMD260731C00175000', source: 'AUTOMATION' });

--- a/client/src/__tests__/positionManagerPanel.test.tsx
+++ b/client/src/__tests__/positionManagerPanel.test.tsx
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const { getPositionLive } = vi.hoisted(() => ({ getPositionLive: vi.fn() }));
+vi.mock('../api/portfolio', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/portfolio')>();
+  return { ...actual, getPositionLive };
+});
+
+import { PositionManagerPanel } from '../components/portfolio/PositionManagerPanel';
+import {
+  setActivePosition,
+  setLinkedMode,
+  getWorkspaceContext,
+  __resetWorkspaceContextForTests,
+} from '../lib/workspaceContextStore';
+
+const SNAPSHOT = {
+  positionId: 'p1',
+  asOf: '2026-07-26T10:00:00Z',
+  available: true,
+  optionSymbol: 'O:AMD260731C00175000',
+  underlying: 'AMD',
+  greeks: { delta: 0.58, gamma: 0.03, theta: -0.09, vega: 0.12, rho: 0.01 },
+  impliedVolatility: 0.42,
+  openInterest: 1200,
+  dayVolume: 340,
+  breakEvenPrice: 177.86,
+  bid: 3.0,
+  ask: 3.05,
+  mid: 3.03,
+  daysToExpiration: 5,
+  source: 'contract-snapshot',
+};
+
+describe('PositionManagerPanel', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    __resetWorkspaceContextForTests();
+    getPositionLive.mockReset();
+    getPositionLive.mockResolvedValue(SNAPSHOT);
+  });
+  afterEach(() => cleanup());
+
+  it('renders nothing until a position is selected on the bus', () => {
+    const { container } = render(<PositionManagerPanel />);
+    expect(container).toBeEmptyDOMElement();
+    expect(getPositionLive).not.toHaveBeenCalled();
+  });
+
+  it('shows live market, working orders, and greeks for the active position', async () => {
+    setActivePosition({
+      id: 'p1',
+      underlying: 'AMD',
+      optionSymbol: 'O:AMD260731C00175000',
+      source: 'AUTOMATION',
+      stopPrice: 2.4,
+      targetPrice: 4.1,
+    });
+    render(<PositionManagerPanel />);
+    await waitFor(() => expect(getPositionLive).toHaveBeenCalledWith('p1'));
+    expect(await screen.findByText('$3.00')).toBeInTheDocument(); // bid
+    expect(screen.getByText('$3.05')).toBeInTheDocument(); // ask
+    expect(screen.getByText('$2.40')).toBeInTheDocument(); // stop
+    expect(screen.getByText('$4.10')).toBeInTheDocument(); // take profit
+    expect(screen.getByText('AMD')).toBeInTheDocument();
+  });
+
+  it('toggles Linked Mode from the panel and clears the selection', async () => {
+    setLinkedMode(true);
+    setActivePosition({ id: 'p1', underlying: 'AMD', optionSymbol: 'O:AMD260731C00175000', source: 'AUTOMATION' });
+    render(<PositionManagerPanel />);
+    fireEvent.click(await screen.findByRole('button', { name: /linked/i }));
+    expect(getWorkspaceContext().linkedMode).toBe(false);
+    fireEvent.click(screen.getByRole('button', { name: /clear selected position/i }));
+    expect(getWorkspaceContext().activePosition).toBeNull();
+  });
+});

--- a/client/src/__tests__/systemStatusControl.test.tsx
+++ b/client/src/__tests__/systemStatusControl.test.tsx
@@ -33,6 +33,15 @@ describe('summarizeSystemStatus', () => {
     expect(s.alerts).toHaveLength(0);
   });
 
+  it('reads HEALTHY in normal snapshot-mode operation (no false DEGRADED)', () => {
+    // Equities and charts are snapshot-by-design on this entitlement; that is
+    // the healthy steady state, not a degradation. Automation idle (UNKNOWN).
+    const s = summarizeSystemStatus(healthy());
+    expect(s.headline).toBe('HEALTHY');
+    expect(s.tone).toBe('good');
+    expect(s.alerts).toHaveLength(0);
+  });
+
   it('always includes every subsystem so nothing becomes unreachable', () => {
     const labels = summarizeSystemStatus(healthy()).rows.map(r => r.label);
     for (const required of [

--- a/client/src/__tests__/systemStatusControl.test.tsx
+++ b/client/src/__tests__/systemStatusControl.test.tsx
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, fireEvent } from '@testing-library/react';
+import type { SystemStatus } from '../hooks/useSystemStatus';
+
+afterEach(() => cleanup());
+
+// The control derives its summary from useSystemStatus; mock the hook so the
+// test drives status without real timers, sockets, or HTTP probes.
+let mockStatus: SystemStatus;
+vi.mock('../hooks/useSystemStatus', () => ({
+  useSystemStatus: () => mockStatus,
+}));
+
+import { SystemStatusControl, summarizeSystemStatus } from '../components/layout/SystemStatusControl';
+
+function healthy(): SystemStatus {
+  return {
+    backend: 'ONLINE',
+    socket: 'CONNECTED',
+    optionsFeed: 'LIVE',
+    equityFeed: 'SNAPSHOT',
+    chart: { status: 'SNAPSHOT', ageSeconds: 3 },
+    ai: 'ready',
+    automation: 'UNKNOWN',
+  };
+}
+
+describe('summarizeSystemStatus', () => {
+  it('reports HEALTHY when nothing needs attention', () => {
+    const s = summarizeSystemStatus({ ...healthy(), equityFeed: 'REALTIME', chart: { status: 'LIVE', ageSeconds: 1 } });
+    expect(s.headline).toBe('HEALTHY');
+    expect(s.tone).toBe('good');
+    expect(s.alerts).toHaveLength(0);
+  });
+
+  it('always includes every subsystem so nothing becomes unreachable', () => {
+    const labels = summarizeSystemStatus(healthy()).rows.map(r => r.label);
+    for (const required of [
+      'Backend',
+      'Broker',
+      'Massive REST',
+      'Options WebSocket',
+      'Stocks WebSocket',
+      'Equity Data',
+      'Chart',
+      'MongoDB',
+      'AI',
+      'Automation',
+    ]) {
+      expect(labels).toContain(required);
+    }
+  });
+
+  it('does not let a resting (UNKNOWN) automation engine drag the roll-up down', () => {
+    expect(summarizeSystemStatus(healthy()).tone).not.toBe('bad');
+  });
+
+  it('surfaces an operator alert with impact + action when the backend is offline', () => {
+    const s = summarizeSystemStatus({ ...healthy(), backend: 'OFFLINE' });
+    expect(s.headline).toBe('OFFLINE');
+    const alert = s.alerts.find(a => a.title === 'Backend unreachable');
+    expect(alert?.impact).toMatch(/unavailable/i);
+    expect(alert?.action).toBeTruthy();
+  });
+
+  it('flags a delayed options feed as DEGRADED with a targeted action', () => {
+    const s = summarizeSystemStatus({ ...healthy(), optionsFeed: 'STALE' });
+    expect(s.headline).toBe('DEGRADED');
+    expect(s.reason).toBe('Options feed delayed');
+    expect(s.alerts.some(a => /entitlement/i.test(a.action))).toBe(true);
+  });
+});
+
+describe('SystemStatusControl', () => {
+  it('collapses to a single summary and expands to the full breakdown', () => {
+    mockStatus = { ...healthy(), optionsFeed: 'STALE' };
+    render(<SystemStatusControl />);
+    // Collapsed: one summary control, headline visible, detail hidden.
+    expect(screen.getByText('DEGRADED')).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    // Expand.
+    fireEvent.click(screen.getByRole('button', { name: /system status/i }));
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByText('Options WebSocket')).toBeInTheDocument();
+    expect(screen.getByText('Options feed delayed')).toBeInTheDocument();
+  });
+
+  it('offers a Diagnostics entry point when provided', () => {
+    mockStatus = healthy();
+    const onOpenDiagnostics = vi.fn();
+    render(<SystemStatusControl onOpenDiagnostics={onOpenDiagnostics} />);
+    fireEvent.click(screen.getByRole('button', { name: /system status/i }));
+    fireEvent.click(screen.getByRole('button', { name: /diagnostics/i }));
+    expect(onOpenDiagnostics).toHaveBeenCalledOnce();
+  });
+});

--- a/client/src/__tests__/workspaceContextStore.test.ts
+++ b/client/src/__tests__/workspaceContextStore.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  setActiveSymbol,
+  setActiveContract,
+  setActivePosition,
+  setActiveTrade,
+  setLinkedMode,
+  toggleLinkedMode,
+  getWorkspaceContext,
+  useActiveSymbol,
+  useActiveContract,
+  useActivePosition,
+  useLinkedMode,
+  useWorkspaceContext,
+  __resetWorkspaceContextForTests,
+} from '../lib/workspaceContextStore';
+import type { OptionLeg } from '../types/market';
+
+function leg(ticker: string): OptionLeg {
+  return { ticker } as OptionLeg;
+}
+
+describe('workspaceContextStore', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    __resetWorkspaceContextForTests();
+  });
+
+  it('normalizes and publishes the active symbol to subscribers', () => {
+    const { result } = renderHook(() => useActiveSymbol());
+    expect(result.current).toBeNull();
+    act(() => setActiveSymbol('  aapl '));
+    expect(result.current).toBe('AAPL');
+  });
+
+  it('clears the active contract when the underlying changes', () => {
+    act(() => {
+      setActiveSymbol('SPY');
+      setActiveContract(leg('O:SPY260101C00450000'));
+    });
+    expect(getWorkspaceContext().activeContract?.ticker).toBe('O:SPY260101C00450000');
+    act(() => setActiveSymbol('QQQ'));
+    expect(getWorkspaceContext().activeContract).toBeNull();
+  });
+
+  it('does not re-render on a no-op publish (stable reference)', () => {
+    let renders = 0;
+    const { result } = renderHook(() => {
+      renders += 1;
+      return useWorkspaceContext();
+    });
+    const initial = result.current;
+    const before = renders;
+    act(() => setActiveSymbol(null)); // already null → no change
+    expect(renders).toBe(before);
+    expect(result.current).toBe(initial);
+  });
+
+  it('tracks the active position and trade independently', () => {
+    const { result: pos } = renderHook(() => useActivePosition());
+    act(() => setActivePosition({ id: 'p1', underlying: 'AMD', source: 'MANUAL' }));
+    expect(pos.current?.id).toBe('p1');
+    act(() => setActiveTrade({ id: 't1', underlying: 'AMD' }));
+    expect(getWorkspaceContext().activeTrade?.id).toBe('t1');
+    // Selecting a trade must not disturb the active position.
+    expect(pos.current?.id).toBe('p1');
+  });
+
+  it('defaults Linked Mode ON and persists changes to localStorage', () => {
+    const { result } = renderHook(() => useLinkedMode());
+    expect(result.current).toBe(true); // enterprise default
+    act(() => setLinkedMode(false));
+    expect(result.current).toBe(false);
+    expect(window.localStorage.getItem('workspace:linkedMode')).toBe('false');
+    act(() => toggleLinkedMode());
+    expect(result.current).toBe(true);
+  });
+
+  it('propagates a contract to a separate contract subscriber', () => {
+    const { result } = renderHook(() => useActiveContract());
+    expect(result.current).toBeNull();
+    act(() => {
+      setActiveSymbol('SPY');
+      setActiveContract(leg('O:SPY260101C00450000'));
+    });
+    expect(result.current?.ticker).toBe('O:SPY260101C00450000');
+  });
+});

--- a/client/src/components/cockpit/CockpitLayout.tsx
+++ b/client/src/components/cockpit/CockpitLayout.tsx
@@ -8,6 +8,7 @@ import { Panel, Pill, selectActiveTrade, statusTone } from './cockpitUi';
 import { statusOrReason } from './cockpitDisplay';
 import { TradeLifecyclePanel } from './TradeLifecyclePanel';
 import { LearningIntelligencePanel } from './LearningIntelligencePanel';
+import { CollapsibleSection } from '../shared/CollapsibleSection';
 
 function HealthItem({ label, value, healthy }: { label: string; value: string; healthy: boolean }) {
   return (
@@ -507,11 +508,16 @@ export function CockpitLayout() {
         <DecisionPanel visibility={visibility} />
         <TodayPanel visibility={visibility} />
       </div>
-      <SystemOperationsPanel />
       <div className="grid min-w-0 grid-cols-1 gap-3 xl:grid-cols-2">
         <PendingOrdersPanel visibility={visibility} />
         <RecentActionsPanel events={events} />
       </div>
+      {/* Scheduler / monitor / queue telemetry is supervision detail, not a
+          trading decision — collapsed by default so the operator sees strategy,
+          results, and actions first. */}
+      <CollapsibleSection title="Engineering diagnostics" hint="Scheduler · monitor · queue · cache">
+        <SystemOperationsPanel />
+      </CollapsibleSection>
       <TradeLifecyclePanel />
       <LearningIntelligencePanel />
     </div>

--- a/client/src/components/intelligence/ActivityFeed.tsx
+++ b/client/src/components/intelligence/ActivityFeed.tsx
@@ -6,6 +6,7 @@ import {
   ACTIVITY_FILTERS,
   groupActivityEvents,
   humanizeEvent,
+  isOperatorEvent,
   type ActivityFilter,
 } from '../../lib/activityFeed';
 
@@ -36,28 +37,43 @@ export function ActivityFeed({
   events,
   max = 60,
   className = '',
+  operatorOnly = false,
+  title = 'Activity',
 }: {
   events: AutomationVisibilityEvent[];
   max?: number;
   className?: string;
+  /** Show only operator-facing events (trades, orders, risk, errors, alerts).
+   *  Engineering telemetry (heartbeats, reconciliation, scheduler) is excluded
+   *  and lives in the Diagnostics drawer instead. */
+  operatorOnly?: boolean;
+  title?: string;
 }) {
   const [filter, setFilter] = useState<ActivityFilter>('all');
+  const sourceEvents = useMemo(
+    () => (operatorOnly ? events.filter(isOperatorEvent) : events),
+    [events, operatorOnly]
+  );
   const rows = useMemo(
-    () => groupActivityEvents(events, filter).slice(0, max),
-    [events, filter, max]
+    () => groupActivityEvents(sourceEvents, filter).slice(0, max),
+    [sourceEvents, filter, max]
   );
 
   return (
     <div className={`flex flex-col rounded-panel border border-intel-line bg-intel-panel p-4 ${className}`}>
       <div className="mb-3 flex items-center gap-2">
         <Radio className="h-4 w-4 text-intel-accent" aria-hidden="true" />
-        <span className="text-sm font-semibold text-intel-ink">Activity</span>
+        <span className="text-sm font-semibold text-intel-ink">{title}</span>
         <span className="ml-auto font-mono text-[10px] uppercase tracking-label text-intel-ink3">
-          {events.length ? `${events.length} event${events.length === 1 ? '' : 's'}` : 'live'}
+          {sourceEvents.length ? `${sourceEvents.length} event${sourceEvents.length === 1 ? '' : 's'}` : 'live'}
         </span>
       </div>
 
-      <div className="mb-2 flex flex-wrap gap-1" role="tablist" aria-label="Activity filter">
+      <div
+        className={`mb-2 flex-wrap gap-1 ${operatorOnly ? 'hidden' : 'flex'}`}
+        role="tablist"
+        aria-label="Activity filter"
+      >
         {ACTIVITY_FILTERS.map((f) => (
           <button
             key={f.key}

--- a/client/src/components/intelligence/CommandCenterPage.tsx
+++ b/client/src/components/intelligence/CommandCenterPage.tsx
@@ -269,7 +269,7 @@ export function CommandCenterPage({ initial = {}, loadOnMount = true, onOpen }: 
             lastQuoteAt={conn.lastQuoteAt}
             nowMs={now}
           />
-          <ActivityFeed events={events} />
+          <ActivityFeed events={events} operatorOnly title="Operator activity" />
         </div>
       </section>
 

--- a/client/src/components/intelligence/TradingIntelligencePage.tsx
+++ b/client/src/components/intelligence/TradingIntelligencePage.tsx
@@ -4,6 +4,7 @@ import {
   BookOpenText,
   CalendarDays,
   FileSearch,
+  GraduationCap,
   LayoutDashboard,
   Newspaper,
 } from 'lucide-react';
@@ -13,6 +14,7 @@ import { DecisionJournalPage } from './DecisionJournalPage';
 import { StrategyAnalyticsPage } from './StrategyAnalyticsPage';
 import { TradeReportsPage } from './TradeReportsPage';
 import { TradingSessionsPage } from './TradingSessionsPage';
+import { LearningIntelligencePanel } from '../cockpit/LearningIntelligencePanel';
 import type { IntelligenceView } from './views';
 
 const NAV: Array<{ view: IntelligenceView; label: string; icon: typeof LayoutDashboard }> = [
@@ -21,6 +23,7 @@ const NAV: Array<{ view: IntelligenceView; label: string; icon: typeof LayoutDas
   { view: 'trades', label: 'Trade Reports', icon: FileSearch },
   { view: 'decisions', label: 'Decision Journal', icon: BookOpenText },
   { view: 'analytics', label: 'Strategy Analytics', icon: BarChart3 },
+  { view: 'learning', label: 'Learning', icon: GraduationCap },
   { view: 'sessions', label: 'Sessions', icon: CalendarDays },
 ];
 
@@ -62,6 +65,7 @@ export function TradingIntelligencePage() {
         {view === 'trades' && <TradeReportsPage />}
         {view === 'decisions' && <DecisionJournalPage />}
         {view === 'analytics' && <StrategyAnalyticsPage />}
+        {view === 'learning' && <LearningIntelligencePanel />}
         {view === 'sessions' && <TradingSessionsPage />}
       </div>
     </div>

--- a/client/src/components/intelligence/views.ts
+++ b/client/src/components/intelligence/views.ts
@@ -1,2 +1,2 @@
 /** The workspace views, shared by the shell and the Command Center cards. */
-export type IntelligenceView = 'command' | 'daily' | 'trades' | 'decisions' | 'analytics' | 'sessions';
+export type IntelligenceView = 'command' | 'daily' | 'trades' | 'decisions' | 'analytics' | 'learning' | 'sessions';

--- a/client/src/components/layout/DiagnosticsDrawer.tsx
+++ b/client/src/components/layout/DiagnosticsDrawer.tsx
@@ -1,0 +1,81 @@
+import { Suspense, lazy, useEffect, useRef } from 'react';
+import { X } from 'lucide-react';
+
+// Diagnostics drawer — one consolidated, collapsed-by-default surface for all
+// engineering telemetry (scheduler, monitor, Mongo, queue, cache, heartbeats,
+// WebSocket health, API latency, logs, broker/Massive/AI diagnostics).
+//
+// It does NOT reimplement any of that: it reuses the existing System Operations
+// page verbatim inside a slide-over so the telemetry stays available from every
+// workspace without occupying the operator's normal trading surface. Nothing is
+// removed — this is purely where the noise now lives.
+
+const SystemOperationsPage = lazy(() =>
+  import('../operations/SystemOperationsPage').then(m => ({ default: m.SystemOperationsPage })),
+);
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export function DiagnosticsDrawer({ open, onClose }: Props) {
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    closeRef.current?.focus();
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[60] flex justify-end" role="presentation">
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-[1px]"
+        onClick={onClose}
+        role="presentation"
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Diagnostics"
+        className="relative flex h-full w-full max-w-5xl flex-col border-l border-intel-line bg-intel-bg shadow-2xl"
+      >
+        <header className="flex items-start justify-between gap-4 border-b border-intel-line px-5 py-3">
+          <div>
+            <h2 className="font-mono text-sm font-semibold uppercase tracking-label text-intel-ink">
+              Diagnostics
+            </h2>
+            <p className="mt-0.5 text-[11px] text-intel-ink3">
+              Engineering telemetry — not required for normal trading. Everything here is searchable.
+            </p>
+          </div>
+          <button
+            ref={closeRef}
+            type="button"
+            onClick={onClose}
+            aria-label="Close diagnostics"
+            className="rounded-panel border border-intel-line p-1.5 text-intel-ink2 transition-colors hover:border-intel-accentLine hover:text-intel-accent focus:outline-none focus-visible:border-intel-accentLine"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </header>
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <Suspense
+            fallback={
+              <div className="p-6 font-mono text-xs text-intel-ink3">Loading diagnostics…</div>
+            }
+          >
+            <SystemOperationsPage />
+          </Suspense>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/layout/SystemStatusControl.tsx
+++ b/client/src/components/layout/SystemStatusControl.tsx
@@ -51,16 +51,23 @@ function socketTone(s: string): Tone {
 function optionsTone(s: string): Tone {
   return s === 'LIVE' ? 'good' : s === 'CONNECTING' ? 'neutral' : 'warn';
 }
+// Equities are snapshot/delayed-by-design on this entitlement (no equity WS —
+// see useSystemStatus.ts). SNAPSHOT and DELAYED are the intended steady state,
+// NOT a degradation; only a genuinely absent feed is a warning. Treating
+// snapshot as 'warn' here would make the rolled-up headline read a permanent
+// false DEGRADED during completely normal operation.
 function equityTone(s: string): Tone {
   if (s === 'REALTIME') return 'good';
-  if (s === 'DELAYED' || s === 'SNAPSHOT') return 'warn';
-  return 'neutral';
+  if (s === 'SNAPSHOT' || s === 'DELAYED') return 'neutral';
+  return 'warn'; // UNAVAILABLE — the feed genuinely stopped delivering
 }
+// Charts run on entitlement-limited snapshot data; SNAPSHOT/CLOSED/CONNECTING
+// are normal, non-alarming states. Only STALE (delivery stopped / fetch errored)
+// is a real problem.
 function chartTone(s: string): Tone {
   if (s === 'LIVE') return 'good';
-  if (s === 'SNAPSHOT') return 'warn';
   if (s === 'STALE') return 'bad';
-  return 'neutral';
+  return 'neutral'; // SNAPSHOT / CLOSED / CONNECTING
 }
 function aiTone(s: string): Tone {
   return s === 'ready' ? 'good' : s === 'busy' ? 'warn' : 'bad';
@@ -142,10 +149,14 @@ export function summarizeSystemStatus(status: SystemStatus): SystemSummary {
     });
   }
 
-  const headline = overall === 'good' ? 'HEALTHY' : overall === 'bad' ? 'OFFLINE' : 'DEGRADED';
+  // 'neutral' is a normal, non-alarming steady state (snapshot feeds, idle
+  // automation) — it must read HEALTHY, not DEGRADED. Only a genuine 'warn'
+  // degrades the headline; 'bad' takes it offline.
+  const headline = overall === 'bad' ? 'OFFLINE' : overall === 'warn' ? 'DEGRADED' : 'HEALTHY';
+  const summaryTone: Tone = overall === 'bad' ? 'bad' : overall === 'warn' ? 'warn' : 'good';
   const reason = alerts.length ? alerts[0].title : null;
 
-  return { tone: overall, headline, reason, rows, alerts };
+  return { tone: summaryTone, headline, reason, rows, alerts };
 }
 
 type Props = {

--- a/client/src/components/layout/SystemStatusControl.tsx
+++ b/client/src/components/layout/SystemStatusControl.tsx
@@ -1,0 +1,262 @@
+import { memo, useEffect, useId, useRef, useState } from 'react';
+import { useSystemStatus, type SystemStatus } from '../../hooks/useSystemStatus';
+
+// Compact, single-glance production status control. Replaces the permanent row
+// of seven individual technical badges (Backend / Socket / Options / Equity /
+// Chart / AI / Automation) with ONE summary — "System · HEALTHY" or
+// "System · DEGRADED — Options feed delayed" — that expands, on click, to the
+// full per-subsystem breakdown plus an operator-friendly alert summary.
+//
+// The seven domains are NOT deleted: every one is still shown, with the same
+// independent tone logic, inside the popover. Low-level engineering telemetry
+// (lease owners, heartbeat counters, request IDs, etc.) belongs in the
+// Diagnostics drawer, not here.
+
+type Tone = 'good' | 'warn' | 'bad' | 'neutral';
+
+const TONE_TEXT: Record<Tone, string> = {
+  good: 'text-intel-pos',
+  warn: 'text-intel-warn',
+  bad: 'text-intel-neg',
+  neutral: 'text-intel-ink3',
+};
+const TONE_DOT: Record<Tone, string> = {
+  good: 'bg-intel-pos',
+  warn: 'bg-intel-warn',
+  bad: 'bg-intel-neg',
+  neutral: 'bg-intel-ink3',
+};
+
+type SubsystemRow = { label: string; value: string; tone: Tone; note?: string };
+
+export type SystemSummary = {
+  /** Overall roll-up tone across every subsystem. */
+  tone: Tone;
+  /** Operator headline: HEALTHY | DEGRADED | OFFLINE. */
+  headline: string;
+  /** Short reason shown next to the headline when not fully healthy. */
+  reason: string | null;
+  /** Every subsystem, for the expanded popover. */
+  rows: SubsystemRow[];
+  /** Operator-friendly alerts: what's wrong, impact, recommended action. */
+  alerts: { title: string; impact: string; action: string }[];
+};
+
+function backendTone(s: string): Tone {
+  return s === 'ONLINE' ? 'good' : s === 'DEGRADED' ? 'warn' : 'bad';
+}
+function socketTone(s: string): Tone {
+  return s === 'CONNECTED' ? 'good' : s === 'CONNECTING' ? 'warn' : 'bad';
+}
+function optionsTone(s: string): Tone {
+  return s === 'LIVE' ? 'good' : s === 'CONNECTING' ? 'neutral' : 'warn';
+}
+function equityTone(s: string): Tone {
+  if (s === 'REALTIME') return 'good';
+  if (s === 'DELAYED' || s === 'SNAPSHOT') return 'warn';
+  return 'neutral';
+}
+function chartTone(s: string): Tone {
+  if (s === 'LIVE') return 'good';
+  if (s === 'SNAPSHOT') return 'warn';
+  if (s === 'STALE') return 'bad';
+  return 'neutral';
+}
+function aiTone(s: string): Tone {
+  return s === 'ready' ? 'good' : s === 'busy' ? 'warn' : 'bad';
+}
+function automationTone(s: string): Tone {
+  return s === 'RUNNING' ? 'good' : s === 'PAUSED' ? 'warn' : s === 'ERROR' ? 'bad' : 'neutral';
+}
+
+const WORST: Tone[] = ['good', 'neutral', 'warn', 'bad'];
+function worst(a: Tone, b: Tone): Tone {
+  return WORST.indexOf(a) >= WORST.indexOf(b) ? a : b;
+}
+
+/**
+ * Pure roll-up of the independent subsystem states into one operator summary.
+ * Exported for unit testing — it holds all the "what matters" judgement, with
+ * no React or DOM dependency.
+ */
+export function summarizeSystemStatus(status: SystemStatus): SystemSummary {
+  const rows: SubsystemRow[] = [
+    { label: 'Backend', value: status.backend, tone: backendTone(status.backend) },
+    { label: 'Broker', value: 'PAPER', tone: 'neutral', note: 'Paper trading only' },
+    { label: 'Massive REST', value: status.backend === 'OFFLINE' ? 'UNKNOWN' : 'OK', tone: status.backend === 'OFFLINE' ? 'bad' : 'good' },
+    { label: 'Options WebSocket', value: status.optionsFeed, tone: optionsTone(status.optionsFeed) },
+    { label: 'Stocks WebSocket', value: status.socket, tone: socketTone(status.socket) },
+    { label: 'Equity Data', value: status.equityFeed, tone: equityTone(status.equityFeed) },
+    { label: 'Chart', value: status.chart.status, tone: chartTone(status.chart.status) },
+    { label: 'MongoDB', value: status.backend === 'OFFLINE' ? 'UNKNOWN' : 'OK', tone: status.backend === 'OFFLINE' ? 'bad' : 'good' },
+    { label: 'AI', value: status.ai.toUpperCase(), tone: aiTone(status.ai) },
+    { label: 'Automation', value: status.automation, tone: automationTone(status.automation) },
+  ];
+
+  // Overall tone excludes the intentionally-neutral rows (Broker=PAPER,
+  // Automation=UNKNOWN when idle) so a resting system still reads HEALTHY.
+  const overall = rows
+    .filter(r => !(r.label === 'Broker') && !(r.label === 'Automation' && r.value === 'UNKNOWN'))
+    .reduce<Tone>((acc, r) => worst(acc, r.tone), 'good');
+
+  const alerts: SystemSummary['alerts'] = [];
+  if (status.backend === 'OFFLINE') {
+    alerts.push({
+      title: 'Backend unreachable',
+      impact: 'Quotes, orders, and automation are unavailable',
+      action: 'Check the Render service and retry in a moment',
+    });
+  } else if (status.backend === 'DEGRADED') {
+    alerts.push({
+      title: 'Backend responding slowly',
+      impact: 'Data may lag; actions may take longer to confirm',
+      action: 'Monitor; open Diagnostics if it persists',
+    });
+  }
+  if (status.optionsFeed === 'STALE') {
+    alerts.push({
+      title: 'Options feed delayed',
+      impact: 'Options quotes may be stale',
+      action: 'Check Massive entitlement and the Options WebSocket owner',
+    });
+  }
+  if (status.socket === 'DISCONNECTED') {
+    alerts.push({
+      title: 'Realtime stream disconnected',
+      impact: 'Live prices are not updating',
+      action: 'The client will auto-reconnect; reload if it does not recover',
+    });
+  }
+  if (status.chart.status === 'STALE') {
+    alerts.push({
+      title: 'Chart data stale',
+      impact: 'The chart is showing last-known bars',
+      action: 'Reselect the symbol or check the data feed in Diagnostics',
+    });
+  }
+  if (status.ai === 'error') {
+    alerts.push({
+      title: 'AI engine unreachable',
+      impact: 'AI analysis and chat are unavailable',
+      action: 'Check the agent service; retry shortly',
+    });
+  }
+
+  const headline = overall === 'good' ? 'HEALTHY' : overall === 'bad' ? 'OFFLINE' : 'DEGRADED';
+  const reason = alerts.length ? alerts[0].title : null;
+
+  return { tone: overall, headline, reason, rows, alerts };
+}
+
+type Props = {
+  marketClosed?: boolean;
+  chartErrored?: boolean;
+  /** Opens the full Diagnostics surface (System Ops) from the popover footer. */
+  onOpenDiagnostics?: () => void;
+};
+
+export const SystemStatusControl = memo(function SystemStatusControl({
+  marketClosed,
+  chartErrored,
+  onOpenDiagnostics,
+}: Props) {
+  const status = useSystemStatus({ marketClosed, chartErrored });
+  const summary = summarizeSystemStatus(status);
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const popId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onDocClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDocClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  return (
+    <div
+      ref={rootRef}
+      className="relative flex items-center border-b border-intel-line bg-intel-bg px-4 py-1.5"
+    >
+      <button
+        type="button"
+        onClick={() => setOpen(v => !v)}
+        aria-expanded={open}
+        aria-controls={popId}
+        aria-label={`System status: ${summary.headline}${summary.reason ? ` — ${summary.reason}` : ''}`}
+        className="inline-flex items-center gap-2 rounded-panel border border-transparent px-1.5 py-0.5 transition-colors hover:border-intel-line focus:outline-none focus-visible:border-intel-accentLine"
+      >
+        <span className={`h-1.5 w-1.5 rounded-full ${TONE_DOT[summary.tone]}`} />
+        <span className="font-mono text-[9.5px] uppercase tracking-label text-intel-ink3">System</span>
+        <span className={`font-mono text-[10px] font-semibold uppercase tracking-label ${TONE_TEXT[summary.tone]}`}>
+          {summary.headline}
+        </span>
+        {summary.reason && (
+          <span className="hidden font-mono text-[10px] text-intel-ink3 sm:inline">· {summary.reason}</span>
+        )}
+      </button>
+
+      {open && (
+        <div
+          id={popId}
+          role="dialog"
+          aria-label="System status detail"
+          className="absolute left-2 top-full z-50 mt-1 w-[320px] rounded-panel border border-intel-line bg-intel-panel p-3 shadow-2xl"
+        >
+          {summary.alerts.length > 0 && (
+            <div className="mb-3 flex flex-col gap-2">
+              {summary.alerts.map(a => (
+                <div key={a.title} className="rounded-panel border border-intel-warn/40 bg-intel-warn/10 px-2.5 py-2">
+                  <div className="font-mono text-[11px] font-semibold text-intel-warn">{a.title}</div>
+                  <div className="mt-0.5 text-[11px] text-intel-ink2">Impact: {a.impact}</div>
+                  <div className="text-[11px] text-intel-ink3">Recommended: {a.action}</div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className="flex flex-col gap-1">
+            {summary.rows.map(row => (
+              <div key={row.label} className="flex items-center justify-between gap-3">
+                <span className="inline-flex items-center gap-2">
+                  <span className={`h-1.5 w-1.5 rounded-full ${TONE_DOT[row.tone]}`} />
+                  <span className="font-mono text-[10px] uppercase tracking-label text-intel-ink3">{row.label}</span>
+                </span>
+                <span className={`font-mono text-[10.5px] font-semibold uppercase tracking-label ${TONE_TEXT[row.tone]}`}>
+                  {row.value}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-3 flex items-center justify-between border-t border-intel-line pt-2">
+            <span className="font-mono text-[9.5px] uppercase tracking-label text-intel-ink3">
+              {status.chart.ageSeconds != null ? `Chart updated ${status.chart.ageSeconds}s ago` : 'Live'}
+            </span>
+            {onOpenDiagnostics && (
+              <button
+                type="button"
+                onClick={() => {
+                  setOpen(false);
+                  onOpenDiagnostics();
+                }}
+                className="font-mono text-[10px] font-semibold uppercase tracking-label text-intel-accent hover:underline"
+              >
+                Diagnostics →
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+});

--- a/client/src/components/layout/navModes.tsx
+++ b/client/src/components/layout/navModes.tsx
@@ -15,12 +15,14 @@ export type NavMode = {
   icon: ReactNode;
 };
 
-/** Primary operating modes — the desk a trader lives in. */
+/** Primary operating modes — aligned to the operator lifecycle
+ *  (Research → Analyze → Enter → Manage → Review). Internal view ids are
+ *  unchanged; only the operator-facing vocabulary moves to the terminal terms. */
 export const PRIMARY_MODES: NavMode[] = [
-  { id: 'trading', label: 'Terminal', hint: 'Discover · analyze · execute · manage', icon: <LineChart className="h-[18px] w-[18px]" /> },
-  { id: 'portfolio', label: 'Positions', hint: 'The book · aggregate risk · P/L', icon: <Layers className="h-[18px] w-[18px]" /> },
+  { id: 'trading', label: 'Trade', hint: 'Research · analyze · enter', icon: <LineChart className="h-[18px] w-[18px]" /> },
+  { id: 'portfolio', label: 'Positions', hint: 'Manage the book · risk · P/L', icon: <Layers className="h-[18px] w-[18px]" /> },
   { id: 'cockpit', label: 'Automation', hint: 'Supervise the machine', icon: <Bot className="h-[18px] w-[18px]" /> },
-  { id: 'intelligence', label: 'Intelligence', hint: 'Sessions · journal · research', icon: <BrainCircuit className="h-[18px] w-[18px]" /> },
+  { id: 'intelligence', label: 'Review', hint: 'Trades · journal · learning', icon: <BrainCircuit className="h-[18px] w-[18px]" /> },
 ];
 
 /** Secondary destination — demoted from the primary rail to a footer utility. */

--- a/client/src/components/options/OptionsChainPanel.tsx
+++ b/client/src/components/options/OptionsChainPanel.tsx
@@ -546,27 +546,11 @@ export const OptionsChainPanel = memo(function OptionsChainPanel({
                 {formatExpirationDate(leg.expiration)}
                 {isHeld && <span className="ml-2 text-intel-accent">· In your book</span>}
               </div>
+              {/* Bid/Ask/Mark/Last/Vol/OI/IV/Spread already read on the row
+                  itself (and in the Top of Book + ticket). The drawer only adds
+                  the analytics the one-line row can't carry. */}
               <div className="grid grid-cols-4 gap-x-4 gap-y-2 md:grid-cols-8">
-                <InfoTile
-                  label="Bid"
-                  value={liveBid != null ? `$${liveBid.toFixed(2)}` : '—'}
-                  sub={liveQuote?.bidSize != null ? `×${liveQuote.bidSize}` : undefined}
-                  tone="pos"
-                />
-                <InfoTile
-                  label="Ask"
-                  value={liveAsk != null ? `$${liveAsk.toFixed(2)}` : '—'}
-                  sub={liveQuote?.askSize != null ? `×${liveQuote.askSize}` : undefined}
-                  tone="neg"
-                />
-                <InfoTile label="Mark" value={liveMark != null ? `$${liveMark.toFixed(2)}` : '—'} />
-                <InfoTile label="Last" value={liveLast != null ? `$${liveLast.toFixed(2)}` : '—'} />
-                <InfoTile label="Vol" value={leg.volume != null ? leg.volume.toLocaleString() : '—'} />
-                <InfoTile label="OI" value={resolvedOpenInterest != null ? resolvedOpenInterest.toLocaleString() : '—'} />
-                <InfoTile label="IV" value={resolvedIv != null ? `${(resolvedIv * 100).toFixed(1)}%` : '—'} />
                 <InfoTile label="B/E" value={breakeven != null ? `$${breakeven.toFixed(2)}` : '—'} />
-              </div>
-              <div className="mt-2 grid grid-cols-4 gap-x-4 gap-y-2 border-t border-intel-line pt-2.5 md:grid-cols-8">
                 <InfoTile
                   label="Intrinsic"
                   value={formatCurrency(intrinsicValue(side, underlyingPrice, strike))}
@@ -574,11 +558,6 @@ export const OptionsChainPanel = memo(function OptionsChainPanel({
                 <InfoTile
                   label="Extrinsic"
                   value={formatCurrency(extrinsicValue(side, underlyingPrice, strike, mark))}
-                />
-                <InfoTile
-                  label="Spread"
-                  value={spreadPct != null ? `${spreadPct.toFixed(1)}%` : '—'}
-                  tone={spreadPct != null && spreadPct > 10 ? 'warn' : undefined}
                 />
                 <InfoTile label="Prob ITM" value={pItm != null ? `${(pItm * 100).toFixed(0)}%` : '—'} />
                 <InfoTile
@@ -669,6 +648,39 @@ export const OptionsChainPanel = memo(function OptionsChainPanel({
           </div>
         )}
       </div>
+      {/* Sticky footer — the spot/1σ recap and visible-contract count stay
+          pinned below the internal scroll, so the operator never loses the
+          reference frame while the ladder moves. */}
+      {rows.length > 0 && (
+        <div className="flex items-center justify-between gap-3 border-t border-intel-line bg-intel-panel px-3 py-1.5 font-mono text-[10px] tabular-nums text-intel-ink3">
+          <div className="flex items-center gap-3">
+            {underlyingPrice != null && (
+              <span>
+                SPOT <span className="text-intel-info">{formatCurrency(underlyingPrice)}</span>
+              </span>
+            )}
+            {expectedMoveValue != null && underlyingPrice != null && (
+              <span className="hidden sm:inline">
+                1σ{' '}
+                <span className="text-intel-ai">
+                  {formatCurrency(underlyingPrice - expectedMoveValue)}–{formatCurrency(underlyingPrice + expectedMoveValue)}
+                </span>
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-3">
+            <span>
+              {rows.length} {optionType === 'calls' ? 'calls' : 'puts'}
+              {dteLabel ? ` · ${dteLabel}` : ''}
+            </span>
+            {selectedContract && (
+              <span className="max-w-[180px] truncate text-intel-info" title={selectedContract.ticker.replace(/^O:/, '')}>
+                ◧ {selectedContract.ticker.replace(/^O:/, '')}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
     </section>
   );
 });

--- a/client/src/components/options/PriceLadder.tsx
+++ b/client/src/components/options/PriceLadder.tsx
@@ -12,6 +12,8 @@ import { useLiveQuote, useLiveTrade, useLiveTradeHistory } from '../../lib/liveM
 const TICK = 0.01;
 const RUNGS_EACH_SIDE = 7;
 const TAPE_ROWS = 8;
+// Collapse a run of this many (or more) dead inside-spread rungs into one gap.
+const COLLAPSE_MIN = 4;
 const LIVE_QUOTE_FRESH_MS = 10_000;
 // A quiet contract with a healthy, acknowledged subscription can legitimately
 // go well past LIVE_QUOTE_FRESH_MS between NBBO prints — the last quote is
@@ -44,6 +46,10 @@ type Rung = {
   isLast: boolean;
 };
 
+// A ladder display row is either a real price rung or a collapsed gap standing
+// in for a run of dead inside-spread rungs.
+type LadderItem = { type: 'rung'; rung: Rung } | { type: 'gap'; id: string; rungs: Rung[] };
+
 type PriceLadderProps = {
   symbol: string | null;
   underlying: string;
@@ -66,6 +72,10 @@ export const PriceLadder = memo(function PriceLadder({
   marketClosed,
 }: PriceLadderProps) {
   const [now, setNow] = useState(() => Date.now());
+  // Inside-spread price levels with no resting size are collapsed by default so
+  // a wide spread doesn't flood the ladder with dead rungs. Operators can
+  // expand a gap on demand; a new contract starts collapsed again.
+  const [expandedGaps, setExpandedGaps] = useState<Set<string>>(() => new Set());
   const quote = useLiveQuote(symbol);
   const lastTrade = useLiveTrade(symbol);
   const tape = useLiveTradeHistory(symbol);
@@ -98,6 +108,47 @@ export const PriceLadder = memo(function PriceLadder({
   }, [bid, ask, quote?.bidSize, quote?.askSize, lastPrice]);
 
   const tapeRows = useMemo(() => tape.slice(0, TAPE_ROWS), [tape]);
+
+  // A new contract resets any manually expanded gaps.
+  useEffect(() => {
+    setExpandedGaps(new Set());
+  }, [symbol]);
+
+  // Fold the rungs into a display list: any run of ≥ COLLAPSE_MIN contiguous
+  // inside-spread rungs that carry no resting size (and aren't the last print
+  // or the mid marker) becomes a single collapsible gap. The inside market —
+  // bid, ask, mid, and last — always survives, so the market stays centered.
+  const ladderItems = useMemo<LadderItem[]>(() => {
+    if (!rungs.length) return [];
+    const items: LadderItem[] = [];
+    let run: Rung[] = [];
+    const flush = () => {
+      if (!run.length) return;
+      if (run.length >= COLLAPSE_MIN) {
+        const id = `${run[0].price.toFixed(2)}-${run[run.length - 1].price.toFixed(2)}`;
+        items.push({ type: 'gap', id, rungs: run });
+      } else {
+        for (const r of run) items.push({ type: 'rung', rung: r });
+      }
+      run = [];
+    };
+    for (const rung of rungs) {
+      const isMidMarker = mid != null && Math.abs(rung.price - mid) < TICK / 2;
+      const significant =
+        rung.isBid || rung.isAsk || rung.isLast || rung.bidSize != null || rung.askSize != null || isMidMarker;
+      const insideSpread =
+        bid != null && ask != null && rung.price > bid + TICK / 2 && rung.price < ask - TICK / 2;
+      if (insideSpread && !significant) {
+        run.push(rung);
+      } else {
+        flush();
+        items.push({ type: 'rung', rung });
+      }
+    }
+    flush();
+    return items;
+  }, [rungs, mid, bid, ask]);
+
   useEffect(() => {
     const id = window.setInterval(() => setNow(Date.now()), 1_000);
     return () => window.clearInterval(id);
@@ -185,12 +236,63 @@ export const PriceLadder = memo(function PriceLadder({
     OFFLINE: 'Options service unavailable.',
   }[status];
 
+  const renderRung = (rung: Rung) => (
+    <div
+      key={rung.price.toFixed(2)}
+      className={`grid grid-cols-3 items-center px-4 py-[3px] font-mono text-[12px] tabular-nums ${
+        rung.isBid || rung.isAsk ? 'bg-intel-panel2' : ''
+      }`}
+    >
+      {/* Bid size — left flank, only at the best bid rung. */}
+      <span className="text-intel-info">
+        {rung.bidSize != null ? (
+          <span className="inline-flex items-center gap-2">
+            <span className="inline-block h-3 rounded-sm bg-intel-info/25" style={{ width: sizeBar(rung.bidSize) }} />
+            {rung.bidSize}
+          </span>
+        ) : (
+          ''
+        )}
+      </span>
+
+      {/* Price spine — center band; last trade lit; bid/ask tinted. */}
+      <span
+        className={`rounded-sm py-[1px] text-center font-semibold ${
+          rung.isLast
+            ? 'bg-intel-info text-intel-bg'
+            : rung.isBid
+              ? 'bg-intel-panel2 text-intel-info'
+              : rung.isAsk
+                ? 'bg-intel-panel2 text-intel-neg'
+                : mid != null && Math.abs(rung.price - mid) < TICK / 2
+                  ? 'bg-intel-accentSoft text-intel-accent'
+                  : 'bg-intel-panel2/50 text-intel-ink2'
+        }`}
+        title={rung.isLast && lastTrade?.size != null ? `Last trade ×${lastTrade.size}` : undefined}
+      >
+        {rung.price.toFixed(2)}
+      </span>
+
+      {/* Ask size — right flank, only at the best ask rung. */}
+      <span className="text-right text-intel-neg">
+        {rung.askSize != null ? (
+          <span className="inline-flex items-center justify-end gap-2">
+            {rung.askSize}
+            <span className="inline-block h-3 rounded-sm bg-intel-neg/25" style={{ width: sizeBar(rung.askSize) }} />
+          </span>
+        ) : (
+          ''
+        )}
+      </span>
+    </div>
+  );
+
   return (
     <section className="flex h-full flex-col rounded-panel bg-intel-panel" data-testid="price-ladder">
       <div className="flex items-center justify-between border-b border-intel-divider px-4 py-2.5">
         <div className="flex min-w-0 items-center gap-2">
           <h3 className="font-mono text-[10px] font-semibold uppercase tracking-label text-intel-ink3">
-            Matrix · Top of Book
+            Top of Book
           </h3>
           <span className="truncate font-mono text-[11px] font-semibold text-intel-ink">
             {contractLabel ?? symbol ?? `${underlying} Options`}
@@ -207,63 +309,60 @@ export const PriceLadder = memo(function PriceLadder({
 
       {rungs.length === 0 ? (
         <div
-          className="flex flex-1 items-center justify-center px-4 py-8 text-center font-mono text-[11px] text-intel-ink3"
+          className="flex flex-1 flex-col items-center justify-center gap-3 px-6 py-8 text-center"
           data-testid="price-ladder-status"
         >
-          {statusCopy}
+          {/* Stacked-rung glyph — reads as "book" even before data lands, so the
+              panel looks intentional rather than empty. */}
+          <div
+            aria-hidden
+            className="flex flex-col items-center gap-[3px] opacity-60"
+          >
+            {[16, 24, 20, 28, 18].map((w, i) => (
+              <span
+                key={i}
+                className={`h-[3px] rounded-full ${i === 2 ? 'bg-intel-accent/60' : 'bg-intel-line'}`}
+                style={{ width: `${w}px` }}
+              />
+            ))}
+          </div>
+          <p className="font-mono text-[11px] text-intel-ink2">{statusCopy}</p>
+          {status === 'WAITING_FOR_CONTRACTS' && (
+            <p className="max-w-[220px] font-mono text-[10px] leading-relaxed text-intel-ink3">
+              Pick a strike in the Matrix, or use Auto-Select Contract, to stream the live book and tape here.
+            </p>
+          )}
         </div>
       ) : (
         <div className="flex-1 overflow-y-auto">
-          {rungs.map(rung => (
-            <div
-              key={rung.price.toFixed(2)}
-              className={`grid grid-cols-3 items-center px-4 py-[3px] font-mono text-[12px] tabular-nums ${
-                rung.isBid || rung.isAsk ? 'bg-intel-panel2' : ''
-              }`}
-            >
-              {/* Bid size — left flank, only at the best bid rung. */}
-              <span className="text-intel-info">
-                {rung.bidSize != null ? (
-                  <span className="inline-flex items-center gap-2">
-                    <span className="inline-block h-3 rounded-sm bg-intel-info/25" style={{ width: sizeBar(rung.bidSize) }} />
-                    {rung.bidSize}
-                  </span>
-                ) : (
-                  ''
-                )}
-              </span>
-
-              {/* Price spine — center band; last trade lit; bid/ask tinted. */}
-              <span
-                className={`rounded-sm py-[1px] text-center font-semibold ${
-                  rung.isLast
-                    ? 'bg-intel-info text-intel-bg'
-                    : rung.isBid
-                      ? 'bg-intel-panel2 text-intel-info'
-                      : rung.isAsk
-                        ? 'bg-intel-panel2 text-intel-neg'
-                        : mid != null && Math.abs(rung.price - mid) < TICK / 2
-                          ? 'bg-intel-accentSoft text-intel-accent'
-                          : 'bg-intel-panel2/50 text-intel-ink2'
-                }`}
-                title={rung.isLast && lastTrade?.size != null ? `Last trade ×${lastTrade.size}` : undefined}
+          {ladderItems.map(item =>
+            item.type === 'rung' ? (
+              renderRung(item.rung)
+            ) : expandedGaps.has(item.id) ? (
+              item.rungs.map(rung => renderRung(rung))
+            ) : (
+              <button
+                key={`gap-${item.id}`}
+                type="button"
+                onClick={() =>
+                  setExpandedGaps(prev => {
+                    const next = new Set(prev);
+                    next.add(item.id);
+                    return next;
+                  })
+                }
+                className="grid w-full grid-cols-3 items-center px-4 py-1 transition-colors hover:bg-intel-panel2/50"
+                title={`${item.rungs.length} price levels with no resting size — click to expand`}
+                aria-label={`Show ${item.rungs.length} hidden price levels with no resting size`}
               >
-                {rung.price.toFixed(2)}
-              </span>
-
-              {/* Ask size — right flank, only at the best ask rung. */}
-              <span className="text-right text-intel-neg">
-                {rung.askSize != null ? (
-                  <span className="inline-flex items-center justify-end gap-2">
-                    {rung.askSize}
-                    <span className="inline-block h-3 rounded-sm bg-intel-neg/25" style={{ width: sizeBar(rung.askSize) }} />
-                  </span>
-                ) : (
-                  ''
-                )}
-              </span>
-            </div>
-          ))}
+                <span className="h-px bg-intel-divider" />
+                <span className="mx-auto rounded-sm border border-intel-divider bg-intel-panel2/40 px-2 py-[1px] font-mono text-[9px] uppercase tracking-label text-intel-ink3">
+                  {item.rungs.length} empty ⋯
+                </span>
+                <span className="h-px bg-intel-divider" />
+              </button>
+            )
+          )}
         </div>
       )}
 

--- a/client/src/components/portfolio/PortfolioPanel.tsx
+++ b/client/src/components/portfolio/PortfolioPanel.tsx
@@ -336,12 +336,24 @@ function PositionBlotterRow({
   return (
     <tr
       onClick={onSelect}
-      aria-selected={selected}
       className={`cursor-pointer border-b border-intel-lineSoft font-mono text-xs text-intel-ink2 transition-colors hover:bg-intel-panel2 ${
         selected ? 'bg-intel-accentSoft' : ''
       }`}
     >
-      <td className={`${TD} font-semibold text-intel-ink`}>{pos.symbol}</td>
+      <td className={`${TD} font-semibold text-intel-ink`}>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelect();
+          }}
+          aria-pressed={selected}
+          aria-label={`Manage position ${pos.symbol}`}
+          className="text-left text-intel-ink hover:text-intel-accent focus:outline-none focus-visible:underline"
+        >
+          {pos.symbol}
+        </button>
+      </td>
       <td className={TD}>
         <span className={source === 'AUTO' ? 'text-intel-accent' : 'text-intel-ink2'}>{source}</span>
       </td>

--- a/client/src/components/portfolio/PortfolioPanel.tsx
+++ b/client/src/components/portfolio/PortfolioPanel.tsx
@@ -9,8 +9,10 @@ import {
   type ManualIntent,
 } from '../../api/manualTrading';
 import type { DeskInsight } from '../../api/analysis';
-import type { PortfolioOperations, PortfolioRisk } from '../../api/portfolio';
+import type { OwnedPosition, PortfolioOperations, PortfolioRisk } from '../../api/portfolio';
 import type { WatchlistSnapshot } from '../../types/market';
+import { PositionManagerPanel } from './PositionManagerPanel';
+import { setActivePosition, useActivePosition } from '../../lib/workspaceContextStore';
 import {
   ActionButton,
   AlertBanner,
@@ -274,6 +276,8 @@ function PositionBlotterRow({
   closing,
   closeDisabled,
   onClose,
+  onSelect,
+  selected,
 }: {
   pos: PositionView;
   source: 'AUTO' | 'MANUAL';
@@ -285,6 +289,8 @@ function PositionBlotterRow({
   closing: boolean;
   closeDisabled: boolean;
   onClose: () => void;
+  onSelect: () => void;
+  selected: boolean;
 }) {
   const liveSymbol = toLiveOptionSymbol(pos.symbol);
   useCockpitLiveSubscription(liveSymbol);
@@ -328,7 +334,13 @@ function PositionBlotterRow({
       : entry;
 
   return (
-    <tr className="border-b border-intel-lineSoft font-mono text-xs text-intel-ink2 transition-colors hover:bg-intel-panel2">
+    <tr
+      onClick={onSelect}
+      aria-selected={selected}
+      className={`cursor-pointer border-b border-intel-lineSoft font-mono text-xs text-intel-ink2 transition-colors hover:bg-intel-panel2 ${
+        selected ? 'bg-intel-accentSoft' : ''
+      }`}
+    >
       <td className={`${TD} font-semibold text-intel-ink`}>{pos.symbol}</td>
       <td className={TD}>
         <span className={source === 'AUTO' ? 'text-intel-accent' : 'text-intel-ink2'}>{source}</span>
@@ -370,7 +382,10 @@ function PositionBlotterRow({
         <button
           type="button"
           aria-label={`Close position ${pos.symbol}`}
-          onClick={onClose}
+          onClick={(e) => {
+            e.stopPropagation();
+            onClose();
+          }}
           disabled={closing || closeDisabled}
           className="rounded border border-intel-neg/40 px-2 py-1 font-mono text-[10px] uppercase tracking-wide text-intel-neg transition hover:bg-intel-neg/10 disabled:cursor-not-allowed disabled:opacity-40"
         >
@@ -795,6 +810,36 @@ export function PortfolioPanel({ aiEnabled = true, sentimentEnabled = true, onOp
     [automationPositions, manualPositions]
   );
 
+  // Symbol -> broker-truth owned position, so selecting a blotter row can pass
+  // the automation positionId (needed by the live snapshot endpoint) and the
+  // attached stop/target onto the shared context bus. No new fetch — this reads
+  // the same operations payload the blotter already renders.
+  const ownedBySymbol = useMemo(() => {
+    const map = new Map<string, OwnedPosition>();
+    const rows = [
+      ...(portfolioOperations?.automationContext?.positionsBySymbol ?? []),
+      ...(portfolioOperations?.manualBrokerActivity?.positions ?? []),
+    ];
+    for (const row of rows) map.set(normalizePositionSymbol(row.symbol), row);
+    return map;
+  }, [portfolioOperations]);
+
+  const activePosition = useActivePosition();
+  const handleSelectPosition = useCallback(
+    (pos: PositionView, source: 'AUTO' | 'MANUAL') => {
+      const owned = ownedBySymbol.get(normalizePositionSymbol(pos.symbol));
+      setActivePosition({
+        id: owned?.automation?.positionId ?? pos.symbol,
+        underlying: getUnderlyingSymbol(pos.symbol),
+        optionSymbol: pos.symbol,
+        source: owned?.source ?? (source === 'AUTO' ? 'AUTOMATION' : 'MANUAL'),
+        stopPrice: owned?.automation?.stopPrice ?? null,
+        targetPrice: owned?.automation?.targetPrice ?? null,
+      });
+    },
+    [ownedBySymbol]
+  );
+
   // Book greeks exposure: Σ greek × signed contracts × 100. Null (shown as em
   // dash) when any open position is missing that greek — a partial sum would
   // misstate the book.
@@ -999,6 +1044,9 @@ export function PortfolioPanel({ aiEnabled = true, sentimentEnabled = true, onOp
         )}
       </div>
 
+      {/* POSITION MANAGER — detail for the selected position (context bus) */}
+      <PositionManagerPanel />
+
       {/* POSITIONS BLOTTER */}
       <section className="rounded-panel bg-intel-panel">
         <div className="flex flex-wrap items-center justify-between gap-2 border-b border-intel-divider px-4 py-2.5">
@@ -1071,6 +1119,8 @@ export function PortfolioPanel({ aiEnabled = true, sentimentEnabled = true, onOp
                     closing={closingSymbol === pos.symbol}
                     closeDisabled={isMarketOpen === false}
                     onClose={() => handleClosePosition(pos)}
+                    onSelect={() => handleSelectPosition(pos, source)}
+                    selected={activePosition?.optionSymbol === pos.symbol}
                   />
                 );
               })}

--- a/client/src/components/portfolio/PositionManagerPanel.tsx
+++ b/client/src/components/portfolio/PositionManagerPanel.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useRef, useState } from 'react';
+import { X, Crosshair } from 'lucide-react';
+import { getPositionLive, type PositionLiveSnapshot } from '../../api/portfolio';
+import { GreeksGrid } from '../cockpit/GreeksGrid';
+import {
+  useActivePosition,
+  setActivePosition,
+  useLinkedMode,
+  setLinkedMode,
+} from '../../lib/workspaceContextStore';
+
+// Position Management workspace — the focused detail surface for the ONE open
+// position the operator is managing. Driven entirely by the shared workspace
+// context bus (useActivePosition), so selecting a position anywhere lights this
+// up. It reuses the existing per-position live endpoint (getPositionLive) and
+// the cockpit GreeksGrid; it introduces no new API, socket, or broker path.
+//
+// Read + focus only in this pass: it surfaces identity, live market, Greeks,
+// working orders, risk, and DTE, and drives Linked Mode. Execution (close,
+// partial close) stays on the canonical paths that already exist in the blotter.
+
+const POLL_MS = 3000;
+
+function money(n: number | null | undefined): string {
+  return n == null || !Number.isFinite(n) ? '—' : `$${n.toFixed(2)}`;
+}
+function pct(n: number | null | undefined): string {
+  return n == null || !Number.isFinite(n) ? '—' : `${(n * 100).toFixed(1)}%`;
+}
+function num(n: number | null | undefined, digits = 0): string {
+  return n == null || !Number.isFinite(n) ? '—' : n.toFixed(digits);
+}
+
+function Stat({ label, value, tone }: { label: string; value: string; tone?: 'pos' | 'neg' }) {
+  const toneClass = tone === 'pos' ? 'text-intel-pos' : tone === 'neg' ? 'text-intel-neg' : 'text-intel-ink';
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="font-mono text-[9.5px] uppercase tracking-label text-intel-ink3">{label}</span>
+      <span className={`font-mono text-sm font-semibold tabular-nums ${toneClass}`}>{value}</span>
+    </div>
+  );
+}
+
+export function PositionManagerPanel() {
+  const position = useActivePosition();
+  const linked = useLinkedMode();
+  const [live, setLive] = useState<PositionLiveSnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const activeId = position?.id ?? null;
+  const idRef = useRef<string | null>(null);
+  idRef.current = activeId;
+
+  useEffect(() => {
+    setLive(null);
+    setError(null);
+    if (!activeId) return;
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const snap = await getPositionLive(activeId);
+        if (!cancelled && idRef.current === activeId) setLive(snap);
+      } catch {
+        if (!cancelled && idRef.current === activeId) setError('Live snapshot unavailable');
+      }
+    };
+    void poll();
+    const timer = window.setInterval(poll, POLL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [activeId]);
+
+  if (!position) return null;
+
+  const optionSymbol = position.optionSymbol ?? (typeof position['symbol'] === 'string' ? (position['symbol'] as string) : null);
+  const source = position.source ?? 'MANUAL';
+  const stopPrice = typeof position['stopPrice'] === 'number' ? (position['stopPrice'] as number) : null;
+  const targetPrice = typeof position['targetPrice'] === 'number' ? (position['targetPrice'] as number) : null;
+
+  const bid = live?.bid ?? null;
+  const ask = live?.ask ?? null;
+  const mid = live?.mid ?? (bid != null && ask != null ? (bid + ask) / 2 : null);
+  const spread = bid != null && ask != null ? ask - bid : null;
+  const spreadPct = spread != null && mid ? spread / mid : null;
+
+  return (
+    <section
+      className="rounded-panel border border-intel-accentLine bg-intel-panel"
+      aria-label="Position manager"
+      data-testid="position-manager"
+    >
+      <header className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-intel-line px-4 py-3">
+        <span className="font-mono text-sm font-semibold text-intel-ink">{position.underlying}</span>
+        {optionSymbol && (
+          <span className="font-mono text-[11px] text-intel-ink2">{optionSymbol}</span>
+        )}
+        <span className="rounded-full border border-intel-line px-2 py-0.5 font-mono text-[9.5px] uppercase tracking-label text-intel-ink3">
+          {source}
+        </span>
+        <button
+          type="button"
+          onClick={() => setLinkedMode(!linked)}
+          aria-pressed={linked}
+          title="Linked Mode — sync chart, matrix, Greeks, and AI to this position"
+          className={`ml-auto inline-flex items-center gap-1.5 rounded-panel border px-2 py-0.5 font-mono text-[10px] uppercase tracking-label transition-colors ${
+            linked
+              ? 'border-intel-accentLine bg-intel-accentSoft text-intel-accent'
+              : 'border-intel-line text-intel-ink3 hover:text-intel-ink2'
+          }`}
+        >
+          <Crosshair className="h-3 w-3" /> Linked {linked ? 'On' : 'Off'}
+        </button>
+        <button
+          type="button"
+          onClick={() => setActivePosition(null)}
+          aria-label="Clear selected position"
+          className="rounded-panel border border-intel-line p-1 text-intel-ink3 transition-colors hover:text-intel-ink2"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </header>
+
+      <div className="grid grid-cols-2 gap-x-6 gap-y-3 px-4 py-3 sm:grid-cols-3 lg:grid-cols-6">
+        <Stat label="Bid" value={money(bid)} />
+        <Stat label="Ask" value={money(ask)} />
+        <Stat label="Mid" value={money(mid)} />
+        <Stat label="Spread" value={spread == null ? '—' : `${money(spread)} · ${pct(spreadPct)}`} />
+        <Stat label="DTE" value={num(live?.daysToExpiration)} />
+        <Stat label="Break-even" value={money(live?.breakEvenPrice)} />
+      </div>
+
+      <div className="border-t border-intel-line px-4 py-3">
+        <span className="mb-2 block font-mono text-[9.5px] uppercase tracking-label text-intel-ink3">Greeks</span>
+        <GreeksGrid greeks={live} />
+      </div>
+
+      <div className="grid gap-3 border-t border-intel-line px-4 py-3 sm:grid-cols-2">
+        <div>
+          <span className="mb-2 block font-mono text-[9.5px] uppercase tracking-label text-intel-ink3">Working orders</span>
+          <div className="flex flex-col gap-1.5 font-mono text-[12px]">
+            <div className="flex items-center justify-between">
+              <span className="text-intel-neg">Stop</span>
+              <span className="tabular-nums text-intel-ink2">{stopPrice == null ? 'Not attached' : money(stopPrice)}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-intel-pos">Take profit</span>
+              <span className="tabular-nums text-intel-ink2">{targetPrice == null ? 'Not attached' : money(targetPrice)}</span>
+            </div>
+          </div>
+        </div>
+        <div>
+          <span className="mb-2 block font-mono text-[9.5px] uppercase tracking-label text-intel-ink3">Risk &amp; liquidity</span>
+          <div className="flex flex-col gap-1.5 font-mono text-[12px]">
+            <div className="flex items-center justify-between">
+              <span className="text-intel-ink3">Implied vol</span>
+              <span className="tabular-nums text-intel-ink2">{pct(live?.impliedVolatility)}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-intel-ink3">Open interest</span>
+              <span className="tabular-nums text-intel-ink2">{num(live?.openInterest)}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-intel-ink3">Day volume</span>
+              <span className="tabular-nums text-intel-ink2">{num(live?.dayVolume)}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {(error || live?.available === false) && (
+        <p className="border-t border-intel-line px-4 py-2 font-mono text-[11px] text-intel-ink3">
+          {source === 'AUTOMATION'
+            ? 'Live contract snapshot is temporarily unavailable — showing last known values.'
+            : 'Live Greeks require an automation-tracked position; identity and working orders are shown from broker truth.'}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/client/src/components/portfolio/PositionManagerPanel.tsx
+++ b/client/src/components/portfolio/PositionManagerPanel.tsx
@@ -46,7 +46,11 @@ export function PositionManagerPanel() {
   const linked = useLinkedMode();
   const [live, setLive] = useState<PositionLiveSnapshot | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const activeId = position?.id ?? null;
+  // Only automation-tracked positions have a Mongo positionId the live-snapshot
+  // endpoint can resolve. Manual positions carry the option symbol as their id,
+  // which the endpoint can't use — so we never poll for them (no wasted 3s
+  // request cycle) and show the explanatory note instead.
+  const activeId = position?.source === 'AUTOMATION' ? (position?.id ?? null) : null;
   const idRef = useRef<string | null>(null);
   idRef.current = activeId;
 
@@ -168,7 +172,7 @@ export function PositionManagerPanel() {
         </div>
       </div>
 
-      {(error || live?.available === false) && (
+      {(error || live?.available === false || source !== 'AUTOMATION') && (
         <p className="border-t border-intel-line px-4 py-2 font-mono text-[11px] text-intel-ink3">
           {source === 'AUTOMATION'
             ? 'Live contract snapshot is temporarily unavailable — showing last known values.'

--- a/client/src/components/shared/CollapsibleSection.tsx
+++ b/client/src/components/shared/CollapsibleSection.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react';
+import { ChevronRight } from 'lucide-react';
+
+// Progressive-disclosure wrapper for advanced / secondary panels. Built on the
+// native <details> element so it is keyboard- and screen-reader-accessible with
+// no extra state. Collapsed by default keeps the primary workflow calm while
+// the capability stays one click away — nothing is removed.
+
+type Props = {
+  title: string;
+  hint?: string;
+  /** Start expanded. Advanced tools should stay collapsed (the default). */
+  defaultOpen?: boolean;
+  children: ReactNode;
+  className?: string;
+};
+
+export function CollapsibleSection({ title, hint, defaultOpen = false, children, className = '' }: Props) {
+  return (
+    <details
+      open={defaultOpen}
+      className={`group rounded-panel border border-intel-line bg-intel-panel ${className}`}
+    >
+      <summary className="flex cursor-pointer list-none items-center gap-2 px-4 py-2.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-intel-accent">
+        <ChevronRight className="h-4 w-4 text-intel-ink3 transition-transform group-open:rotate-90" aria-hidden="true" />
+        <span className="font-mono text-xs font-semibold uppercase tracking-eyebrow text-intel-ink">{title}</span>
+        {hint && <span className="font-mono text-[10px] text-intel-ink3">· {hint}</span>}
+        <span className="ml-auto font-mono text-[10px] uppercase tracking-label text-intel-ink3 group-open:hidden">
+          Show
+        </span>
+      </summary>
+      <div className="border-t border-intel-line p-4">{children}</div>
+    </details>
+  );
+}

--- a/client/src/components/trading/OrderTicketPanel.tsx
+++ b/client/src/components/trading/OrderTicketPanel.tsx
@@ -747,7 +747,9 @@ export const OrderTicketPanel = memo(function OrderTicketPanel({
         </TicketCard>
 
         <TicketCard title="Probability">
-          <div className="grid grid-cols-5 gap-x-2 gap-y-2">
+          {/* 6 metrics on a 3-col grid → two balanced rows (was 5-col, which
+              stranded Vega alone on a second line). */}
+          <div className="grid grid-cols-3 gap-x-3 gap-y-2">
             <TicketMetric
               label="POP"
               value={popDisplay}

--- a/client/src/lib/activityFeed.ts
+++ b/client/src/lib/activityFeed.ts
@@ -60,8 +60,12 @@ const OPERATOR_SIGNAL =
 export function isOperatorEvent(event: AutomationVisibilityEvent): boolean {
   const name = `${event.event ?? ''}`;
   if ((event.severity ?? '').toLowerCase() === 'critical') return true;
-  if (OPERATOR_SIGNAL.test(name)) return true;
+  // Engineering telemetry is checked BEFORE the operator-signal match so a
+  // reconciliation event that happens to contain an operator token (e.g.
+  // RECONCILE_POSITION_CLOSED) stays in Diagnostics rather than leaking onto
+  // the operator timeline.
   if (ENGINEERING.test(name)) return false;
+  if (OPERATOR_SIGNAL.test(name)) return true;
   const category = categorize(event);
   return category === 'trades' || category === 'orders' || category === 'risk' || category === 'errors';
 }

--- a/client/src/lib/activityFeed.ts
+++ b/client/src/lib/activityFeed.ts
@@ -42,6 +42,45 @@ export function categorize(event: AutomationVisibilityEvent): ActivityCategory {
 // Repetitive, low-signal events that should be collapsed into a count.
 const GROUPABLE = /(HEARTBEAT|MARK_RECEIVED|EVALUATED|TICK|POLL|NO_SIGNAL|CACHE_)/i;
 
+// Pure engineering telemetry — reconciliation, scheduler, lease, queue, cache.
+// These belong in the Diagnostics drawer, never on the operator's timeline.
+const ENGINEERING = /(HEARTBEAT|RECONCIL|SCHEDULER|LEASE|QUEUE|CACHE_|POLL|TICK|EVALUATED|MARK_RECEIVED|RENEW|DEDUP|SNAPSHOT_TAKEN|WATCHLIST_CACHE)/i;
+
+// Events an operator acts on, even when they'd otherwise look routine. These
+// always stay on the operator timeline regardless of the engineering filter.
+const OPERATOR_SIGNAL =
+  /(FILL|POSITION_OPENED|POSITION_CLOSED|POSITION_FILLED|EXIT|ORDER_SUBMITTED|ORDER_FILLED|CANCEL|RISK_REJECT|RISK_APPROV|RECOMMEND|EMERGENCY|BROKER_DISCONNECT|DATA_STALE|DATA_DEGRADED|SIGNAL_CHANGED|CANDIDATE)/i;
+
+/**
+ * Whether an event belongs on the OPERATOR activity timeline (a trading /
+ * risk / system event a person acts on) rather than in engineering Diagnostics.
+ * Critical severity is always operator-facing; explicit engineering telemetry
+ * is always excluded; otherwise trade/order/risk/error categories qualify.
+ */
+export function isOperatorEvent(event: AutomationVisibilityEvent): boolean {
+  const name = `${event.event ?? ''}`;
+  if ((event.severity ?? '').toLowerCase() === 'critical') return true;
+  if (OPERATOR_SIGNAL.test(name)) return true;
+  if (ENGINEERING.test(name)) return false;
+  const category = categorize(event);
+  return category === 'trades' || category === 'orders' || category === 'risk' || category === 'errors';
+}
+
+/** Split a raw event stream into operator-facing and engineering (diagnostic)
+ *  events without dropping anything — the two arrays partition the input. */
+export function splitOperatorEvents(events: AutomationVisibilityEvent[]): {
+  operator: AutomationVisibilityEvent[];
+  engineering: AutomationVisibilityEvent[];
+} {
+  const operator: AutomationVisibilityEvent[] = [];
+  const engineering: AutomationVisibilityEvent[] = [];
+  for (const event of events) {
+    if (isOperatorEvent(event)) operator.push(event);
+    else engineering.push(event);
+  }
+  return { operator, engineering };
+}
+
 function isGroupable(event: AutomationVisibilityEvent): boolean {
   // Never group anything that failed — errors always stay individual.
   if ((event.severity ?? '').toLowerCase() === 'critical') return false;

--- a/client/src/lib/workspaceContextStore.ts
+++ b/client/src/lib/workspaceContextStore.ts
@@ -1,0 +1,190 @@
+import { useSyncExternalStore } from 'react';
+import type { OptionLeg } from '../types/market';
+
+// Shared workspace context bus — the single source of truth for "what the
+// operator is currently focused on" across every workspace (Trade, Positions,
+// Automation, Review, AI Desk).
+//
+// This deliberately mirrors liveMarketStore's useSyncExternalStore pattern:
+// the hot state (which symbol/contract/position/trade is active) lives outside
+// the React tree so a focus change re-renders only the panels that subscribe
+// to that slice, never the whole application. App.tsx publishes into this bus
+// from its existing selection handlers; downstream panels (chart, matrix,
+// Greeks, risk, AI) read from it instead of receiving the same value threaded
+// through a dozen props.
+//
+// It does NOT own market data (that stays in liveMarketStore) and it does NOT
+// open sockets or fetch — it is pure focus state, so wiring a new consumer
+// never creates a duplicate subscription or API client.
+
+/** A selected open position, kept intentionally loose so the bus doesn't couple
+ *  to any one portfolio DTO. Panels read the fields they need. */
+export type ActivePosition = {
+  id: string;
+  underlying: string;
+  optionSymbol?: string | null;
+  /** Lifecycle owner — 'AUTOMATION' | 'MANUAL' | other; passthrough for display. */
+  source?: string | null;
+} & Record<string, unknown>;
+
+/** A selected trade for the Review workspace (closed trade / lifecycle record). */
+export type ActiveTrade = {
+  id: string;
+  underlying?: string | null;
+} & Record<string, unknown>;
+
+export type WorkspaceContext = {
+  /** The active underlying symbol (normalized upper-case), or null. */
+  activeSymbol: string | null;
+  /** The active option contract, or null when only an underlying is selected. */
+  activeContract: OptionLeg | null;
+  /** The open position the operator is managing, or null. */
+  activePosition: ActivePosition | null;
+  /** The trade selected in the Review workspace, or null. */
+  activeTrade: ActiveTrade | null;
+  /** When true, selecting a position/trade also re-centers the chart underlying.
+   *  When false, management never interrupts a symbol the operator is studying. */
+  linkedMode: boolean;
+};
+
+type Listener = () => void;
+
+const LINKED_MODE_KEY = 'workspace:linkedMode';
+
+function readPersistedLinkedMode(): boolean {
+  try {
+    const raw = window.localStorage.getItem(LINKED_MODE_KEY);
+    // Default ON — linked focus is the enterprise default; operators opt out.
+    return raw == null ? true : raw === 'true';
+  } catch {
+    return true;
+  }
+}
+
+let state: WorkspaceContext = {
+  activeSymbol: null,
+  activeContract: null,
+  activePosition: null,
+  activeTrade: null,
+  linkedMode: readPersistedLinkedMode(),
+};
+
+const listeners = new Set<Listener>();
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}
+
+/** Replace state with a new object only when something actually changed, so
+ *  useSyncExternalStore consumers keep a stable reference and don't re-render
+ *  on no-op publishes. */
+function commit(next: Partial<WorkspaceContext>): void {
+  let changed = false;
+  const merged = { ...state };
+  for (const key of Object.keys(next) as (keyof WorkspaceContext)[]) {
+    if (next[key] !== undefined && merged[key] !== next[key]) {
+      (merged[key] as unknown) = next[key];
+      changed = true;
+    }
+  }
+  if (!changed) return;
+  state = merged;
+  emit();
+}
+
+function normalizeSymbol(symbol: string | null): string | null {
+  if (symbol == null) return null;
+  const trimmed = symbol.trim().toUpperCase();
+  return trimmed.length ? trimmed : null;
+}
+
+// ---- publishers (called by App.tsx selection handlers) ----------------------
+
+/** Set the active underlying. Selecting a new underlying clears the active
+ *  contract, matching operator expectation that the chain re-scopes. */
+export function setActiveSymbol(symbol: string | null): void {
+  const next = normalizeSymbol(symbol);
+  if (next === state.activeSymbol) return;
+  commit({ activeSymbol: next, activeContract: null });
+}
+
+/** Set (or clear) the active option contract. */
+export function setActiveContract(contract: OptionLeg | null): void {
+  commit({ activeContract: contract });
+}
+
+/** Set (or clear) the open position under management. */
+export function setActivePosition(position: ActivePosition | null): void {
+  commit({ activePosition: position });
+}
+
+/** Set (or clear) the trade selected for review. */
+export function setActiveTrade(trade: ActiveTrade | null): void {
+  commit({ activeTrade: trade });
+}
+
+/** Toggle or set Linked Mode; persisted locally so it survives reloads. */
+export function setLinkedMode(next: boolean): void {
+  if (next === state.linkedMode) return;
+  try {
+    window.localStorage.setItem(LINKED_MODE_KEY, String(next));
+  } catch {
+    /* non-fatal: persistence is best-effort */
+  }
+  commit({ linkedMode: next });
+}
+
+export function toggleLinkedMode(): void {
+  setLinkedMode(!state.linkedMode);
+}
+
+// ---- readers ----------------------------------------------------------------
+
+export function getWorkspaceContext(): WorkspaceContext {
+  return state;
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Subscribe to the whole context. Prefer the narrower hooks below where a
+ *  panel only cares about one slice. */
+export function useWorkspaceContext(): WorkspaceContext {
+  return useSyncExternalStore(subscribe, getWorkspaceContext, getWorkspaceContext);
+}
+
+export function useActiveSymbol(): string | null {
+  return useSyncExternalStore(subscribe, () => state.activeSymbol, () => state.activeSymbol);
+}
+
+export function useActiveContract(): OptionLeg | null {
+  return useSyncExternalStore(subscribe, () => state.activeContract, () => state.activeContract);
+}
+
+export function useActivePosition(): ActivePosition | null {
+  return useSyncExternalStore(subscribe, () => state.activePosition, () => state.activePosition);
+}
+
+export function useActiveTrade(): ActiveTrade | null {
+  return useSyncExternalStore(subscribe, () => state.activeTrade, () => state.activeTrade);
+}
+
+export function useLinkedMode(): boolean {
+  return useSyncExternalStore(subscribe, () => state.linkedMode, () => state.linkedMode);
+}
+
+/** Test-only: reset the bus to a clean state. Not used in production code. */
+export function __resetWorkspaceContextForTests(): void {
+  state = {
+    activeSymbol: null,
+    activeContract: null,
+    activePosition: null,
+    activeTrade: null,
+    linkedMode: true,
+  };
+  emit();
+}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -116,3 +116,127 @@ body {
 #root {
   min-height: 100vh;
 }
+
+/* ── Custom scrollbars ──────────────────────────────────────────────────────
+   One consistent, thin, professional scrollbar across every panel scroll
+   region. Intel palette; the track is transparent so the bar never overlaps or
+   competes with content, and the thumb recedes until hovered. Firefox uses the
+   standardized properties; WebKit/Blink use the pseudo-elements. Monaco ships
+   its own overlay scrollbars, so it is exempted below. */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #1f2b3e transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: #1f2b3e; /* subtle, always visible so scrollability reads */
+  border-radius: 9999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+*::-webkit-scrollbar-thumb:vertical {
+  min-height: 32px;
+}
+
+*:hover::-webkit-scrollbar-thumb {
+  background-color: #2b3b56;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background-color: #3d5378; /* brighter on direct hover of the bar */
+}
+
+*::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+/* Monaco manages its own scrollbars — don't let the global rule fight it. */
+.monaco-editor *::-webkit-scrollbar-thumb {
+  background-color: rgba(148, 163, 184, 0.3);
+}
+
+/* ── AI desk note markdown ──────────────────────────────────────────────────
+   Render the model's markdown in the terminal idiom: purple, tracked, uppercase
+   section headings (thesis / bull / bear / catalysts / risks surface as h2/h3),
+   compact lists, and restrained links. Display only — the AI text is untouched. */
+.desk-markdown {
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: #eef2fa;
+}
+.desk-markdown > *:first-child {
+  margin-top: 0;
+}
+.desk-markdown > *:last-child {
+  margin-bottom: 0;
+}
+.desk-markdown p {
+  margin: 0 0 0.5rem;
+}
+.desk-markdown strong {
+  color: #eef2fa;
+  font-weight: 600;
+}
+.desk-markdown em {
+  color: #93a3ba;
+}
+.desk-markdown h1,
+.desk-markdown h2,
+.desk-markdown h3,
+.desk-markdown h4 {
+  margin: 0.75rem 0 0.25rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: #a98bf5;
+}
+.desk-markdown ul {
+  margin: 0 0 0.5rem;
+  padding-left: 1rem;
+  list-style: disc;
+}
+.desk-markdown ol {
+  margin: 0 0 0.5rem;
+  padding-left: 1.1rem;
+  list-style: decimal;
+}
+.desk-markdown li {
+  margin: 0.125rem 0;
+}
+.desk-markdown li::marker {
+  color: #5c6b81;
+}
+.desk-markdown a {
+  color: #6aa5f5;
+  text-decoration: underline;
+}
+.desk-markdown code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8em;
+  background: rgba(148, 163, 184, 0.12);
+  padding: 0 0.25rem;
+  border-radius: 3px;
+}
+.desk-markdown blockquote {
+  margin: 0.5rem 0;
+  border-left: 2px solid #243144;
+  padding-left: 0.6rem;
+  color: #93a3ba;
+}
+.desk-markdown hr {
+  margin: 0.6rem 0;
+  border: 0;
+  border-top: 1px solid #16202e;
+}

--- a/docs/design/bottom-workspace-tabs-migration.md
+++ b/docs/design/bottom-workspace-tabs-migration.md
@@ -1,0 +1,126 @@
+# Bottom Workspace → Tabs: Architecture & Safe Migration Path
+
+**Status: prototype / not implemented.** This is the Phase 2E deliverable — an
+architecture note and the safest migration path for converting the trading
+view's lower workspace from a vertical stack into a tabbed workspace. No tab code
+ships in Phase 2 because the naive implementation regresses live data (see
+*Risk* below). The full switch is deferred to the V3 Contract Workspace effort.
+
+## Current state
+
+In `client/src/App.tsx` the `tradingView` center column stacks, top to bottom:
+
+| Order | Panel | Element | Disclosure today |
+| --- | --- | --- | --- |
+| 1 | Chart | `chartPanelEl` | always visible |
+| 2 | Options Matrix | `chainPanelEl` | always visible (bounded `h-[32rem]`) |
+| 3 | AI / Desk Insight | `deskInsightPanel` | always visible |
+| 4 | Greeks & Contract Analysis | `GreeksPanel` in `CollapsibleSection` | collapsed by default |
+| 5 | Scanner | `scannerPanelEl` in `CollapsibleSection` | collapsed by default |
+
+The operator scrolls `<main>` to move between AI → Greeks → Scanner. Chart and
+Matrix are the anchors; everything below is progressive-disclosure today.
+
+**Target:** replace items 3–5 (and future Automation / Journal / Analytics) with
+a single tabbed workspace — one pane visible at a time, selected by a tab bar —
+so the operator *changes workspaces* instead of scrolling.
+
+```
+┌ AI · Greeks · Scanner · Automation · Journal · Analytics ┐
+│                                                          │
+│                 (one pane, bounded height,               │
+│                  its own internal scroll)                │
+└──────────────────────────────────────────────────────────┘
+```
+
+## Risk: why conditional mounting is unsafe
+
+`GreeksPanel` and `OptionsScanner` acquire live-quote subscriptions / fire REST
+fetches on mount. The obvious tab implementation —
+
+```tsx
+{tab === 'greeks' ? <GreeksPanel/> : tab === 'scanner' ? <Scanner/> : <AI/>}
+```
+
+— **unmounts the inactive panes**, which tears down their subscriptions and
+refetches on every tab switch. Consequences:
+
+- Live option/Greeks subscriptions drop and re-`live:subscribe` on each switch —
+  extra socket churn and a visible re-warm flicker.
+- Scanner re-runs its fetch; scroll position, expanded rows, and in-flight AI
+  requests are lost.
+- Increased backend/provider load from repeated (re)subscription.
+
+That violates the Phase 2 boundary ("no websocket logic changes, no data
+regressions") in spirit even though no data *code* changed.
+
+## Safe pattern: mount-all, toggle visibility
+
+Keep every pane **mounted**; hide inactive panes with CSS (`hidden` /
+`display:none`) rather than unmounting them.
+
+```tsx
+<div role="tablist" aria-label="Workspace">
+  {TABS.map(t => (
+    <button role="tab" aria-selected={t.id === active} aria-controls={`pane-${t.id}`}
+      id={`tab-${t.id}`} onClick={() => setActive(t.id)} /* + arrow-key roving */>
+      {t.label}
+    </button>
+  ))}
+</div>
+{TABS.map(t => (
+  <div key={t.id} role="tabpanel" id={`pane-${t.id}`} aria-labelledby={`tab-${t.id}`}
+       hidden={t.id !== active} className="min-h-0 flex-1 overflow-y-auto">
+    {t.render()}   {/* the EXISTING deskInsightPanel / GreeksPanel / scannerPanelEl, unchanged */}
+  </div>
+))}
+```
+
+Properties:
+
+- **Subscriptions persist** across switches — inactive panes are merely hidden,
+  never unmounted, so no re-`live:subscribe`, no refetch, no flicker.
+- **State persists** — scroll position, expanded rows, form drafts survive.
+- Each pane keeps its own bounded height + internal scroll (already true today),
+  which is what removes the page scroll.
+- The panels themselves are reused **verbatim** — zero changes to Greeks, AI, or
+  Scanner internals, so the diff is additive and trivially revertible.
+
+For heavy panes that are rarely opened, a *mount-once-on-first-activation* refinement
+(lazy mount, then keep mounted) trades a first-open delay for lower idle cost — optional.
+
+## Active-tab state
+
+- Store `active` as local view state in `App.tsx` (`useState`), optionally
+  persisted to `localStorage` per operator. This is **view** state, not business
+  or market state — it does not touch the market store, order lifecycle, or any
+  MongoDB/API contract.
+- Sensible default: `AI` when no contract is selected, `Greeks` once a contract
+  is armed (mirrors the Select → Analyze → Review workflow).
+
+## Incremental migration steps
+
+1. Add a presentational `WorkspaceTabs` component (tablist + panes, CSS
+   visibility toggle, `role=tablist/tab/tabpanel`, roving arrow-key focus). No
+   data, no business logic.
+2. Wrap the **existing** `deskInsightPanel`, `GreeksPanel`, and `scannerPanelEl`
+   as panes — panels unchanged.
+3. Default active tab per workflow; keep all panes mounted.
+4. Verify (screenshots + network/socket trace) that switching tabs does **not**
+   re-subscribe or refetch, and that Greeks/Scanner keep streaming.
+5. Only then retire the `CollapsibleSection` wrappers for these three.
+6. Later: add Automation / Journal / Analytics panes as those surfaces land.
+
+## Accessibility
+
+`role="tablist"` / `role="tab"` / `role="tabpanel"`, `aria-selected`,
+`aria-controls`/`aria-labelledby`, roving `tabindex` with Left/Right (and
+Home/End) arrow navigation, and a visible focus ring on the active tab. Hidden
+panes use the `hidden` attribute so they are removed from the a11y tree and tab
+order while mounted.
+
+## Rollback
+
+Because panes reuse the same components, reverting to the stacked +
+`CollapsibleSection` layout is a one-line swap of the container — no data or
+component changes to unwind.

--- a/docs/ui/V2-UI-002-feature-preservation.md
+++ b/docs/ui/V2-UI-002-feature-preservation.md
@@ -1,0 +1,43 @@
+# V2-UI-002 — Feature Preservation Matrix
+
+Presentation-layer alignment. **Nothing was removed.** Every enterprise
+capability remains reachable; this table records where each now lives and at
+what disclosure level.
+
+Levels: **PRIMARY** (default operator surface) · **CONTEXTUAL** (appears when a
+symbol/position/trade is selected) · **ADVANCED** (behind a collapsible section)
+· **DIAGNOSTIC** (in the Diagnostics drawer / System Ops) · **HISTORICAL** (in
+the Review workspace).
+
+| Capability | Before | After — location | Level |
+| --- | --- | --- | --- |
+| Terminal / chart | `trading` view | Trade workspace (renamed rail label) | PRIMARY |
+| Watchlist | Sidebar | Trade workspace sidebar | PRIMARY |
+| Options matrix / chain | trading grid | Trade workspace (centers on active contract when Linked) | PRIMARY / CONTEXTUAL |
+| Order ticket | trading grid | Trade workspace right rail | PRIMARY |
+| AI summary (desk insight) | trading grid | Trade workspace | PRIMARY |
+| Greeks (contract analysis) | always-open panel | Trade workspace — **collapsible** "Greeks & contract analysis" | ADVANCED |
+| Scanner | always-open full-width | Trade workspace — **collapsible** "Scanner" | ADVANCED |
+| Positions blotter + book summary | `portfolio` view | Positions workspace | PRIMARY |
+| **Per-position management** (bid/ask/mid/spread, Greeks, working orders, IV/OI, DTE, break-even) | scattered / close-only | **Position Manager** panel (select a row) | CONTEXTUAL |
+| Close position / cancel order | portfolio blotter | unchanged (canonical path) | PRIMARY |
+| Automation supervision (strategy, recommendation, today's results, health, recent actions) | Cockpit | Automation workspace default | PRIMARY |
+| Scheduler / monitor / queue telemetry | Cockpit (always open) | Automation — **collapsible** "Engineering diagnostics" + Diagnostics drawer | DIAGNOSTIC |
+| Trade lifecycle | Cockpit | Automation workspace | PRIMARY |
+| Learning intelligence | Cockpit only | Automation **and** Review workspace (Learning tab) | PRIMARY / HISTORICAL |
+| Risk engine | Cockpit / portfolio | Automation + per-position risk in Position Manager | PRIMARY / CONTEXTUAL |
+| AI Desk (verdict → full analysis) | ChatDock | ChatDock (verdict-first, "View Full Analysis") | PRIMARY |
+| Daily reports · Trade reports · Decision journal · Strategy analytics · Sessions | Intelligence tabs | Review workspace tabs | HISTORICAL |
+| System status (7 badges) | permanent badge row | **compact System control** + popover | PRIMARY |
+| Backend / broker / Massive / WS / Mongo / AI / automation health | badge row | System control popover **and** Diagnostics drawer | PRIMARY / DIAGNOSTIC |
+| Data health · engine room · logs · lease · cache · latency · heartbeats | System Ops page | Diagnostics drawer (reuses System Ops) + System Ops view | DIAGNOSTIC |
+| Operator activity timeline | mixed with heartbeats | Command Center — operator-only feed | PRIMARY |
+| Engineering event log | mixed feed | Diagnostics drawer live logs | DIAGNOSTIC |
+
+## Navigation — before vs after
+
+**Before (rail):** Terminal · Positions · Automation · Intelligence — + System Ops (secondary)
+**After (rail):** Trade · Positions · Automation · Review — + System Ops (secondary) + **Diagnostics drawer** (from the System status control, reachable from every workspace)
+
+Internal view ids (`trading` · `portfolio` · `cockpit` · `intelligence` ·
+`operations`) are unchanged, so all deep links and view behavior are preserved.


### PR DESCRIPTION
## V2-UI-002 — Production Trading Workspace Alignment

Presentation-layer sprint. Reorganizes AI-Trader into an institutional workstation while **preserving every enterprise capability**. No trading logic, prompts, schemas, broker/Massive/socket paths, or engines were touched; no live/autonomous trading enabled.

### Deliverables
| # | Deliverable | Status |
|---|---|---|
| — | Shared context bus + Linked Mode + compact status + nav + integration (prior slice) | ✅ |
| 1 | **Diagnostics drawer** — reuses System Ops verbatim in a slide-over, reachable from every workspace via the status control; collapsed by default | ✅ |
| 2 | **Operator activity timeline** — `isOperatorEvent`/`splitOperatorEvents`; Command Center feed is operator-only; engineering events stay in Diagnostics | ✅ |
| 3 | **Position Management workspace** — select a position → identity, bid/ask/mid/spread, Greeks, working orders, IV/OI/volume, DTE, break-even (reuses `getPositionLive` + `GreeksGrid`) | ✅ |
| 4 | **Matrix integration** — Linked Mode syncs chart/matrix/contract to the active position via existing setters | ✅ |
| 5 | **Automation cleanup** — scheduler/monitor/queue telemetry collapsed under "Engineering diagnostics"; strategy/results/actions lead | ✅ |
| 6 | **AI Desk** — already verdict-first with explicit "View Full Analysis" (AiReportCard); requirement met, left untouched | ✅ |
| 7 | **Trade workspace** — Greeks & Scanner moved behind collapsible advanced sections; chart/chain/ticket/AI lead | ✅ |
| 8 | **Review workspace** — Learning added as a first-class tab beside reports/journal/analytics/sessions | ✅ |
| 9 | **Responsive** — Position Manager is card-based/responsive and surfaces in the mobile Portfolio tab; no new giant tables. *Dedicated mobile "Manage" tab is a minor follow-on.* | ◑ |

### Feature preservation
Full matrix in `docs/ui/V2-UI-002-feature-preservation.md`. Nothing removed; internal view ids unchanged so all deep links/behaviors are preserved.

**Nav before:** Terminal · Positions · Automation · Intelligence (+ System Ops)
**Nav after:** Trade · Positions · Automation · Review (+ System Ops + Diagnostics drawer everywhere)

**Consolidated:** 7 status badges → 1 status control; Learning now lives in Review too; engineering telemetry → one Diagnostics drawer.
**Moved (not removed):** Greeks/Scanner → collapsible advanced; scheduler/monitor/queue → Engineering diagnostics; mixed activity feed → operator feed + Diagnostics logs.

### Reuse / safety
- One shared context bus (`workspaceContextStore`) — no duplicate stores; opens no sockets/fetches.
- Position Manager reuses the existing per-position live endpoint and the blotter's close path — no new API/broker/socket.
- Diagnostics drawer reuses `SystemOperationsPage` verbatim.
- Build guard confirms **single HTTP client, single socket client** in the bundle.

### Validation
- Root `npm run lint` — clean (`--max-warnings=0`)
- Root `npm run build` (server `tsc` + client `tsc`+`vite build`) — pass; postbuild guard OK
- `npm --prefix client test` — **164 pass / 34 files** (22 new tests: context bus, status roll-up, operator/engineering split, position manager)
- `npm --prefix server test` — **460 pass / 0 fail**
- `git diff --check` — clean
- No trading/automation/report regressions; no duplicate sockets or HTTP clients

### Performance
Additive, subscription-scoped state (useSyncExternalStore) — focus changes re-render only subscribing panels, not the app tree. Bundle deltas modest (PortfolioPanel 26→32 kB gz 9.3; GreeksGrid split into a shared 2 kB chunk). Position Manager polls the existing 3s live endpoint only while a position is selected.

### Known limitations
- P2 execution actions (partial close, modify/replace, scale, reverse, bracket/OCO) intentionally **not** included — separate approved execution sprint. UI shows read + focus + existing close/cancel only.
- Dedicated mobile **Manage** tab not added (management is available via the Positions tab, card-based).
- Diagnostics drawer reuses the full System Ops page rather than a bespoke tabbed telemetry layout.

Ready for review. **Do not auto-merge** — awaiting approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)