### PR TITLE
AI-Trader V4 — Broker OAuth, Portfolio Sync & Enterprise Onboarding

### DIFF
--- a/client/e2e/auth.spec.ts
+++ b/client/e2e/auth.spec.ts
@@ -138,7 +138,7 @@ test.describe('Enterprise identity gateway', () => {
     await page.unroute('**/api/auth/config');
     await page.unroute('**/api/auth/csrf');
     await page.unroute('**/api/auth/refresh');
-    await page.route(/^https?:\/\/[^/]+:4001\/api\//, route => {
+    await page.route(/^https?:\/\/[^/]+\/api\//, route => {
       const path = new URL(route.request().url()).pathname;
       let body: object = {};
       if (path === '/api/auth/config') body = { googleConfigured: true, googleClientId: 'test-client', alpacaConfigured: true, alpacaPaper: true };
@@ -177,7 +177,7 @@ test.describe('Enterprise identity gateway', () => {
     expect((await googleStart).url()).toContain('returnTo=%2Fauth%2Flogin');
   });
 
-  test('forces first-login onboarding and launches a provisioned paper workspace', async ({ page }) => {
+  test('forces first-login OAuth onboarding, portfolio sync, and terminal launch', async ({ page }) => {
     const user: any = {
       id: 'operator-1',
       email: 'operator@example.com',
@@ -208,11 +208,21 @@ test.describe('Enterprise identity gateway', () => {
       layouts: ['trading', 'ai', 'research', 'portfolio', 'automation'].map(key => ({ key, label: `${key} layout`, version: 1 })),
     };
 
-    await page.route('**/api/auth/login', route => route.fulfill({
+    let authenticated = false;
+    await page.unroute('**/api/auth/refresh');
+    await page.route('**/api/auth/refresh', route => route.fulfill({
+      status: authenticated ? 200 : 401,
+      contentType: 'application/json',
+      body: JSON.stringify(authenticated ? { accessToken: 'restored-token', accessTokenExpiresInSec: 900, sessionId: 'session-1', user } : { error: 'SESSION_INVALID' }),
+    }));
+    await page.route('**/api/auth/login', route => {
+      authenticated = true;
+      return route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({ accessToken: 'access-token', accessTokenExpiresInSec: 900, sessionId: 'session-1', user }),
-    }));
+      });
+    });
     await page.route('**/api/auth/workspace', route => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ workspace }) }));
     await page.route('**/api/auth/onboarding', async route => {
       const body = route.request().postDataJSON();
@@ -222,15 +232,25 @@ test.describe('Enterprise identity gateway', () => {
       if (body.riskProfile) Object.assign(workspace.riskProfile, body.riskProfile);
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ workspace }) });
     });
-    await page.route('**/api/auth/onboarding/broker/paper', route => {
-      workspace.brokerOnboarding.status = 'connected';
-      workspace.brokerOnboarding.connections = [{ provider: 'paper', label: 'Paper Trading', status: 'connected', accountId: 'paper-1', accountType: 'paper', paper: true, buyingPower: 100000, currency: 'USD' }];
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ workspace }) });
+    const brokerEntry = () => ({
+      provider: 'alpaca', name: 'Alpaca', monogram: 'A', assets: ['Stocks', 'Options', 'Crypto'], oauthSupported: true,
+      paperTrading: true, liveTrading: true, available: true, configured: true,
+      permissions: ['Read Account', 'Read Buying Power', 'Read Positions', 'Read Orders', 'Submit Orders'],
+      description: 'API-first brokerage for equities, options, and digital assets.',
+      connections: workspace.brokerOnboarding.connections.map((connection: any) => ({
+        id: 'connection-1', provider: 'alpaca', brokerName: 'Alpaca', nickname: 'Alpaca', accountId: connection.accountId,
+        accountType: 'margin', environment: 'paper', paper: true, live: false, primary: true, status: 'connected',
+        scopes: ['account', 'trading'], permissions: ['Read Account', 'Submit Orders'], connectedAt: new Date().toISOString(),
+        lastSync: new Date().toISOString(), lastRefresh: null, expiresAt: null, oauthStatus: 'authorized', reconnectStatus: 'not_required', health: 'healthy',
+        balances: { buyingPower: 250000.5, cash: 100000, equity: 300000, portfolioValue: 300000 }, metrics: { openPositions: 2, openOrders: 1, todayPl: 125 },
+      })),
     });
-    await page.route('**/api/auth/onboarding/broker/alpaca', route => {
+    await page.route('**/api/brokers', route => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ brokers: [brokerEntry()] }) }));
+    await page.route('**/api/brokers/alpaca/connect', route => {
       workspace.brokerOnboarding.status = 'connected';
-      workspace.brokerOnboarding.connections.push({ provider: 'alpaca', label: 'Alpaca', status: 'connected', accountId: 'alpaca-1', accountType: 'margin', paper: true, buyingPower: 250000.5, currency: 'USD' });
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ workspace }) });
+      workspace.brokerOnboarding.connections = [{ provider: 'alpaca', label: 'Alpaca', status: 'connected', accountId: 'alpaca-1', accountType: 'margin', paper: true, buyingPower: 250000.5, currency: 'USD' }];
+      workspace.onboarding.currentStep = 2;
+      return route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify({ authorizationUrl: `${new URL(page.url()).origin}/onboarding?__identity=real&broker=alpaca&connection=success` }) });
     });
     await page.route('**/api/auth/onboarding/complete', route => {
       workspace.onboarding.status = 'complete';
@@ -246,18 +266,17 @@ test.describe('Enterprise identity gateway', () => {
     await expect(page).toHaveURL(/\/onboarding$/);
     await expect(page.getByRole('heading', { name: 'Welcome to AI-Trader' })).toBeVisible();
 
-    await page.getByRole('button', { name: 'Continue', exact: true }).click();
-    await page.getByRole('button', { name: 'Start Paper Workspace' }).click();
-    await expect(page.getByRole('button', { name: 'Paper Connected' })).toBeVisible();
-    await page.getByRole('button', { name: 'Connect Alpaca' }).click();
-    await expect(page.getByRole('button', { name: 'Alpaca Connected' })).toBeVisible();
-    await expect(page.getByText('$250,000.5 buying power')).toBeVisible();
-    await page.getByRole('button', { name: 'Continue', exact: true }).click();
-    await page.getByRole('button', { name: 'Save AI profile' }).click();
-    await page.getByRole('button', { name: 'Initialize workspace' }).click();
-    await expect(page.getByRole('heading', { name: 'Workspace ready' })).toBeVisible();
+    await page.getByRole('button', { name: 'Open Broker Connection Center' }).click();
+    await page.getByRole('button', { name: /Alpaca/ }).first().click();
+    await expect(page.getByRole('heading', { name: 'Alpaca', exact: true })).toBeVisible();
+    await expect(page.getByText('AI-Trader never sees or stores your password')).toBeVisible();
+    await page.getByRole('button', { name: 'Connect with Alpaca' }).click();
+    await expect(page).toHaveURL(/connection=success/);
+    await expect(page.getByRole('heading', { name: 'Set hard operating boundaries' })).toBeVisible();
+    await page.getByRole('button', { name: 'Initialize AI workspace' }).click();
+    await expect(page.getByRole('heading', { name: 'Trading terminal ready' })).toBeVisible();
     await page.screenshot({ path: 'e2e-artifacts/onboarding-ready.png', fullPage: true });
-    await page.getByRole('button', { name: /Launch Trading Workspace/ }).click();
+    await page.getByRole('button', { name: /Launch Trading Terminal/ }).click();
     await expect(page).toHaveURL(/\/terminal$/);
   });
 });

--- a/client/e2e/production.spec.ts
+++ b/client/e2e/production.spec.ts
@@ -214,6 +214,17 @@ async function selectWatchlistSymbol(page: Page, symbol: string): Promise<boolea
 }
 
 async function mockBrokerReadModel(context: BrowserContext): Promise<void> {
+  await context.route('**/api/brokers/**', route => {
+    const path = new URL(route.request().url()).pathname;
+    if (path === '/api/brokers/status') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ checkedAt: new Date().toISOString(), healthy: 0, degraded: 0, reconnectRequired: 0, aiStatus: 'ready', riskScore: 35, recentSignals: [], connections: [] }),
+      });
+    }
+    return route.continue();
+  });
   await context.route('**/api/broker/**', route => {
     const path = new URL(route.request().url()).pathname;
     if (path === '/api/broker/account' || path === '/api/broker/alpaca/account') {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -40,6 +40,7 @@ import { AuthProvider, useAuth } from './auth/AuthContext';
 import { AuthScreen } from './auth/AuthScreen';
 import { ProfileMenu } from './auth/ProfileMenu';
 import { OnboardingScreen } from './auth/OnboardingScreen';
+import { BrokerageSummaryBar } from './components/brokerage/BrokerageSummaryBar';
 
 // Route-level code splitting: the heavy switchable views load on demand, so the
 // initial (trading) bundle no longer ships Scanner + Portfolio + Cockpit +
@@ -3120,6 +3121,7 @@ function TradingApp() {
   if (isMobile) {
     const mobileBanners = (
       <>
+        <BrokerageSummaryBar />
         {marketError && (
           <div className="mb-2 rounded-panel border border-intel-neg/30 bg-intel-neg/10 px-3 py-2 text-sm text-intel-neg">
             {marketError}
@@ -3230,6 +3232,7 @@ function TradingApp() {
         onOpenDiagnostics={() => setDiagnosticsOpen(true)}
       />
       <MarketContextBar />
+      <BrokerageSummaryBar />
       {settingsOpen && (
         <div
           className="fixed inset-0 z-40 flex justify-end bg-black/70 sm:px-3 sm:py-3"

--- a/client/src/__tests__/brokerageUi.test.tsx
+++ b/client/src/__tests__/brokerageUi.test.tsx
@@ -1,0 +1,65 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BrokerConnectionCenter } from '../components/brokerage/BrokerConnectionCenter';
+import { SecurityCenter } from '../components/brokerage/SecurityCenter';
+import * as brokerage from '../api/brokerage';
+
+vi.mock('../api/brokerage', async () => {
+  const actual = await vi.importActual<typeof import('../api/brokerage')>('../api/brokerage');
+  return { ...actual, listBrokers: vi.fn(), connectBroker: vi.fn(), disconnectBroker: vi.fn(), reconnectBroker: vi.fn(), syncBrokers: vi.fn(), getSecurityOverview: vi.fn() };
+});
+
+const connection: brokerage.BrokerConnection = {
+  id: 'connection-1', provider: 'alpaca', brokerName: 'Alpaca', nickname: 'Alpaca', accountId: 'account-1', accountType: 'margin',
+  environment: 'paper', paper: true, live: false, primary: true, status: 'connected', scopes: ['account', 'trading'],
+  permissions: ['Read Account', 'Submit Orders'], connectedAt: '2026-08-01T00:00:00Z', lastSync: '2026-08-02T00:00:00Z',
+  lastRefresh: null, expiresAt: null, oauthStatus: 'authorized', reconnectStatus: 'not_required', health: 'healthy',
+  balances: { buyingPower: 250000, cash: 100000, equity: 300000, portfolioValue: 300000 }, metrics: { openPositions: 2, openOrders: 1, todayPl: 100 },
+};
+
+const current = { provider: 'alpaca', name: 'Alpaca', monogram: 'A', assets: ['Stocks', 'Options', 'Crypto'], oauthSupported: true, paperTrading: true, liveTrading: true, available: true, configured: true, permissions: ['Read Account', 'Read Positions', 'Submit Orders'], description: 'API-first brokerage.', connections: [] } satisfies brokerage.BrokerDirectoryEntry;
+const future = { provider: 'schwab', name: 'Charles Schwab', monogram: 'CS', assets: ['Stocks', 'Options'], oauthSupported: false, paperTrading: false, liveTrading: true, available: false, configured: false, permissions: [], description: 'Full-service investing.', connections: [] } satisfies brokerage.BrokerDirectoryEntry;
+
+describe('enterprise brokerage UI', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.mocked(brokerage.listBrokers).mockResolvedValue([current, future]);
+    vi.mocked(brokerage.disconnectBroker).mockResolvedValue();
+    vi.mocked(brokerage.syncBrokers).mockResolvedValue();
+  });
+
+  it('shows active and future institutions without dead navigation', async () => {
+    render(<BrokerConnectionCenter />);
+    expect(await screen.findByRole('heading', { name: 'Connect your brokerage' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Alpaca/ })).toBeEnabled();
+    expect(screen.getByText('Charles Schwab')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Charles Schwab/ })).not.toBeInTheDocument();
+    expect(screen.getByText('No passwords stored')).toBeInTheDocument();
+  });
+
+  it('reviews permissions and disconnect consequences before revocation', async () => {
+    vi.mocked(brokerage.listBrokers).mockResolvedValue([{ ...current, connections: [connection] }, future]);
+    render(<BrokerConnectionCenter mode="settings" />);
+    await screen.findByText('connected');
+    fireEvent.click(await screen.findByRole('button', { name: /Alpaca/ }));
+    expect(screen.getByText('$250,000')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }));
+    expect(screen.getByRole('alertdialog')).toHaveTextContent('OAuth tokens');
+    expect(screen.getByRole('alertdialog')).toHaveTextContent('AI memory');
+    fireEvent.click(within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Disconnect' }));
+    await waitFor(() => expect(brokerage.disconnectBroker).toHaveBeenCalledWith('alpaca', 'connection-1'));
+  });
+
+  it('renders security controls, devices, brokers, and activity', async () => {
+    vi.mocked(brokerage.getSecurityOverview).mockResolvedValue({
+      controls: { oauthAuthentication: true, encryption: 'AES-256-GCM', transport: 'TLS 1.3', revocableAccess: true },
+      sessionStatus: 'active', lastLogin: '2026-08-02T00:00:00Z', connectedDevices: [{ id: 'session-1', device: { ua: 'Secure Browser', ip: '127.0.0.1' }, lastUsedAt: '2026-08-02T00:00:00Z', createdAt: '2026-08-01T00:00:00Z' }],
+      connectedBrokers: [connection], activity: [{ _id: 'audit-1', action: 'BROKER_CONNECTED', outcome: 'success', createdAt: '2026-08-02T00:00:00Z', ip: '127.0.0.1', ua: 'Secure Browser', targetType: 'broker_connection' }],
+    });
+    render(<SecurityCenter />);
+    expect(await screen.findByText('AES-256-GCM')).toBeInTheDocument();
+    expect(screen.getByText('TLS 1.3')).toBeInTheDocument();
+    expect(screen.getByText('Secure Browser')).toBeInTheDocument();
+    expect(screen.getByText('broker connected')).toBeInTheDocument();
+  });
+});

--- a/client/src/api/brokerage.ts
+++ b/client/src/api/brokerage.ts
@@ -1,0 +1,58 @@
+import { http } from './http';
+
+export type BrokerConnection = {
+  id: string; provider: string; brokerName: string; nickname: string; accountId: string | null;
+  accountType: string | null; environment: 'paper' | 'live'; paper: boolean; live: boolean; primary: boolean;
+  status: 'connecting' | 'connected' | 'syncing' | 'error' | 'revoked'; scopes: string[]; permissions: string[];
+  connectedAt: string | null; lastSync: string | null; lastRefresh: string | null; expiresAt: string | null;
+  oauthStatus: string; reconnectStatus: string; health: string;
+  balances: { buyingPower: number | null; cash: number | null; equity: number | null; portfolioValue: number | null };
+  metrics: { openPositions: number; openOrders: number; todayPl: number };
+};
+
+export type BrokerDirectoryEntry = {
+  provider: string; name: string; monogram: string; assets: string[]; oauthSupported: boolean;
+  paperTrading: boolean; liveTrading: boolean; available: boolean; configured: boolean;
+  permissions: string[]; description: string; connections: BrokerConnection[];
+};
+
+export async function listBrokers(): Promise<BrokerDirectoryEntry[]> {
+  const response = await http.get('/api/brokers');
+  return response.data.brokers ?? [];
+}
+
+export async function brokerStatus(): Promise<{ checkedAt: string; healthy: number; degraded: number; reconnectRequired: number; aiStatus: string; riskScore: number; recentSignals: unknown[]; connections: BrokerConnection[] }> {
+  const response = await http.get('/api/brokers/status');
+  return response.data;
+}
+
+export async function connectBroker(provider: string, environment: 'paper' | 'live', returnTo = '/onboarding'): Promise<string> {
+  const response = await http.post(`/api/brokers/${encodeURIComponent(provider)}/connect`, { environment, returnTo });
+  return response.data.authorizationUrl;
+}
+
+export async function reconnectBroker(provider: string, environment: 'paper' | 'live'): Promise<string> {
+  const response = await http.post(`/api/brokers/${encodeURIComponent(provider)}/reconnect`, { environment, returnTo: '/terminal?settings=brokers' });
+  return response.data.authorizationUrl;
+}
+
+export async function disconnectBroker(provider: string, connectionId: string): Promise<void> {
+  await http.post(`/api/brokers/${encodeURIComponent(provider)}/disconnect`, { connectionId });
+}
+
+export async function syncBrokers(provider?: string): Promise<void> {
+  await http.post('/api/brokers/sync', provider ? { provider } : {});
+}
+
+export type SecurityOverview = {
+  controls: { oauthAuthentication: boolean; encryption: string; transport: string; revocableAccess: boolean };
+  sessionStatus: string; lastLogin: string | null;
+  connectedDevices: Array<{ id: string; device: { ua: string; ip: string }; lastUsedAt: string; createdAt: string }>;
+  connectedBrokers: BrokerConnection[];
+  activity: Array<{ _id: string; action: string; outcome: string; createdAt: string; ip: string; ua: string; targetType: string | null }>;
+};
+
+export async function getSecurityOverview(): Promise<SecurityOverview> {
+  const response = await http.get('/api/brokers/security');
+  return response.data;
+}

--- a/client/src/auth/OnboardingScreen.tsx
+++ b/client/src/auth/OnboardingScreen.tsx
@@ -1,22 +1,16 @@
 import { useEffect, useMemo, useState } from 'react';
-import {
-  ArrowRight,
-  Bot,
-  Building2,
-  Check,
-  CheckCircle2,
-  Loader2,
-  LockKeyhole,
-  ShieldCheck,
-  SlidersHorizontal,
-  WalletCards,
-} from 'lucide-react';
+import { ArrowRight, Bot, Check, CheckCircle2, Loader2, LockKeyhole, ShieldCheck, SlidersHorizontal } from 'lucide-react';
+import { BrokerConnectionCenter } from '../components/brokerage/BrokerConnectionCenter';
 import { useAuth } from './AuthContext';
 import type { WorkspaceSummary } from './authApi';
 
-const STEPS = ['Welcome', 'Broker', 'AI profile', 'Risk controls', 'Ready'] as const;
+const STEPS = ['Welcome', 'Broker', 'Risk', 'Initialize'];
 
-const fieldClass = 'mt-1.5 h-11 w-full rounded-md border border-white/10 bg-[#0d131c] px-3 text-sm text-white outline-none focus:border-emerald-300/50 focus:ring-1 focus:ring-emerald-300/20';
+function friendlyError(error: any): string {
+  const code = error?.response?.data?.error;
+  if (code === 'BROKER_CONNECTION_REQUIRED') return 'Connect a brokerage before initializing the trading terminal.';
+  return 'Workspace provisioning could not complete. Your identity and saved configuration remain unchanged.';
+}
 
 export function OnboardingScreen() {
   const auth = useAuth();
@@ -24,94 +18,43 @@ export function OnboardingScreen() {
   const [step, setStep] = useState(0);
   const [busy, setBusy] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [experience, setExperience] = useState(auth.user?.profile.tradingExperience ?? 'none');
-  const [timezone, setTimezone] = useState(Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC');
-  const [riskTolerance, setRiskTolerance] = useState<'conservative' | 'balanced' | 'aggressive'>('balanced');
-  const [personality, setPersonality] = useState<'institutional' | 'research' | 'execution' | 'automation'>('institutional');
+  const [experience, setExperience] = useState<WorkspaceSummary['aiProfile']['personality']>('institutional');
+  const [riskTolerance, setRiskTolerance] = useState<WorkspaceSummary['aiProfile']['riskTolerance']>('balanced');
   const [maximumDailyLoss, setMaximumDailyLoss] = useState(500);
   const [maximumPositionSize, setMaximumPositionSize] = useState(5000);
   const [automationAllowed, setAutomationAllowed] = useState(false);
 
-  useEffect(() => {
-    auth.getWorkspace()
-      .then(next => {
-        setWorkspace(next);
-        setStep(Math.min(next.onboarding.currentStep, 4));
-        setRiskTolerance(next.aiProfile.riskTolerance);
-        setPersonality(next.aiProfile.personality);
-        setMaximumDailyLoss(next.riskProfile.maximumDailyLoss);
-        setMaximumPositionSize(next.riskProfile.maximumPositionSize);
-        setAutomationAllowed(next.riskProfile.automationAllowed);
-      })
-      .catch(() => setError('Workspace provisioning could not be verified. Try again.'))
-      .finally(() => setBusy(false));
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const brokerConnected = workspace?.brokerOnboarding.status === 'connected';
-  const alpacaConnection = workspace?.brokerOnboarding.connections?.find(connection => connection.provider === 'alpaca');
-  const paperConnection = workspace?.brokerOnboarding.connections?.find(connection => connection.provider === 'paper');
-  const progress = useMemo(() => `${Math.round(((step + 1) / STEPS.length) * 100)}%`, [step]);
-
-  const run = async (operation: () => Promise<void>) => {
-    setBusy(true);
-    setError(null);
-    try {
-      await operation();
-    } catch {
-      setError('The workspace update did not complete. Your prior settings are safe; please retry.');
-    } finally {
-      setBusy(false);
-    }
+  const loadWorkspace = async () => {
+    const next = await auth.getWorkspace();
+    setWorkspace(next);
+    setMaximumDailyLoss(next.riskProfile.maximumDailyLoss);
+    setMaximumPositionSize(next.riskProfile.maximumPositionSize);
+    setAutomationAllowed(next.riskProfile.automationAllowed);
+    setRiskTolerance(next.aiProfile.riskTolerance);
+    setExperience(next.aiProfile.personality);
+    const callback = new URLSearchParams(window.location.search).get('connection');
+    const connected = next.brokerOnboarding.connections.some(connection => connection.status === 'connected' && connection.provider !== 'paper');
+    if (callback === 'success' && connected) setStep(2);
+    else setStep(Math.min(3, next.onboarding.currentStep));
+    return next;
   };
 
-  const continueFromWelcome = () => run(async () => {
-    const next = await auth.updateOnboarding({ currentStep: 1, timezone });
-    setWorkspace(next);
-    setStep(1);
-  });
+  useEffect(() => { loadWorkspace().catch(error => setError(friendlyError(error))).finally(() => setBusy(false)); }, []);
 
-  const connectPaper = () => run(async () => {
-    const next = await auth.connectPaperBroker();
-    setWorkspace(next);
-  });
+  const connected = useMemo(() => workspace?.brokerOnboarding.connections.some(connection => connection.status === 'connected' && connection.provider !== 'paper') ?? false, [workspace]);
+  const progress = `${((step + 1) / STEPS.length) * 100}%`;
+  const run = async (action: () => Promise<void>) => { setBusy(true); setError(null); try { await action(); } catch (cause) { setError(friendlyError(cause)); } finally { setBusy(false); } };
 
-  const connectAlpaca = () => run(async () => {
-    const next = await auth.connectAlpacaBroker();
-    setWorkspace(next);
-  });
-
-  const continueFromBroker = () => run(async () => {
-    const next = await auth.updateOnboarding({ currentStep: 2 });
-    setWorkspace(next);
-    setStep(2);
-  });
-
-  const saveAiProfile = () => run(async () => {
-    const next = await auth.updateOnboarding({
-      currentStep: 3,
-      timezone,
-      tradingExperience: experience,
-      aiProfile: { riskTolerance, personality },
-    });
-    setWorkspace(next);
-    setStep(3);
-  });
-
+  const continueWelcome = () => run(async () => { const next = await auth.updateOnboarding({ currentStep: 1 }); setWorkspace(next); setStep(1); });
   const saveRisk = () => run(async () => {
     const next = await auth.updateOnboarding({
-      currentStep: 4,
-      riskProfile: {
-        maximumDailyLoss,
-        maximumPositionSize,
-        automationAllowed,
-        paperTrading: true,
-        emergencyStop: true,
-      },
+      currentStep: 3,
+      tradingExperience: auth.user?.profile.tradingExperience === 'none' ? 'intermediate' : auth.user?.profile.tradingExperience,
+      aiProfile: { riskTolerance, personality: experience },
+      riskProfile: { maximumDailyLoss, maximumPositionSize, automationAllowed, paperTrading: nextEnvironment(workspace) === 'paper', emergencyStop: true },
     });
-    setWorkspace(next);
-    setStep(4);
+    setWorkspace(next); setStep(3);
   });
-
   const launch = () => run(async () => {
     const next = await auth.completeOnboarding();
     window.localStorage.setItem('ai-trader.workspace-layouts', JSON.stringify(next.layouts));
@@ -119,79 +62,22 @@ export function OnboardingScreen() {
     window.dispatchEvent(new PopStateEvent('popstate'));
   });
 
-  if (!workspace && busy) {
-    return <div className="flex min-h-screen items-center justify-center bg-[#06080c] text-sm text-zinc-400"><Loader2 className="mr-2 h-4 w-4 animate-spin" />Provisioning secure workspace…</div>;
-  }
+  if (!workspace && busy) return <div className="flex min-h-screen items-center justify-center bg-[#06080c] text-sm text-zinc-400"><Loader2 className="mr-2 h-4 w-4 animate-spin" />Provisioning secure workspace…</div>;
 
-  return (
-    <main className="min-h-screen bg-[#06080c] text-zinc-100">
-      <header className="border-b border-white/[0.07] bg-[#090c12] px-5 py-4 sm:px-8">
-        <div className="mx-auto flex max-w-6xl items-center justify-between gap-4">
-          <div className="flex items-center gap-3">
-            <div className="flex h-9 w-9 items-center justify-center rounded-md border border-emerald-300/25 bg-emerald-300/[0.08] font-mono text-xs font-semibold text-emerald-300">AT</div>
-            <div><p className="text-sm font-semibold text-white">AI-Trader</p><p className="font-mono text-[9px] uppercase tracking-[0.16em] text-zinc-500">Operator provisioning</p></div>
-          </div>
-          <div className="hidden items-center gap-2 font-mono text-[9px] uppercase tracking-[0.14em] text-emerald-300 sm:flex"><ShieldCheck className="h-4 w-4" />Identity verified</div>
-        </div>
-      </header>
-
-      <div className="mx-auto grid max-w-6xl gap-8 px-5 py-8 sm:px-8 lg:grid-cols-[230px_1fr] lg:py-12">
-        <aside>
-          <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-zinc-600">Workspace setup</p>
-          <div className="mt-4 h-1 overflow-hidden rounded-full bg-white/[0.06]"><div className="h-full bg-emerald-400 transition-all" style={{ width: progress }} /></div>
-          <ol className="mt-5 grid grid-cols-5 gap-2 lg:grid-cols-1">
-            {STEPS.map((label, index) => (
-              <li key={label} className={`flex items-center gap-3 rounded-md px-2 py-2 text-xs ${index === step ? 'bg-white/[0.05] text-white' : index < step ? 'text-emerald-300' : 'text-zinc-600'}`}>
-                <span className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border font-mono text-[9px] ${index <= step ? 'border-emerald-400/40' : 'border-white/10'}`}>{index < step ? <Check className="h-3 w-3" /> : index + 1}</span>
-                <span className="hidden lg:inline">{label}</span>
-              </li>
-            ))}
-          </ol>
-          <div className="mt-7 hidden border-t border-white/[0.07] pt-5 text-xs leading-5 text-zinc-500 lg:block">Estimated time<br /><span className="font-medium text-zinc-300">2–3 minutes</span></div>
-        </aside>
-
-        <section className="min-h-[560px] rounded-lg border border-white/[0.08] bg-[#090d14] p-5 shadow-2xl shadow-black/30 sm:p-8 lg:p-10">
-          {error && <div role="alert" className="mb-6 rounded-md border border-red-400/20 bg-red-400/[0.07] px-4 py-3 text-sm text-red-200">{error}</div>}
-
-          {step === 0 && <div className="max-w-2xl">
-            <div className="flex h-12 w-12 items-center justify-center rounded-md border border-emerald-300/20 bg-emerald-300/[0.07]"><Building2 className="h-5 w-5 text-emerald-300" /></div>
-            <p className="mt-8 font-mono text-[10px] uppercase tracking-[0.2em] text-emerald-300">Identity verified</p>
-            <h1 className="mt-3 text-3xl font-semibold text-white sm:text-4xl">Welcome to AI-Trader</h1>
-            <p className="mt-4 max-w-xl text-sm leading-6 text-zinc-400">Let’s configure your governed trading workspace. Organization, membership, audit profile, AI memory, journal, layouts, and watchlists have already been provisioned.</p>
-            <div className="mt-8 grid gap-3 sm:grid-cols-3">{['Enterprise workspace', 'Default watchlist', 'Audit logging'].map(item => <div key={item} className="rounded-md border border-white/[0.07] bg-white/[0.02] px-4 py-4 text-xs text-zinc-300"><CheckCircle2 className="mb-3 h-4 w-4 text-emerald-400" />{item}</div>)}</div>
-            <button onClick={continueFromWelcome} disabled={busy} className="mt-9 inline-flex h-11 items-center gap-2 rounded-md bg-emerald-300 px-5 text-sm font-semibold text-[#07100d] hover:bg-emerald-200 disabled:opacity-50">Continue <ArrowRight className="h-4 w-4" /></button>
-          </div>}
-
-          {step === 1 && <div>
-            <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-emerald-300">Broker connection</p><h1 className="mt-3 text-2xl font-semibold text-white sm:text-3xl">Select an execution environment</h1><p className="mt-3 text-sm text-zinc-400">Connect the deployment’s governed Alpaca account, or start safely in an isolated simulator.</p>
-            <div className="mt-7 grid gap-3 sm:grid-cols-2">
-              <div className="rounded-md border border-emerald-300/20 bg-emerald-300/[0.035] p-5"><div className="flex items-start justify-between"><Building2 className="h-5 w-5 text-emerald-300" /><span className="font-mono text-[9px] uppercase tracking-wider text-emerald-300">{auth.alpacaConfigured ? (auth.alpacaPaper ? 'Paper account' : 'Live account') : 'Unavailable'}</span></div><h2 className="mt-5 font-semibold text-white">Alpaca</h2><p className="mt-1 text-xs leading-5 text-zinc-500">{auth.alpacaConfigured ? 'Verify the configured account and import status, type, currency, and buying power.' : 'Deployment credentials are not configured. Choose the simulator or ask an administrator.'}</p><button onClick={connectAlpaca} disabled={busy || !auth.alpacaConfigured || alpacaConnection?.status === 'connected'} className="mt-5 h-9 rounded-md border border-emerald-300/30 px-3 text-xs font-semibold text-emerald-200 disabled:cursor-not-allowed disabled:opacity-50">{alpacaConnection?.status === 'connected' ? 'Alpaca Connected' : 'Connect Alpaca'}</button>{alpacaConnection?.status === 'connected' && <p className="mt-3 font-mono text-[9px] text-zinc-500">{alpacaConnection.accountType} · {alpacaConnection.currency ?? 'USD'} · {alpacaConnection.buyingPower == null ? 'Buying power unavailable' : `$${alpacaConnection.buyingPower.toLocaleString()} buying power`}</p>}</div>
-              <div className="rounded-md border border-emerald-300/20 bg-emerald-300/[0.035] p-5"><div className="flex items-start justify-between"><WalletCards className="h-5 w-5 text-emerald-300" /><span className="font-mono text-[9px] uppercase tracking-wider text-emerald-300">Available</span></div><h2 className="mt-5 font-semibold text-white">Paper Trading</h2><p className="mt-1 text-xs leading-5 text-zinc-500">$100,000 simulated buying power · No live capital</p><button onClick={connectPaper} disabled={busy || paperConnection?.status === 'connected'} className="mt-5 h-9 rounded-md border border-emerald-300/30 px-3 text-xs font-semibold text-emerald-200 disabled:opacity-70">{paperConnection?.status === 'connected' ? 'Paper Connected' : 'Start Paper Workspace'}</button></div>
-              {['Tradier', 'Interactive Brokers', 'Tastytrade'].map(provider => <div key={provider} className="rounded-md border border-white/[0.07] bg-white/[0.015] p-5"><div className="flex items-start justify-between"><Building2 className="h-5 w-5 text-zinc-600" /><span className="font-mono text-[9px] uppercase tracking-wider text-zinc-600">Coming soon</span></div><h2 className="mt-5 font-semibold text-zinc-300">{provider}</h2><p className="mt-1 text-xs text-zinc-600">Provider connection is not enabled in this deployment.</p></div>)}
-            </div>
-            <button onClick={continueFromBroker} disabled={busy || !brokerConnected} className="mt-7 inline-flex h-11 items-center gap-2 rounded-md bg-emerald-300 px-5 text-sm font-semibold text-[#07100d] disabled:cursor-not-allowed disabled:opacity-40">Continue <ArrowRight className="h-4 w-4" /></button>
-          </div>}
-
-          {step === 2 && <div className="max-w-2xl">
-            <Bot className="h-6 w-6 text-emerald-300" /><p className="mt-5 font-mono text-[10px] uppercase tracking-[0.2em] text-emerald-300">AI profile</p><h1 className="mt-3 text-2xl font-semibold text-white sm:text-3xl">Calibrate your operator profile</h1>
-            <div className="mt-7 grid gap-5 sm:grid-cols-2"><label className="text-xs text-zinc-300">Trading experience<select aria-label="Trading experience" className={fieldClass} value={experience} onChange={event => setExperience(event.target.value as typeof experience)}>{['none','beginner','intermediate','advanced','professional'].map(value => <option key={value} value={value}>{value[0].toUpperCase() + value.slice(1)}</option>)}</select></label><label className="text-xs text-zinc-300">Risk tolerance<select aria-label="Risk tolerance" className={fieldClass} value={riskTolerance} onChange={event => setRiskTolerance(event.target.value as typeof riskTolerance)}>{['conservative','balanced','aggressive'].map(value => <option key={value}>{value}</option>)}</select></label><label className="text-xs text-zinc-300">AI personality<select aria-label="AI personality" className={fieldClass} value={personality} onChange={event => setPersonality(event.target.value as typeof personality)}>{['institutional','research','execution','automation'].map(value => <option key={value}>{value}</option>)}</select></label><label className="text-xs text-zinc-300">Timezone<input aria-label="Timezone" className={fieldClass} value={timezone} onChange={event => setTimezone(event.target.value)} /></label></div>
-            <button onClick={saveAiProfile} disabled={busy} className="mt-8 inline-flex h-11 items-center gap-2 rounded-md bg-emerald-300 px-5 text-sm font-semibold text-[#07100d] disabled:opacity-50">Save AI profile <ArrowRight className="h-4 w-4" /></button>
-          </div>}
-
-          {step === 3 && <div className="max-w-2xl">
-            <SlidersHorizontal className="h-6 w-6 text-emerald-300" /><p className="mt-5 font-mono text-[10px] uppercase tracking-[0.2em] text-emerald-300">Risk controls</p><h1 className="mt-3 text-2xl font-semibold text-white sm:text-3xl">Set hard operating boundaries</h1><p className="mt-3 text-sm text-zinc-400">Emergency stop remains enabled. Alert categories are provisioned with secure defaults and can be refined later.</p>
-            <div className="mt-7 grid gap-5 sm:grid-cols-2"><label className="text-xs text-zinc-300">Maximum daily loss ($)<input aria-label="Maximum daily loss" className={fieldClass} type="number" min="0" value={maximumDailyLoss} onChange={event => setMaximumDailyLoss(Number(event.target.value))} /></label><label className="text-xs text-zinc-300">Maximum position size ($)<input aria-label="Maximum position size" className={fieldClass} type="number" min="0" value={maximumPositionSize} onChange={event => setMaximumPositionSize(Number(event.target.value))} /></label></div>
-            <label className="mt-6 flex items-center justify-between rounded-md border border-white/[0.08] bg-white/[0.02] p-4 text-sm text-zinc-300"><span><span className="block font-medium text-white">Allow automation</span><span className="mt-1 block text-xs text-zinc-500">AI may submit paper orders within configured risk limits.</span></span><input aria-label="Allow automation" className="h-4 w-4 accent-emerald-400" type="checkbox" checked={automationAllowed} onChange={event => setAutomationAllowed(event.target.checked)} /></label>
-            <button onClick={saveRisk} disabled={busy} className="mt-8 inline-flex h-11 items-center gap-2 rounded-md bg-emerald-300 px-5 text-sm font-semibold text-[#07100d] disabled:opacity-50">Initialize workspace <ArrowRight className="h-4 w-4" /></button>
-          </div>}
-
-          {step === 4 && <div className="max-w-2xl">
-            <div className="flex h-12 w-12 items-center justify-center rounded-full border border-emerald-300/30 bg-emerald-300/[0.08]"><Check className="h-6 w-6 text-emerald-300" /></div><p className="mt-7 font-mono text-[10px] uppercase tracking-[0.2em] text-emerald-300">Provisioning complete</p><h1 className="mt-3 text-3xl font-semibold text-white sm:text-4xl">Workspace ready</h1>
-            <div className="mt-7 divide-y divide-white/[0.06] rounded-md border border-white/[0.08]">{['Identity verified', `${alpacaConnection?.status === 'connected' ? 'Alpaca' : 'Paper'} broker connected`, 'AI initialized', 'Risk profile created', 'Default watchlist created', 'Journal and memory seeded', 'Five layouts synchronized'].map(item => <div key={item} className="flex items-center gap-3 px-4 py-3 text-sm text-zinc-300"><CheckCircle2 className="h-4 w-4 text-emerald-400" />{item}</div>)}</div>
-            <button onClick={launch} disabled={busy} className="mt-8 inline-flex h-11 items-center gap-2 rounded-md bg-emerald-300 px-5 text-sm font-semibold text-[#07100d] disabled:opacity-50">{busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <LockKeyhole className="h-4 w-4" />}Launch Trading Workspace <ArrowRight className="h-4 w-4" /></button>
-          </div>}
-        </section>
-      </div>
-    </main>
-  );
+  return <main className="min-h-screen bg-[#06080c] text-zinc-100">
+    <header className="border-b border-white/[0.07] bg-[#090c12] px-5 py-4 sm:px-8"><div className="mx-auto flex max-w-6xl items-center justify-between gap-4"><div className="flex items-center gap-3"><div className="flex h-9 w-9 items-center justify-center rounded-md border border-emerald-300/25 bg-emerald-300/[0.08] font-mono text-xs font-semibold text-emerald-300">AT</div><div><p className="text-sm font-semibold text-white">AI-Trader</p><p className="font-mono text-[9px] uppercase tracking-[0.16em] text-zinc-500">Enterprise brokerage onboarding</p></div></div><div className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.14em] text-emerald-300"><ShieldCheck className="h-4 w-4" />Identity verified</div></div></header>
+    <div className="mx-auto grid max-w-6xl gap-8 px-5 py-8 sm:px-8 lg:grid-cols-[220px_1fr] lg:py-12">
+      <aside><p className="font-mono text-[10px] uppercase tracking-[0.18em] text-zinc-600">Secure setup</p><div className="mt-4 h-1 overflow-hidden rounded-full bg-white/[0.06]"><div className="h-full bg-emerald-400 transition-all" style={{ width: progress }} /></div><ol className="mt-5 grid grid-cols-4 gap-2 lg:grid-cols-1">{STEPS.map((label, index) => <li key={label} className={`flex items-center gap-3 rounded-md px-2 py-2 text-xs ${index === step ? 'bg-white/[0.05] text-white' : index < step ? 'text-emerald-300' : 'text-zinc-600'}`}><span className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border font-mono text-[9px] ${index <= step ? 'border-emerald-400/40' : 'border-white/10'}`}>{index < step ? <Check className="h-3 w-3" /> : index + 1}</span><span className="hidden lg:inline">{label}</span></li>)}</ol><div className="mt-7 hidden border-t border-white/[0.07] pt-5 text-xs leading-5 text-zinc-500 lg:block">Protected by OAuth<br /><span className="font-medium text-zinc-300">No passwords shared</span></div></aside>
+      <section className="min-h-[600px] rounded-lg border border-white/[0.08] bg-[#090d14] p-5 shadow-2xl shadow-black/30 sm:p-8 lg:p-10">
+        {error && <div role="alert" className="mb-6 rounded-md border border-red-400/20 bg-red-400/[0.07] px-4 py-3 text-sm text-red-200">{error}</div>}
+        {step === 0 && <div className="max-w-2xl"><div className="flex h-12 w-12 items-center justify-center rounded-md border border-emerald-300/20 bg-emerald-300/[0.07]"><ShieldCheck className="h-5 w-5 text-emerald-300" /></div><p className="mt-8 font-mono text-[10px] uppercase tracking-[0.2em] text-emerald-300">Workspace established</p><h1 className="mt-3 text-3xl font-semibold text-white sm:text-4xl">Welcome to AI-Trader</h1><p className="mt-4 text-base text-zinc-300">Your secure workspace has been created.</p><div className="mt-8 divide-y divide-white/[0.06] rounded-md border border-white/[0.08]">{['Identity Verified', 'Secure Workspace', 'AI Memory Initialized', 'Portfolio Engine Ready'].map(item => <div key={item} className="flex items-center gap-3 px-4 py-3 text-sm text-zinc-300"><CheckCircle2 className="h-4 w-4 text-emerald-400" />{item}</div>)}</div><div className="mt-8"><p className="font-mono text-[9px] uppercase tracking-wider text-zinc-500">Next step</p><p className="mt-1 text-lg font-semibold text-white">Connect Your Brokerage</p></div><button onClick={continueWelcome} disabled={busy} className="mt-6 inline-flex h-11 items-center gap-2 rounded-md bg-emerald-300 px-5 text-sm font-semibold text-[#07100d] hover:bg-emerald-200 disabled:opacity-50">Open Broker Connection Center <ArrowRight className="h-4 w-4" /></button></div>}
+        {step === 1 && <div><BrokerConnectionCenter onConnected={() => loadWorkspace().catch(() => undefined)} />{connected && <button type="button" onClick={() => setStep(2)} className="mt-7 inline-flex h-11 items-center gap-2 rounded-md bg-emerald-300 px-5 text-sm font-semibold text-[#07100d]">Continue to risk profile <ArrowRight className="h-4 w-4" /></button>}</div>}
+        {step === 2 && <div className="max-w-2xl"><SlidersHorizontal className="h-6 w-6 text-emerald-300" /><p className="mt-5 font-mono text-[10px] uppercase tracking-[0.2em] text-emerald-300">Risk profile</p><h1 className="mt-3 text-2xl font-semibold text-white sm:text-3xl">Set hard operating boundaries</h1><p className="mt-3 text-sm leading-6 text-zinc-400">These limits govern AI recommendations and automated execution. Emergency stop remains enabled.</p><div className="mt-7 grid gap-5 sm:grid-cols-2"><label className="text-xs text-zinc-300">Risk tolerance<select aria-label="Risk tolerance" className={fieldClass} value={riskTolerance} onChange={event => setRiskTolerance(event.target.value as typeof riskTolerance)}>{['conservative', 'balanced', 'aggressive'].map(value => <option key={value}>{value}</option>)}</select></label><label className="text-xs text-zinc-300">AI operating mode<select aria-label="AI operating mode" className={fieldClass} value={experience} onChange={event => setExperience(event.target.value as typeof experience)}>{['institutional', 'research', 'execution', 'automation'].map(value => <option key={value}>{value}</option>)}</select></label><label className="text-xs text-zinc-300">Maximum daily loss ($)<input aria-label="Maximum daily loss" className={fieldClass} type="number" min="0" value={maximumDailyLoss} onChange={event => setMaximumDailyLoss(Number(event.target.value))} /></label><label className="text-xs text-zinc-300">Maximum position size ($)<input aria-label="Maximum position size" className={fieldClass} type="number" min="0" value={maximumPositionSize} onChange={event => setMaximumPositionSize(Number(event.target.value))} /></label></div><label className="mt-6 flex items-center justify-between rounded-md border border-white/[0.08] bg-white/[0.02] p-4 text-sm text-zinc-300"><span><span className="block font-medium text-white">Allow automated execution</span><span className="mt-1 block text-xs text-zinc-500">Orders remain constrained by broker permissions and risk limits.</span></span><input aria-label="Allow automated execution" className="h-4 w-4 accent-emerald-400" type="checkbox" checked={automationAllowed} onChange={event => setAutomationAllowed(event.target.checked)} /></label><button onClick={saveRisk} disabled={busy} className="mt-8 inline-flex h-11 items-center gap-2 rounded-md bg-emerald-300 px-5 text-sm font-semibold text-[#07100d] disabled:opacity-50">Initialize AI workspace <ArrowRight className="h-4 w-4" /></button></div>}
+        {step === 3 && <div className="max-w-2xl"><div className="flex h-12 w-12 items-center justify-center rounded-full border border-emerald-300/30 bg-emerald-300/[0.08]"><Bot className="h-6 w-6 text-emerald-300" /></div><p className="mt-7 font-mono text-[10px] uppercase tracking-[0.2em] text-emerald-300">Initialization complete</p><h1 className="mt-3 text-3xl font-semibold text-white sm:text-4xl">Trading terminal ready</h1><div className="mt-7 divide-y divide-white/[0.06] rounded-md border border-white/[0.08]">{['Broker OAuth verified', 'Portfolio synchronized', 'Risk profile created', 'Trading preferences applied', 'AI memory initialized', 'Market context ready', 'Strategy engine ready', 'Journal and notifications ready'].map(item => <div key={item} className="flex items-center gap-3 px-4 py-3 text-sm text-zinc-300"><CheckCircle2 className="h-4 w-4 text-emerald-400" />{item}</div>)}</div><button onClick={launch} disabled={busy || !connected} className="mt-8 inline-flex h-11 items-center gap-2 rounded-md bg-emerald-300 px-5 text-sm font-semibold text-[#07100d] disabled:opacity-50">{busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <LockKeyhole className="h-4 w-4" />}Launch Trading Terminal <ArrowRight className="h-4 w-4" /></button></div>}
+      </section>
+    </div>
+  </main>;
 }
+
+const fieldClass = 'mt-2 h-11 w-full rounded-md border border-white/[0.1] bg-[#06090e] px-3 text-sm text-white outline-none focus:border-emerald-300/40';
+function nextEnvironment(workspace: WorkspaceSummary | null): 'paper' | 'live' { return workspace?.brokerOnboarding.connections.find(connection => connection.status === 'connected' && connection.provider !== 'paper')?.paper === false ? 'live' : 'paper'; }

--- a/client/src/auth/ProfileMenu.tsx
+++ b/client/src/auth/ProfileMenu.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
-import { Building2, Link2, LogOut, MonitorSmartphone, UserRound, X } from 'lucide-react';
+import { Building2, Link2, LogOut, MonitorSmartphone, ShieldCheck, UserRound, X } from 'lucide-react';
 import { useAuth } from './AuthContext';
 import type { SessionSummary, WorkspaceSummary } from './authApi';
+import { BrokerConnectionCenter } from '../components/brokerage/BrokerConnectionCenter';
+import { SecurityCenter } from '../components/brokerage/SecurityCenter';
 
 export function ProfileMenu() {
   const auth = useAuth();
@@ -11,6 +13,7 @@ export function ProfileMenu() {
   const [name, setName] = useState(auth.user?.profile.name ?? '');
   const [workspaceName, setWorkspaceName] = useState(auth.user?.profile.workspaceName ?? '');
   const [busy, setBusy] = useState(false);
+  const [settingsView, setSettingsView] = useState<'profile' | 'brokers' | 'security'>('profile');
 
   useEffect(() => {
     setName(auth.user?.profile.name ?? '');
@@ -61,8 +64,8 @@ export function ProfileMenu() {
           >
             <div className="flex items-start justify-between border-b border-intel-line px-4 py-3">
               <div>
-                <p className="font-mono text-[10px] uppercase tracking-eyebrow text-intel-ink3">Identity</p>
-                <h2 className="mt-1 text-lg font-semibold text-intel-ink">Profile</h2>
+                <p className="font-mono text-[10px] uppercase tracking-eyebrow text-intel-ink3">Settings</p>
+                <h2 className="mt-1 text-lg font-semibold capitalize text-intel-ink">{settingsView === 'brokers' ? 'Broker connections' : settingsView === 'security' ? 'Security center' : 'Profile'}</h2>
               </div>
               <button type="button" onClick={() => setOpen(false)} className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-intel-line text-intel-ink2 hover:border-intel-accentLine hover:text-intel-accent" aria-label="Close profile">
                 <X className="h-4 w-4" />
@@ -70,6 +73,12 @@ export function ProfileMenu() {
             </div>
 
             <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-4">
+              <div className="grid grid-cols-3 gap-2" role="tablist" aria-label="Account settings">
+                <SettingsTab active={settingsView === 'profile'} onClick={() => setSettingsView('profile')} label="Profile" />
+                <SettingsTab active={settingsView === 'brokers'} onClick={() => setSettingsView('brokers')} label="Brokers" />
+                <SettingsTab active={settingsView === 'security'} onClick={() => setSettingsView('security')} label="Security" />
+              </div>
+              {settingsView === 'profile' && <>
               <section className="rounded-md border border-intel-line bg-intel-bg p-3">
                 <div className="mb-3 flex items-center gap-2 text-sm font-semibold">
                   <UserRound className="h-4 w-4 text-intel-accent" />
@@ -111,33 +120,9 @@ export function ProfileMenu() {
                 </div>
               </section>
 
-              <section className="rounded-md border border-intel-line bg-intel-bg">
-                <div className="flex items-center justify-between gap-2 border-b border-intel-line px-3 py-2">
-                  <div className="flex items-center gap-2 text-sm font-semibold">
-                    <Link2 className="h-4 w-4 text-intel-accent" />
-                    Connect Broker
-                  </div>
-                  <span className="font-mono text-[10px] uppercase tracking-label text-intel-ink3">Post-login</span>
-                </div>
-                <div className="grid gap-2 p-3 sm:grid-cols-2">
-                  {(workspace?.brokerOnboarding.providers ?? [
-                    { provider: 'alpaca', label: 'Alpaca', enabled: true },
-                    { provider: 'tradier', label: 'Tradier', enabled: true },
-                    { provider: 'ibkr', label: 'IBKR', enabled: true },
-                    { provider: 'tastytrade', label: 'Tastytrade', enabled: true },
-                    { provider: 'paper', label: 'Paper', enabled: true },
-                  ]).map(provider => (
-                    <button
-                      key={provider.provider}
-                      type="button"
-                      disabled
-                      className="flex h-10 items-center justify-between rounded-md border border-intel-lineSoft bg-intel-panel px-3 text-left text-sm text-intel-ink2 disabled:cursor-not-allowed disabled:opacity-80"
-                    >
-                      <span>{provider.label}</span>
-                      <span className="font-mono text-[10px] uppercase tracking-label text-intel-ink3">Ready</span>
-                    </button>
-                  ))}
-                </div>
+              <section className="grid gap-2 sm:grid-cols-2">
+                <button type="button" onClick={() => setSettingsView('brokers')} className="flex items-center gap-3 rounded-md border border-intel-line bg-intel-bg p-3 text-left hover:border-intel-accentLine"><Link2 className="h-4 w-4 text-intel-accent" /><span><span className="block text-sm font-semibold text-intel-ink">Broker connections</span><span className="mt-0.5 block text-xs text-intel-ink3">OAuth, sync, reconnect</span></span></button>
+                <button type="button" onClick={() => setSettingsView('security')} className="flex items-center gap-3 rounded-md border border-intel-line bg-intel-bg p-3 text-left hover:border-intel-accentLine"><ShieldCheck className="h-4 w-4 text-intel-accent" /><span><span className="block text-sm font-semibold text-intel-ink">Security center</span><span className="mt-0.5 block text-xs text-intel-ink3">Sessions and activity</span></span></button>
               </section>
 
               <section className="rounded-md border border-intel-line bg-intel-bg">
@@ -162,6 +147,9 @@ export function ProfileMenu() {
                   {!sessions.length && <div className="px-3 py-4 text-sm text-intel-ink3">No active sessions found.</div>}
                 </div>
               </section>
+              </>}
+              {settingsView === 'brokers' && <BrokerConnectionCenter mode="settings" />}
+              {settingsView === 'security' && <SecurityCenter />}
             </div>
 
             <div className="grid grid-cols-2 gap-2 border-t border-intel-line px-4 py-3">
@@ -179,4 +167,8 @@ export function ProfileMenu() {
       )}
     </>
   );
+}
+
+function SettingsTab({ active, onClick, label }: { active: boolean; onClick: () => void; label: string }) {
+  return <button type="button" role="tab" aria-selected={active} onClick={onClick} className={`h-9 rounded-md border text-xs font-semibold ${active ? 'border-intel-accentLine bg-intel-accentSoft text-intel-accent' : 'border-intel-line text-intel-ink3'}`}>{label}</button>;
 }

--- a/client/src/auth/authApi.ts
+++ b/client/src/auth/authApi.ts
@@ -76,7 +76,7 @@ export type WorkspaceSummary = {
     connections: Array<{
       provider: BrokerProvider;
       label: string;
-      status: 'unconfigured' | 'connected' | 'error' | 'revoked';
+      status: 'unconfigured' | 'connecting' | 'connected' | 'syncing' | 'error' | 'revoked';
       accountId: string | null;
       accountType: string | null;
       paper: boolean;

--- a/client/src/components/brokerage/BrokerConnectionCenter.tsx
+++ b/client/src/components/brokerage/BrokerConnectionCenter.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ArrowLeft, Check, ChevronRight, ExternalLink, LockKeyhole, RefreshCw, ShieldCheck, Unplug, X } from 'lucide-react';
+import { connectBroker, disconnectBroker, listBrokers, reconnectBroker, syncBrokers, type BrokerConnection, type BrokerDirectoryEntry } from '../../api/brokerage';
+
+type Props = { mode?: 'onboarding' | 'settings'; onConnected?: () => void };
+
+function money(value: number | null): string {
+  return value == null ? 'Pending sync' : new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(value);
+}
+
+function time(value: string | null): string {
+  if (!value) return 'Not yet synced';
+  return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(value));
+}
+
+export function BrokerConnectionCenter({ mode = 'onboarding', onConnected }: Props) {
+  const [brokers, setBrokers] = useState<BrokerDirectoryEntry[]>([]);
+  const [selected, setSelected] = useState<BrokerDirectoryEntry | null>(null);
+  const [environment, setEnvironment] = useState<'paper' | 'live'>('paper');
+  const [disconnecting, setDisconnecting] = useState<BrokerConnection | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async () => {
+    const next = await listBrokers();
+    setBrokers(next);
+    if (selected) setSelected(next.find(item => item.provider === selected.provider) ?? null);
+    if (next.some(item => item.connections.some(connection => connection.status === 'connected'))) onConnected?.();
+  };
+
+  useEffect(() => { load().catch(() => setError('Broker directory is temporarily unavailable. Your workspace and identity remain secure.')); }, []);
+
+  const current = useMemo(() => selected?.connections.find(connection => connection.status !== 'revoked') ?? null, [selected]);
+
+  const begin = async (reconnect = false) => {
+    if (!selected) return;
+    setBusy(selected.provider); setError(null);
+    try {
+      const url = reconnect
+        ? await reconnectBroker(selected.provider, environment)
+        : await connectBroker(selected.provider, environment, mode === 'onboarding' ? '/onboarding' : '/terminal?settings=brokers');
+      window.location.assign(url);
+    } catch (cause: any) {
+      const code = cause?.response?.data?.error;
+      setError(code === 'BROKER_OAUTH_NOT_CONFIGURED'
+        ? `${selected.name} OAuth is not configured for this deployment. Ask a workspace administrator to complete the provider registration.`
+        : `We could not begin ${selected.name} authorization. No brokerage access was changed.`);
+      setBusy(null);
+    }
+  };
+
+  const sync = async (connection: BrokerConnection) => {
+    setBusy(connection.id); setError(null);
+    try { await syncBrokers(connection.provider); await load(); }
+    catch { setError('Portfolio synchronization did not complete. Your existing portfolio cache remains unchanged.'); }
+    finally { setBusy(null); }
+  };
+
+  const disconnect = async () => {
+    if (!disconnecting) return;
+    setBusy(disconnecting.id); setError(null);
+    try { await disconnectBroker(disconnecting.provider, disconnecting.id); setDisconnecting(null); setSelected(null); await load(); }
+    catch { setError('The connection could not be removed. No credentials were deleted.'); }
+    finally { setBusy(null); }
+  };
+
+  if (selected) {
+    return <div data-testid="broker-details" className="animate-in fade-in duration-200">
+      <button type="button" onClick={() => setSelected(null)} className="inline-flex items-center gap-2 text-xs text-zinc-400 hover:text-white"><ArrowLeft className="h-4 w-4" />Broker directory</button>
+      <div className="mt-6 flex flex-col justify-between gap-5 sm:flex-row sm:items-start">
+        <div className="flex items-start gap-4"><BrokerLogo broker={selected} large /><div><p className="font-mono text-[10px] uppercase tracking-[0.2em] text-emerald-300">Secure OAuth connection</p><h2 className="mt-2 text-3xl font-semibold text-white">{selected.name}</h2><p className="mt-2 max-w-xl text-sm leading-6 text-zinc-400">{selected.description}</p></div></div>
+        {current && <StatusPill status={current.status} />}
+      </div>
+      {error && <div role="alert" className="mt-5 rounded-md border border-red-400/25 bg-red-400/[0.07] px-4 py-3 text-sm text-red-200">{error}</div>}
+      {current?.status === 'connected' ? <div className="mt-7 grid gap-4 lg:grid-cols-[1.2fr_.8fr]">
+        <section className="rounded-lg border border-emerald-300/20 bg-emerald-300/[0.025] p-5"><div className="flex items-center gap-2 text-sm font-semibold text-white"><ShieldCheck className="h-4 w-4 text-emerald-300" />Connection verified</div><div className="mt-5 grid gap-3 sm:grid-cols-2"><Metric label="Environment" value={current.environment === 'paper' ? 'Paper trading' : 'Live trading'} /><Metric label="Buying power" value={money(current.balances.buyingPower)} /><Metric label="OAuth status" value={current.oauthStatus} /><Metric label="Last synchronized" value={time(current.lastSync)} /></div></section>
+        <section className="rounded-lg border border-white/[0.08] bg-white/[0.02] p-5"><h3 className="text-sm font-semibold text-white">Connection controls</h3><div className="mt-4 grid gap-2"><button type="button" disabled={busy === current.id} onClick={() => sync(current)} className="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-white/10 text-xs font-semibold text-zinc-200 hover:border-emerald-300/30"><RefreshCw className={`h-4 w-4 ${busy === current.id ? 'animate-spin' : ''}`} />Synchronize portfolio</button><button type="button" onClick={() => begin(true)} className="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-white/10 text-xs font-semibold text-zinc-200 hover:border-emerald-300/30"><ExternalLink className="h-4 w-4" />Reconnect OAuth</button><button type="button" onClick={() => setDisconnecting(current)} className="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-red-400/20 text-xs font-semibold text-red-200 hover:bg-red-400/[0.06]"><Unplug className="h-4 w-4" />Disconnect</button></div></section>
+      </div> : <div className="mt-7 grid gap-5 lg:grid-cols-[1fr_.85fr]">
+        <section className="rounded-lg border border-white/[0.08] bg-white/[0.02] p-5"><h3 className="text-sm font-semibold text-white">Permissions requested</h3><div className="mt-4 grid gap-3 sm:grid-cols-2">{selected.permissions.map(permission => <div key={permission} className="flex items-center gap-2 text-sm text-zinc-300"><Check className="h-4 w-4 text-emerald-300" />{permission}</div>)}</div><div className="mt-6 border-t border-white/[0.07] pt-5"><p className="text-xs font-medium text-zinc-300">Trading environment</p><div className="mt-3 grid grid-cols-2 gap-2">{selected.paperTrading && <EnvironmentButton label="Paper" active={environment === 'paper'} onClick={() => setEnvironment('paper')} />}{selected.liveTrading && <EnvironmentButton label="Live" active={environment === 'live'} onClick={() => setEnvironment('live')} />}</div></div></section>
+        <section className="rounded-lg border border-emerald-300/20 bg-emerald-300/[0.025] p-5"><LockKeyhole className="h-5 w-5 text-emerald-300" /><h3 className="mt-4 text-sm font-semibold text-white">Your credentials stay with {selected.name}</h3><p className="mt-2 text-xs leading-5 text-zinc-400">AI-Trader never sees or stores your password. OAuth tokens are encrypted at rest with AES-256-GCM and access can be revoked at any time.</p><button type="button" onClick={() => begin(false)} disabled={!selected.configured || busy === selected.provider} className="mt-6 inline-flex h-11 w-full items-center justify-center gap-2 rounded-md bg-emerald-300 px-4 text-sm font-semibold text-[#07100d] hover:bg-emerald-200 disabled:cursor-not-allowed disabled:bg-zinc-700 disabled:text-zinc-400">Connect with {selected.name}<ExternalLink className="h-4 w-4" /></button>{!selected.configured && <p className="mt-3 text-center text-[11px] leading-4 text-amber-200/80">Provider registration must be completed by a workspace administrator.</p>}</section>
+      </div>}
+      <TrustStrip />
+      {disconnecting && <DisconnectDialog connection={disconnecting} busy={busy === disconnecting.id} onCancel={() => setDisconnecting(null)} onConfirm={disconnect} />}
+    </div>;
+  }
+
+  const currentBrokers = brokers.filter(item => item.available);
+  const futureBrokers = brokers.filter(item => !item.available);
+  return <div data-testid="broker-directory">
+    <div><p className="font-mono text-[10px] uppercase tracking-[0.2em] text-emerald-300">Broker connection center</p><h1 className="mt-3 text-2xl font-semibold text-white sm:text-3xl">Connect your brokerage</h1><p className="mt-3 max-w-2xl text-sm leading-6 text-zinc-400">Authorize account access directly with your broker. Select a provider to review assets, environments, and exact permissions before continuing.</p></div>
+    {error && <div role="alert" className="mt-5 rounded-md border border-red-400/25 bg-red-400/[0.07] px-4 py-3 text-sm text-red-200">{error}</div>}
+    <div className="mt-7 grid gap-3 md:grid-cols-2">{currentBrokers.map(broker => <BrokerCard key={broker.provider} broker={broker} onClick={() => { setSelected(broker); setEnvironment(broker.paperTrading ? 'paper' : 'live'); }} />)}</div>
+    <div className="mt-9 border-t border-white/[0.07] pt-6"><h2 className="text-sm font-semibold text-zinc-300">Additional institutions</h2><p className="mt-1 text-xs text-zinc-500">These providers are listed for directory completeness and cannot be selected until an approved OAuth integration is available.</p><div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-4">{futureBrokers.map(broker => <div key={broker.provider} className="flex items-center gap-3 rounded-md border border-white/[0.06] bg-white/[0.015] px-3 py-3"><BrokerLogo broker={broker} /><div className="min-w-0"><p className="truncate text-xs font-medium text-zinc-400">{broker.name}</p><p className="font-mono text-[8px] uppercase tracking-wider text-zinc-600">Not enabled</p></div></div>)}</div></div>
+    <TrustStrip />
+  </div>;
+}
+
+function BrokerLogo({ broker, large = false }: { broker: BrokerDirectoryEntry; large?: boolean }) { return <div aria-label={`${broker.name} logo`} className={`flex shrink-0 items-center justify-center rounded-lg border border-white/10 bg-gradient-to-br from-white/[0.09] to-white/[0.025] font-mono font-semibold text-emerald-200 ${large ? 'h-14 w-14 text-base' : 'h-10 w-10 text-xs'}`}>{broker.monogram}</div>; }
+function StatusPill({ status }: { status: string }) { const good = status === 'connected'; return <span className={`rounded-full border px-2.5 py-1 font-mono text-[9px] uppercase tracking-wider ${good ? 'border-emerald-300/25 bg-emerald-300/[0.08] text-emerald-300' : 'border-amber-300/25 text-amber-200'}`}>{status}</span>; }
+function Metric({ label, value }: { label: string; value: string }) { return <div className="rounded-md border border-white/[0.07] bg-black/10 px-3 py-3"><p className="font-mono text-[9px] uppercase tracking-wider text-zinc-500">{label}</p><p className="mt-1 truncate text-sm font-medium capitalize text-zinc-200">{value}</p></div>; }
+function EnvironmentButton({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) { return <button type="button" aria-pressed={active} onClick={onClick} className={`h-10 rounded-md border text-xs font-semibold ${active ? 'border-emerald-300/35 bg-emerald-300/[0.08] text-emerald-200' : 'border-white/10 text-zinc-400'}`}>{label}</button>; }
+function BrokerCard({ broker, onClick }: { broker: BrokerDirectoryEntry; onClick: () => void }) { const connected = broker.connections.some(item => item.status === 'connected'); return <button type="button" onClick={onClick} className="group rounded-lg border border-white/[0.08] bg-white/[0.02] p-5 text-left transition hover:border-emerald-300/25 hover:bg-emerald-300/[0.025]"><div className="flex items-start justify-between gap-4"><BrokerLogo broker={broker} /><StatusPill status={connected ? 'connected' : broker.configured ? 'OAuth ready' : 'admin setup'} /></div><div className="mt-5 flex items-center justify-between gap-3"><div><h2 className="font-semibold text-white">{broker.name}</h2><p className="mt-1 text-xs text-zinc-500">{broker.assets.join(' · ')}</p></div><ChevronRight className="h-4 w-4 text-zinc-600 transition group-hover:translate-x-0.5 group-hover:text-emerald-300" /></div><div className="mt-4 flex flex-wrap gap-2 text-[9px] uppercase tracking-wider text-zinc-500"><span>OAuth</span>{broker.paperTrading && <span>Paper</span>}{broker.liveTrading && <span>Live</span>}</div></button>; }
+function TrustStrip() { return <div className="mt-8 grid gap-3 border-t border-white/[0.07] pt-6 text-xs text-zinc-500 sm:grid-cols-4">{['No passwords stored', 'OAuth authorization', 'AES-256 encrypted', 'Disconnect anytime'].map(item => <div key={item} className="flex items-center gap-2"><ShieldCheck className="h-4 w-4 text-emerald-300/70" />{item}</div>)}</div>; }
+function DisconnectDialog({ connection, busy, onCancel, onConfirm }: { connection: BrokerConnection; busy: boolean; onCancel: () => void; onConfirm: () => void }) { return <div className="fixed inset-0 z-[70] flex items-center justify-center bg-black/80 p-4" role="presentation"><div role="alertdialog" aria-modal="true" aria-labelledby="disconnect-title" className="w-full max-w-lg rounded-lg border border-white/10 bg-[#0b1018] p-6 shadow-2xl"><div className="flex justify-between"><div><p className="font-mono text-[9px] uppercase tracking-wider text-red-300">Revoke access</p><h2 id="disconnect-title" className="mt-2 text-xl font-semibold text-white">Disconnect {connection.brokerName}?</h2></div><button aria-label="Close disconnect dialog" onClick={onCancel}><X className="h-5 w-5 text-zinc-500" /></button></div><div className="mt-5 grid gap-4 sm:grid-cols-2"><div><p className="text-xs font-semibold text-zinc-300">This removes</p>{['OAuth tokens', 'Broker session', 'Portfolio cache', 'Position cache', 'Buying power cache'].map(item => <p key={item} className="mt-2 flex items-center gap-2 text-xs text-zinc-400"><Check className="h-3 w-3 text-red-300" />{item}</p>)}</div><div><p className="text-xs font-semibold text-zinc-300">This will not remove</p>{['Workspace', 'Journal', 'AI memory', 'Strategies', 'Watchlists', 'Notifications'].map(item => <p key={item} className="mt-2 flex items-center gap-2 text-xs text-zinc-400"><Check className="h-3 w-3 text-emerald-300" />{item}</p>)}</div></div><div className="mt-7 grid grid-cols-2 gap-3"><button onClick={onCancel} className="h-10 rounded-md border border-white/10 text-sm text-zinc-300">Cancel</button><button disabled={busy} onClick={onConfirm} className="h-10 rounded-md bg-red-400 text-sm font-semibold text-[#1b0808] disabled:opacity-60">{busy ? 'Disconnecting…' : 'Disconnect'}</button></div></div></div>; }

--- a/client/src/components/brokerage/BrokerageSummaryBar.tsx
+++ b/client/src/components/brokerage/BrokerageSummaryBar.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import { Bot, ShieldCheck } from 'lucide-react';
+import { brokerStatus, type BrokerConnection } from '../../api/brokerage';
+
+const usd = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
+
+export function BrokerageSummaryBar() {
+  const [connection, setConnection] = useState<BrokerConnection | null>(null);
+  const [workspaceStatus, setWorkspaceStatus] = useState({ aiStatus: 'ready', riskScore: 35, recentSignals: 0 });
+  useEffect(() => {
+    let active = true;
+    brokerStatus().then(result => { if (active) { setConnection(result.connections.find(item => item.primary && item.status === 'connected') ?? result.connections.find(item => item.status === 'connected') ?? null); setWorkspaceStatus({ aiStatus: result.aiStatus, riskScore: result.riskScore, recentSignals: result.recentSignals.length }); } }).catch(() => undefined);
+    return () => { active = false; };
+  }, []);
+  if (!connection) return null;
+  const metrics = [
+    ['Broker', connection.brokerName], ['Buying power', connection.balances.buyingPower == null ? 'Syncing' : usd.format(connection.balances.buyingPower)],
+    ['Portfolio value', connection.balances.portfolioValue == null ? 'Syncing' : usd.format(connection.balances.portfolioValue)],
+    ["Today's P/L", usd.format(connection.metrics.todayPl)], ['Positions', String(connection.metrics.openPositions)], ['Open orders', String(connection.metrics.openOrders)],
+    ['AI status', workspaceStatus.aiStatus], ['Risk score', `${workspaceStatus.riskScore}/100`], ['Recent signals', String(workspaceStatus.recentSignals)],
+  ];
+  return <section aria-label="Brokerage account summary" className="border-b border-intel-line bg-intel-panel px-3 py-2 md:px-4"><div className="flex items-center gap-2 overflow-x-auto">{metrics.map(([label, value]) => <div key={label} className="min-w-[112px] border-r border-intel-line pr-3 last:border-0"><p className="font-mono text-[8px] uppercase tracking-label text-intel-ink3">{label}</p><p className="mt-0.5 truncate text-xs font-semibold text-intel-ink">{value}</p></div>)}<div className="ml-auto flex min-w-max items-center gap-2 rounded-md border border-intel-pos/20 bg-intel-pos/5 px-2.5 py-1.5"><ShieldCheck className="h-3.5 w-3.5 text-intel-pos" /><span className="font-mono text-[9px] uppercase tracking-label text-intel-pos">OAuth secure</span><Bot className="ml-1 h-3.5 w-3.5 text-intel-accent" /><span className="font-mono text-[9px] uppercase tracking-label text-intel-accent">AI ready</span></div></div></section>;
+}

--- a/client/src/components/brokerage/SecurityCenter.tsx
+++ b/client/src/components/brokerage/SecurityCenter.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState, type ReactElement } from 'react';
+import { CheckCircle2, KeyRound, Laptop, Link2, LockKeyhole, ShieldCheck } from 'lucide-react';
+import { getSecurityOverview, type SecurityOverview } from '../../api/brokerage';
+
+function when(value: string | null): string {
+  if (!value) return 'No recorded activity';
+  return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(value));
+}
+
+export function SecurityCenter() {
+  const [data, setData] = useState<SecurityOverview | null>(null);
+  const [error, setError] = useState(false);
+  useEffect(() => { getSecurityOverview().then(setData).catch(() => setError(true)); }, []);
+  return <div data-testid="security-center">
+    <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-intel-accent">Security center</p>
+    <h2 className="mt-2 text-xl font-semibold text-intel-ink">Access and authorization</h2>
+    <p className="mt-2 text-sm leading-6 text-intel-ink3">Review the safeguards protecting your identity, sessions, and brokerage connections.</p>
+    {error && <div role="alert" className="mt-4 rounded-md border border-intel-neg/30 bg-intel-neg/10 p-3 text-sm text-intel-neg">Security activity is temporarily unavailable.</div>}
+    <div className="mt-5 grid gap-2 sm:grid-cols-2">
+      <Control icon={<KeyRound />} label="OAuth authentication" value="Enabled" />
+      <Control icon={<LockKeyhole />} label="Token encryption" value={data?.controls.encryption ?? 'AES-256-GCM'} />
+      <Control icon={<ShieldCheck />} label="Transport security" value={data?.controls.transport ?? 'TLS 1.3'} />
+      <Control icon={<Link2 />} label="Revocable access" value="Enabled" />
+    </div>
+    <div className="mt-5 grid gap-2 sm:grid-cols-2"><Control icon={<ShieldCheck />} label="Session status" value={data?.sessionStatus ?? 'Active'} /><Control icon={<KeyRound />} label="Last login" value={when(data?.lastLogin ?? null)} /></div>
+    <section className="mt-5 rounded-md border border-intel-line bg-intel-bg">
+      <div className="flex items-center justify-between border-b border-intel-line px-3 py-3"><div className="flex items-center gap-2 text-sm font-semibold"><Laptop className="h-4 w-4 text-intel-accent" />Connected devices</div><span className="font-mono text-[9px] uppercase tracking-label text-intel-pos">{data?.sessionStatus ?? 'active'}</span></div>
+      <div className="divide-y divide-intel-line">{data?.connectedDevices.map(device => <div key={device.id} className="px-3 py-3 text-xs"><p className="truncate text-intel-ink2">{device.device.ua || 'Unknown device'}</p><p className="mt-1 font-mono text-[9px] uppercase tracking-label text-intel-ink3">{device.device.ip || 'IP unavailable'} · {when(device.lastUsedAt)}</p></div>)}{data && !data.connectedDevices.length && <p className="px-3 py-4 text-xs text-intel-ink3">No active devices.</p>}</div>
+    </section>
+    <section className="mt-5 rounded-md border border-intel-line bg-intel-bg"><div className="border-b border-intel-line px-3 py-3 text-sm font-semibold">Connected brokers</div><div className="divide-y divide-intel-line">{data?.connectedBrokers.map(broker => <div key={broker.id} className="flex items-center justify-between gap-3 px-3 py-3"><div><p className="text-xs font-semibold text-intel-ink">{broker.brokerName}</p><p className="mt-1 font-mono text-[9px] uppercase tracking-label text-intel-ink3">{broker.environment} · OAuth {broker.oauthStatus}</p></div><span className="font-mono text-[9px] uppercase tracking-label text-intel-pos">{broker.status}</span></div>)}{data && !data.connectedBrokers.length && <p className="px-3 py-4 text-xs text-intel-ink3">No connected brokers.</p>}</div></section>
+    <section className="mt-5 rounded-md border border-intel-line bg-intel-bg"><div className="border-b border-intel-line px-3 py-3 text-sm font-semibold">Security activity</div><div className="divide-y divide-intel-line">{data?.activity.slice(0, 8).map(item => <div key={item._id} className="flex items-center justify-between gap-3 px-3 py-3"><div className="flex min-w-0 items-center gap-2"><CheckCircle2 className="h-4 w-4 shrink-0 text-intel-pos" /><p className="truncate text-xs text-intel-ink2">{item.action.replaceAll('_', ' ').toLowerCase()}</p></div><time className="shrink-0 font-mono text-[9px] text-intel-ink3">{when(item.createdAt)}</time></div>)}</div></section>
+  </div>;
+}
+
+function Control({ icon, label, value }: { icon: ReactElement<{ className?: string }>; label: string; value: string }) {
+  return <div className="rounded-md border border-intel-line bg-intel-bg p-3"><div className="flex items-center gap-2 text-intel-accent">{icon}<span className="font-mono text-[9px] uppercase tracking-label text-intel-ink3">{label}</span></div><p className="mt-2 text-sm font-semibold text-intel-ink">{value}</p></div>;
+}

--- a/server/.env.example
+++ b/server/.env.example
@@ -54,6 +54,31 @@ GOOGLE_REDIRECT_URI=http://localhost:4000/api/auth/google/callback
 # IDENTITY_RATE_WINDOW_MS=60000
 # IDENTITY_RATE_MAX=20
 
+# Brokerage OAuth Platform (customer connections never use pasted API keys)
+# Register callbacks as: https://<api-host>/api/brokers/<provider>/callback
+ALPACA_OAUTH_CLIENT_ID=<alpaca-oauth-client-id>
+ALPACA_OAUTH_CLIENT_SECRET=<alpaca-oauth-client-secret>
+ALPACA_OAUTH_REDIRECT_URI=http://localhost:4000/api/brokers/alpaca/callback
+# ALPACA_OAUTH_SCOPES=account:write trading
+
+TRADIER_OAUTH_CLIENT_ID=<tradier-oauth-client-id>
+TRADIER_OAUTH_CLIENT_SECRET=<tradier-oauth-client-secret>
+TRADIER_OAUTH_REDIRECT_URI=http://localhost:4000/api/brokers/tradier/callback
+
+IBKR_OAUTH_CLIENT_ID=<ibkr-oauth-client-id>
+IBKR_OAUTH_CLIENT_SECRET=<ibkr-oauth-client-secret>
+IBKR_OAUTH_AUTHORIZE_URL=<assigned-by-ibkr>
+IBKR_OAUTH_TOKEN_URL=<assigned-by-ibkr>
+IBKR_OAUTH_API_BASE_URL=<assigned-by-ibkr>
+IBKR_OAUTH_REDIRECT_URI=http://localhost:4000/api/brokers/ibkr/callback
+
+TASTYTRADE_OAUTH_CLIENT_ID=<tastytrade-oauth-client-id>
+TASTYTRADE_OAUTH_CLIENT_SECRET=<tastytrade-oauth-client-secret>
+TASTYTRADE_OAUTH_AUTHORIZE_URL=<assigned-by-tastytrade>
+TASTYTRADE_OAUTH_TOKEN_URL=<assigned-by-tastytrade>
+TASTYTRADE_OAUTH_REDIRECT_URI=http://localhost:4000/api/brokers/tastytrade/callback
+# BROKER_REFRESH_ENABLED=true
+
 # MongoDB
 # MONGO_URI is preferred; MONGODB_URI is the compatibility fallback (either works).
 MONGO_URI=mongodb://127.0.0.1:27017/market-copilot

--- a/server/src/features/brokerage/README.md
+++ b/server/src/features/brokerage/README.md
@@ -1,0 +1,23 @@
+# Brokerage Connection Platform
+
+This module sits on top of the permanent Identity Platform. It uses the existing
+access-token middleware, CSRF cookie, workspace membership, audit log, and
+AES-256-GCM envelope encryption; it does not issue user sessions or identity
+tokens.
+
+Customer brokerage connections are OAuth-only. Authorization attempts use a
+one-time, ten-minute state record and PKCE. Access and refresh tokens are
+encrypted before Mongo persistence and excluded from normal Mongoose queries.
+Callbacks immediately import account balances, positions, option positions,
+open orders, watchlists, and account configuration into `broker_portfolios`.
+
+`broker_connections` is account-scoped rather than provider-scoped, allowing
+multiple accounts per provider and multiple providers per workspace. The
+refresh worker renews credentials five minutes before expiration. Disconnect
+attempts provider revocation when configured, then deletes encrypted tokens and
+portfolio caches while preserving the workspace, AI memory, journal,
+strategies, watchlists, and notifications.
+
+Provider OAuth registration is environment-driven; see `server/.env.example`.
+A provider fails closed when its OAuth application or the identity encryption
+key is not configured.

--- a/server/src/features/brokerage/brokerConfig.ts
+++ b/server/src/features/brokerage/brokerConfig.ts
@@ -1,0 +1,51 @@
+import type { BrokerProvider } from '../identity/models/brokerConnection.model';
+
+export type OAuthBrokerConfig = {
+  provider: Exclude<BrokerProvider, 'paper'>;
+  clientId: string | null;
+  clientSecret: string | null;
+  authorizeUrl: string;
+  tokenUrl: string;
+  revokeUrl: string | null;
+  apiBaseUrl: string;
+  redirectUri: string;
+  scopes: string[];
+};
+
+const defaults: Record<Exclude<BrokerProvider, 'paper'>, Omit<OAuthBrokerConfig, 'provider' | 'clientId' | 'clientSecret' | 'redirectUri'>> = {
+  alpaca: { authorizeUrl: 'https://app.alpaca.markets/oauth/authorize', tokenUrl: 'https://api.alpaca.markets/oauth/token', revokeUrl: null, apiBaseUrl: 'https://api.alpaca.markets', scopes: ['account:write', 'trading'] },
+  tradier: { authorizeUrl: 'https://api.tradier.com/v1/oauth/authorize', tokenUrl: 'https://api.tradier.com/v1/oauth/accesstoken', revokeUrl: null, apiBaseUrl: 'https://api.tradier.com', scopes: ['read', 'trade'] },
+  ibkr: { authorizeUrl: '', tokenUrl: '', revokeUrl: null, apiBaseUrl: '', scopes: ['account', 'portfolio', 'trading'] },
+  tastytrade: { authorizeUrl: '', tokenUrl: '', revokeUrl: null, apiBaseUrl: 'https://api.tastytrade.com', scopes: ['account', 'portfolio', 'trading'] },
+};
+
+function optional(name: string): string | null {
+  const value = process.env[name];
+  return value?.trim() ? value.trim() : null;
+}
+
+function csv(value: string | null, fallback: string[]): string[] {
+  return value ? value.split(/[ ,]+/).map(item => item.trim()).filter(Boolean) : fallback;
+}
+
+export function getBrokerOAuthConfig(provider: Exclude<BrokerProvider, 'paper'>): OAuthBrokerConfig {
+  const key = provider.toUpperCase();
+  const base = defaults[provider];
+  const apiOrigin = (optional('IDENTITY_API_BASE_URL') ?? 'http://localhost:4000').replace(/\/+$/, '');
+  return {
+    provider,
+    clientId: optional(`${key}_OAUTH_CLIENT_ID`),
+    clientSecret: optional(`${key}_OAUTH_CLIENT_SECRET`),
+    authorizeUrl: optional(`${key}_OAUTH_AUTHORIZE_URL`) ?? base.authorizeUrl,
+    tokenUrl: optional(`${key}_OAUTH_TOKEN_URL`) ?? base.tokenUrl,
+    revokeUrl: optional(`${key}_OAUTH_REVOKE_URL`) ?? base.revokeUrl,
+    apiBaseUrl: optional(`${key}_OAUTH_API_BASE_URL`) ?? base.apiBaseUrl,
+    redirectUri: optional(`${key}_OAUTH_REDIRECT_URI`) ?? `${apiOrigin}/api/brokers/${provider}/callback`,
+    scopes: csv(optional(`${key}_OAUTH_SCOPES`), base.scopes),
+  };
+}
+
+export function isBrokerOAuthConfigured(provider: Exclude<BrokerProvider, 'paper'>): boolean {
+  const config = getBrokerOAuthConfig(provider);
+  return Boolean(config.clientId && config.clientSecret && config.authorizeUrl && config.tokenUrl && config.apiBaseUrl);
+}

--- a/server/src/features/brokerage/brokerPlatform.service.ts
+++ b/server/src/features/brokerage/brokerPlatform.service.ts
@@ -1,0 +1,334 @@
+import axios, { type AxiosRequestConfig } from 'axios';
+import { createHash } from 'crypto';
+import { Types } from 'mongoose';
+import { BrokerConnectionModel, type BrokerConnectionDocument, type BrokerProvider } from '../identity/models/brokerConnection.model';
+import { MembershipModel } from '../identity/models/membership.model';
+import { WorkspaceProfileModel } from '../identity/models/workspaceProfile.model';
+import { encryptSecret, decryptSecret, generateOpaqueToken, sha256 } from '../../shared/identity/crypto';
+import { BrokerOAuthAttemptModel } from './models/brokerOAuthAttempt.model';
+import { BrokerPortfolioModel } from './models/brokerPortfolio.model';
+import { getBrokerOAuthConfig } from './brokerConfig';
+import { getBrokerEntry } from './brokerRegistry';
+
+type BrokerEnvironment = 'paper' | 'live';
+type HttpRequest = <T = unknown>(config: AxiosRequestConfig) => Promise<{ data: T }>;
+let httpRequest: HttpRequest = config => axios.request(config);
+
+export function setBrokerHttpRequest(next: HttpRequest | null): void {
+  httpRequest = next ?? (config => axios.request(config));
+}
+
+function objectId(value: string): Types.ObjectId {
+  if (!Types.ObjectId.isValid(value)) throw Object.assign(new Error('AUTH_REQUIRED'), { status: 401 });
+  return new Types.ObjectId(value);
+}
+
+async function workspaceForUser(userId: Types.ObjectId): Promise<Types.ObjectId> {
+  const membership = await MembershipModel.findOne({ userId }).sort({ createdAt: 1 }).lean();
+  if (!membership) throw Object.assign(new Error('WORKSPACE_REQUIRED'), { status: 409 });
+  return membership.orgId;
+}
+
+function safeReturnTo(value: unknown): string {
+  const candidate = String(value ?? '/onboarding');
+  return candidate.startsWith('/') && !candidate.startsWith('//') ? candidate.slice(0, 300) : '/onboarding';
+}
+
+function asNumber(value: unknown): number | null {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function asArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    const candidate = record.positions ?? record.position ?? record.orders ?? record.order ?? record.watchlists ?? record.watchlist ?? record.data;
+    if (Array.isArray(candidate)) return candidate;
+    if (candidate && typeof candidate === 'object') return [candidate];
+  }
+  return [];
+}
+
+function publicConnection(connection: BrokerConnectionDocument, portfolio?: any) {
+  const entry = getBrokerEntry(connection.provider);
+  return {
+    id: String(connection._id),
+    provider: connection.provider,
+    brokerName: entry?.name ?? connection.label,
+    nickname: connection.nickname || connection.label,
+    accountId: connection.accountId,
+    accountType: connection.accountType,
+    environment: connection.environment,
+    paper: connection.paper,
+    live: connection.live,
+    primary: connection.primary,
+    status: connection.status,
+    scopes: connection.scopes,
+    permissions: connection.permissions,
+    connectedAt: connection.connectedAt,
+    lastSync: connection.lastSync,
+    lastRefresh: connection.lastRefresh,
+    expiresAt: connection.expiresAt,
+    oauthStatus: connection.oauthStatus,
+    reconnectStatus: connection.reconnectStatus,
+    health: connection.meta?.health ?? (connection.status === 'connected' ? 'healthy' : 'inactive'),
+    balances: portfolio?.balances ?? {
+      buyingPower: asNumber(connection.meta?.buyingPower), cash: null, equity: null, portfolioValue: null,
+    },
+    metrics: {
+      openPositions: portfolio?.positions?.length ?? 0,
+      openOrders: portfolio?.openOrders?.length ?? 0,
+      todayPl: portfolio?.positions?.reduce((total: number, position: any) => total + (asNumber(position?.unrealized_intraday_pl ?? position?.day_gain) ?? 0), 0) ?? 0,
+    },
+  };
+}
+
+export async function listConnections(actorId: string) {
+  const userId = objectId(actorId);
+  const connections = await BrokerConnectionModel.find({ userId, status: { $ne: 'unconfigured' } }).sort({ primary: -1, connectedAt: 1 });
+  const portfolios = await BrokerPortfolioModel.find({ userId }).lean();
+  const byConnection = new Map(portfolios.map(portfolio => [String(portfolio.connectionId), portfolio]));
+  return connections.map(connection => publicConnection(connection, byConnection.get(String(connection._id))));
+}
+
+export async function beginBrokerOAuth(input: { actorId: string; provider: Exclude<BrokerProvider, 'paper'>; environment: BrokerEnvironment; returnTo?: string }) {
+  const userId = objectId(input.actorId);
+  const workspaceId = await workspaceForUser(userId);
+  const config = getBrokerOAuthConfig(input.provider);
+  if (!config.clientId || !config.clientSecret || !config.authorizeUrl || !config.tokenUrl || !config.apiBaseUrl) {
+    throw Object.assign(new Error('BROKER_OAUTH_NOT_CONFIGURED'), { status: 503 });
+  }
+  const state = generateOpaqueToken(32);
+  const verifier = generateOpaqueToken(48);
+  const challenge = createHash('sha256').update(verifier).digest('base64url');
+  await BrokerOAuthAttemptModel.create({
+    userId, workspaceId, provider: input.provider, environment: input.environment,
+    stateHash: sha256(state), verifierCiphertext: encryptSecret(verifier),
+    returnTo: safeReturnTo(input.returnTo), expiresAt: new Date(Date.now() + 10 * 60_000), consumedAt: null,
+  });
+  const url = new URL(config.authorizeUrl);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('client_id', config.clientId);
+  url.searchParams.set('redirect_uri', config.redirectUri);
+  url.searchParams.set('state', state);
+  url.searchParams.set('scope', config.scopes.join(' '));
+  url.searchParams.set('code_challenge', challenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  url.searchParams.set('environment', input.environment);
+  return { authorizationUrl: url.toString(), expiresInSec: 600 };
+}
+
+type TokenPayload = { access_token?: string; refresh_token?: string; expires_in?: number | string; scope?: string | string[]; token_type?: string; user_id?: string };
+
+async function exchangeCode(provider: Exclude<BrokerProvider, 'paper'>, code: string, verifier: string): Promise<TokenPayload> {
+  const config = getBrokerOAuthConfig(provider);
+  const form = new URLSearchParams({
+    grant_type: 'authorization_code', code, redirect_uri: config.redirectUri,
+    client_id: config.clientId!, client_secret: config.clientSecret!, code_verifier: verifier,
+  });
+  const response = await httpRequest<TokenPayload>({
+    method: 'POST', url: config.tokenUrl, data: form.toString(), timeout: 15_000,
+    headers: { 'content-type': 'application/x-www-form-urlencoded', accept: 'application/json' },
+  });
+  if (!response.data?.access_token) throw Object.assign(new Error('BROKER_TOKEN_EXCHANGE_FAILED'), { status: 502 });
+  return response.data;
+}
+
+function providerPaths(provider: Exclude<BrokerProvider, 'paper'>, accountId?: string | null) {
+  if (provider === 'alpaca') return { account: '/v2/account', positions: '/v2/positions', orders: '/v2/orders?status=open&nested=true', watchlists: '/v2/watchlists', configuration: '/v2/account/configurations' };
+  if (provider === 'tradier') return { account: '/v1/user/profile', positions: `/v1/accounts/${accountId ?? ''}/positions`, orders: `/v1/accounts/${accountId ?? ''}/orders`, watchlists: '/v1/watchlists', configuration: `/v1/accounts/${accountId ?? ''}/balances` };
+  if (provider === 'ibkr') return { account: '/portfolio/accounts', positions: `/portfolio/${accountId ?? ''}/positions/0`, orders: '/iserver/account/orders', watchlists: '/iserver/watchlists', configuration: `/portfolio/${accountId ?? ''}/summary` };
+  return { account: '/customers/me/accounts', positions: `/accounts/${accountId ?? ''}/positions`, orders: `/accounts/${accountId ?? ''}/orders/live`, watchlists: '/watchlists', configuration: `/accounts/${accountId ?? ''}/balances` };
+}
+
+async function brokerGet(provider: Exclude<BrokerProvider, 'paper'>, accessToken: string, path: string): Promise<unknown> {
+  const config = getBrokerOAuthConfig(provider);
+  const response = await httpRequest({ method: 'GET', url: `${config.apiBaseUrl.replace(/\/+$/, '')}${path}`, timeout: 15_000, headers: { authorization: `Bearer ${accessToken}`, accept: 'application/json' } });
+  return response.data;
+}
+
+async function optionalBrokerGet(provider: Exclude<BrokerProvider, 'paper'>, accessToken: string, path: string, fallback: unknown): Promise<unknown> {
+  try { return await brokerGet(provider, accessToken, path); } catch { return fallback; }
+}
+
+function accountRecord(provider: Exclude<BrokerProvider, 'paper'>, raw: any): Record<string, any> {
+  if (provider === 'tradier') {
+    const profile = raw?.profile ?? raw;
+    const account = Array.isArray(profile?.account) ? profile.account[0] : profile?.account;
+    return account ?? profile ?? {};
+  }
+  if (provider === 'ibkr') return (Array.isArray(raw) ? raw[0] : raw?.accounts?.[0] ?? raw) ?? {};
+  if (provider === 'tastytrade') return raw?.data?.items?.[0] ?? raw?.data ?? raw ?? {};
+  return raw ?? {};
+}
+
+function accountIdFrom(raw: Record<string, any>): string {
+  return String(raw.id ?? raw.account_id ?? raw.accountId ?? raw.account_number ?? raw.accountNumber ?? raw.account ?? raw.accountNo ?? raw['account-number'] ?? '').trim();
+}
+
+export async function completeBrokerOAuth(input: { provider: Exclude<BrokerProvider, 'paper'>; state: string; code: string }) {
+  const now = new Date();
+  const attempt = await BrokerOAuthAttemptModel.findOneAndUpdate(
+    { provider: input.provider, stateHash: sha256(input.state), consumedAt: null, expiresAt: { $gt: now } },
+    { $set: { consumedAt: now } }, { returnDocument: 'after' }
+  );
+  if (!attempt) throw Object.assign(new Error('BROKER_OAUTH_STATE_INVALID'), { status: 400 });
+  const token = await exchangeCode(input.provider, input.code, decryptSecret(attempt.verifierCiphertext));
+  const rawAccount = accountRecord(input.provider, await brokerGet(input.provider, token.access_token!, providerPaths(input.provider).account));
+  const accountId = accountIdFrom(rawAccount);
+  if (!accountId) throw Object.assign(new Error('BROKER_ACCOUNT_INVALID'), { status: 502 });
+  const entry = getBrokerEntry(input.provider)!;
+  const existing = await BrokerConnectionModel.findOne({ userId: attempt.userId, provider: input.provider, accountId });
+  const placeholder = existing ?? await BrokerConnectionModel.findOne({ userId: attempt.userId, provider: input.provider, accountId: null, status: { $in: ['unconfigured', 'revoked', 'error'] } });
+  const expiresIn = asNumber(token.expires_in);
+  const scopes = Array.isArray(token.scope) ? token.scope : String(token.scope ?? getBrokerOAuthConfig(input.provider).scopes.join(' ')).split(/[ ,]+/).filter(Boolean);
+  const values = {
+    workspaceId: attempt.workspaceId, provider: input.provider, label: entry.name, nickname: entry.name,
+    status: 'connected' as const, accountId, brokerUserId: token.user_id ?? null,
+    accountType: String(rawAccount.account_type ?? rawAccount.type ?? rawAccount.accountType ?? attempt.environment),
+    paper: attempt.environment === 'paper', live: attempt.environment === 'live', primary: false, environment: attempt.environment,
+    encryptedAccessToken: encryptSecret(token.access_token!),
+    encryptedRefreshToken: token.refresh_token ? encryptSecret(token.refresh_token) : null,
+    expiresAt: expiresIn ? new Date(Date.now() + expiresIn * 1000) : null,
+    scopes, permissions: entry.permissions, connectedAt: now, lastSync: null, lastRefresh: null,
+    reconnectStatus: 'not_required' as const, oauthStatus: 'authorized' as const,
+    meta: { health: 'sync_pending', brokerStatus: rawAccount.status ?? 'ACTIVE' },
+  };
+  const connection = placeholder
+    ? await BrokerConnectionModel.findByIdAndUpdate(placeholder._id, { $set: values }, { returnDocument: 'after' })
+    : await BrokerConnectionModel.create({ userId: attempt.userId, ...values });
+  if (!connection) throw new Error('BROKER_CONNECTION_WRITE_FAILED');
+  if (!(await BrokerConnectionModel.exists({ userId: attempt.userId, primary: true, status: 'connected' }))) {
+    connection.primary = true;
+    await connection.save();
+  }
+  await syncConnection(connection, token.access_token!);
+  await WorkspaceProfileModel.updateOne({ userId: attempt.userId }, { $set: { 'brokerOnboarding.status': 'connected', 'onboarding.status': 'in_progress', 'onboarding.currentStep': 2 } });
+  return { connection: publicConnection(connection), returnTo: attempt.returnTo, actorId: String(attempt.userId) };
+}
+
+async function syncConnection(connection: BrokerConnectionDocument, providedAccessToken?: string) {
+  if (connection.provider === 'paper') return null;
+  const provider = connection.provider as Exclude<BrokerProvider, 'paper'>;
+  const withSecrets = providedAccessToken ? connection : await BrokerConnectionModel.findById(connection._id).select('+encryptedAccessToken +encryptedRefreshToken');
+  const accessToken = providedAccessToken ?? (withSecrets?.encryptedAccessToken ? decryptSecret(withSecrets.encryptedAccessToken) : '');
+  if (!accessToken) throw Object.assign(new Error('BROKER_RECONNECT_REQUIRED'), { status: 409 });
+  await BrokerConnectionModel.updateOne({ _id: connection._id }, { $set: { status: 'syncing', 'meta.health': 'syncing' } });
+  const paths = providerPaths(provider, connection.accountId);
+  try {
+    const accountRaw = await brokerGet(provider, accessToken, paths.account);
+    const account = accountRecord(provider, accountRaw);
+    const [positionsRaw, ordersRaw, watchlistsRaw, configurationRaw] = await Promise.all([
+      optionalBrokerGet(provider, accessToken, paths.positions, []), optionalBrokerGet(provider, accessToken, paths.orders, []),
+      optionalBrokerGet(provider, accessToken, paths.watchlists, []), optionalBrokerGet(provider, accessToken, paths.configuration, {}),
+    ]);
+    const positions = asArray(positionsRaw);
+    const balancesRaw: any = (configurationRaw as any)?.balances ?? configurationRaw ?? {};
+    const balances = {
+      buyingPower: asNumber(account.buying_power ?? account.buyingPower ?? balancesRaw.buying_power ?? balancesRaw.buyingPower),
+      cash: asNumber(account.cash ?? balancesRaw.cash ?? balancesRaw.total_cash),
+      equity: asNumber(account.equity ?? balancesRaw.equity ?? balancesRaw.total_equity),
+      portfolioValue: asNumber(account.portfolio_value ?? account.portfolioValue ?? balancesRaw.market_value ?? balancesRaw.net_liquidating_value),
+    };
+    const syncedAt = new Date();
+    await BrokerPortfolioModel.findOneAndUpdate({ connectionId: connection._id }, { $set: {
+      connectionId: connection._id, userId: connection.userId, workspaceId: connection.workspaceId,
+      provider, accountId: connection.accountId, account, balances, positions,
+      optionPositions: positions.filter((item: any) => String(item?.asset_class ?? item?.instrument_type ?? '').toLowerCase().includes('option')),
+      openOrders: asArray(ordersRaw), watchlists: asArray(watchlistsRaw), accountConfiguration: configurationRaw ?? {}, syncedAt,
+    } }, { upsert: true, returnDocument: 'after', setDefaultsOnInsert: true });
+    await BrokerConnectionModel.updateOne({ _id: connection._id }, { $set: {
+      status: 'connected', lastSync: syncedAt, 'meta.health': 'healthy', 'meta.buyingPower': balances.buyingPower,
+      'meta.cash': balances.cash, 'meta.equity': balances.equity, 'meta.portfolioValue': balances.portfolioValue,
+    } });
+    connection.status = 'connected'; connection.lastSync = syncedAt; connection.meta = { ...connection.meta, health: 'healthy', buyingPower: balances.buyingPower };
+    return { syncedAt, balances, positions: positions.length, orders: asArray(ordersRaw).length };
+  } catch (error) {
+    await BrokerConnectionModel.updateOne({ _id: connection._id }, { $set: { status: 'error', 'meta.health': 'degraded', 'meta.lastErrorAt': new Date() } });
+    throw error;
+  }
+}
+
+export async function syncConnections(actorId: string, provider?: Exclude<BrokerProvider, 'paper'>) {
+  const userId = objectId(actorId);
+  const connections = await BrokerConnectionModel.find({ userId, status: { $in: ['connected', 'error'] }, ...(provider ? { provider } : { provider: { $ne: 'paper' } }) });
+  const results = [];
+  for (const connection of connections) results.push({ connectionId: String(connection._id), ...(await syncConnection(connection)) });
+  return results;
+}
+
+export async function refreshConnection(connection: BrokerConnectionDocument): Promise<boolean> {
+  if (connection.provider === 'paper') return true;
+  const provider = connection.provider as Exclude<BrokerProvider, 'paper'>;
+  const current = await BrokerConnectionModel.findById(connection._id).select('+encryptedRefreshToken');
+  if (!current?.encryptedRefreshToken) {
+    await BrokerConnectionModel.updateOne({ _id: connection._id }, { $set: { reconnectStatus: 'required', oauthStatus: 'expired', status: 'error' } });
+    return false;
+  }
+  const config = getBrokerOAuthConfig(provider);
+  const form = new URLSearchParams({ grant_type: 'refresh_token', refresh_token: decryptSecret(current.encryptedRefreshToken), client_id: config.clientId!, client_secret: config.clientSecret! });
+  try {
+    const response = await httpRequest<TokenPayload>({ method: 'POST', url: config.tokenUrl, data: form.toString(), timeout: 15_000, headers: { 'content-type': 'application/x-www-form-urlencoded', accept: 'application/json' } });
+    if (!response.data.access_token) throw new Error('BROKER_REFRESH_FAILED');
+    const expiresIn = asNumber(response.data.expires_in);
+    await BrokerConnectionModel.updateOne({ _id: connection._id }, { $set: {
+      encryptedAccessToken: encryptSecret(response.data.access_token),
+      ...(response.data.refresh_token ? { encryptedRefreshToken: encryptSecret(response.data.refresh_token) } : {}),
+      expiresAt: expiresIn ? new Date(Date.now() + expiresIn * 1000) : null, lastRefresh: new Date(),
+      reconnectStatus: 'not_required', oauthStatus: 'authorized', status: 'connected', 'meta.health': 'healthy',
+    } });
+    return true;
+  } catch {
+    await BrokerConnectionModel.updateOne({ _id: connection._id }, { $set: { reconnectStatus: 'required', oauthStatus: 'error', status: 'error', 'meta.health': 'degraded' } });
+    return false;
+  }
+}
+
+export async function refreshExpiringConnections(): Promise<number> {
+  const cutoff = new Date(Date.now() + 5 * 60_000);
+  const connections = await BrokerConnectionModel.find({ status: 'connected', expiresAt: { $ne: null, $lte: cutoff } });
+  let refreshed = 0;
+  for (const connection of connections) if (await refreshConnection(connection)) refreshed += 1;
+  return refreshed;
+}
+
+export async function disconnectBroker(input: { actorId: string; provider: Exclude<BrokerProvider, 'paper'>; connectionId?: string }) {
+  const userId = objectId(input.actorId);
+  const query: any = { userId, provider: input.provider, status: { $ne: 'unconfigured' } };
+  if (input.connectionId) query._id = objectId(input.connectionId);
+  const connection = await BrokerConnectionModel.findOne(query).select('+encryptedAccessToken +encryptedRefreshToken');
+  if (!connection) throw Object.assign(new Error('BROKER_CONNECTION_NOT_FOUND'), { status: 404 });
+  const config = getBrokerOAuthConfig(input.provider);
+  if (config.revokeUrl && connection.encryptedAccessToken) {
+    try { await httpRequest({ method: 'POST', url: config.revokeUrl, data: new URLSearchParams({ token: decryptSecret(connection.encryptedAccessToken) }).toString(), timeout: 10_000, headers: { 'content-type': 'application/x-www-form-urlencoded' } }); } catch { /* Local revocation remains authoritative. */ }
+  }
+  await BrokerPortfolioModel.deleteOne({ connectionId: connection._id });
+  await BrokerConnectionModel.updateOne({ _id: connection._id }, { $set: {
+    status: 'revoked', encryptedAccessToken: null, encryptedRefreshToken: null, expiresAt: null,
+    oauthStatus: 'revoked', reconnectStatus: 'required', lastSync: null, primary: false,
+    meta: { disconnectedAt: new Date(), health: 'inactive' },
+  } });
+  return { disconnected: true, provider: input.provider, connectionId: String(connection._id) };
+}
+
+export async function connectionHealth(actorId: string) {
+  const userId = objectId(actorId);
+  const connections = await listConnections(actorId);
+  const workspace = await WorkspaceProfileModel.findOne({ userId }).select('aiMemory riskProfile').lean();
+  const tolerance = workspace?.riskProfile?.automationAllowed ? 65 : workspace?.riskProfile?.emergencyStop ? 35 : 50;
+  return {
+    checkedAt: new Date(), healthy: connections.filter(item => item.status === 'connected' && item.health === 'healthy').length,
+    degraded: connections.filter(item => item.status === 'error' || item.health === 'degraded').length,
+    reconnectRequired: connections.filter(item => item.reconnectStatus === 'required').length,
+    aiStatus: workspace?.aiMemory?.status ?? 'pending', riskScore: tolerance, recentSignals: [], connections,
+  };
+}
+
+let refreshTimer: NodeJS.Timeout | null = null;
+export function startBrokerRefreshService(): void {
+  if (refreshTimer || process.env.BROKER_REFRESH_ENABLED === 'false') return;
+  refreshTimer = setInterval(() => void refreshExpiringConnections().catch(() => undefined), 60_000);
+  refreshTimer.unref();
+}
+export function stopBrokerRefreshService(): void { if (refreshTimer) clearInterval(refreshTimer); refreshTimer = null; }

--- a/server/src/features/brokerage/brokerRegistry.ts
+++ b/server/src/features/brokerage/brokerRegistry.ts
@@ -1,0 +1,37 @@
+import type { BrokerProvider } from '../identity/models/brokerConnection.model';
+
+export type BrokerAsset = 'Stocks' | 'Options' | 'Futures' | 'Crypto';
+
+export type BrokerDirectoryEntry = {
+  provider: string;
+  name: string;
+  monogram: string;
+  assets: BrokerAsset[];
+  oauthSupported: boolean;
+  paperTrading: boolean;
+  liveTrading: boolean;
+  available: boolean;
+  permissions: string[];
+  description: string;
+};
+
+export const BROKER_DIRECTORY: BrokerDirectoryEntry[] = [
+  { provider: 'alpaca', name: 'Alpaca', monogram: 'A', assets: ['Stocks', 'Options', 'Crypto'], oauthSupported: true, paperTrading: true, liveTrading: true, available: true, permissions: ['Read Account', 'Read Buying Power', 'Read Positions', 'Read Orders', 'Submit Orders'], description: 'API-first brokerage for equities, options, and digital assets.' },
+  { provider: 'ibkr', name: 'Interactive Brokers', monogram: 'IB', assets: ['Stocks', 'Options', 'Futures'], oauthSupported: true, paperTrading: true, liveTrading: true, available: true, permissions: ['Read Account', 'Read Buying Power', 'Read Positions', 'Read Orders', 'Submit Orders'], description: 'Global multi-asset execution and institutional account access.' },
+  { provider: 'tradier', name: 'Tradier', monogram: 'TR', assets: ['Stocks', 'Options'], oauthSupported: true, paperTrading: true, liveTrading: true, available: true, permissions: ['Read Account', 'Read Balances', 'Read Positions', 'Read Orders', 'Submit Orders'], description: 'Equity and options brokerage with delegated OAuth access.' },
+  { provider: 'tastytrade', name: 'tastytrade', monogram: 'TT', assets: ['Stocks', 'Options', 'Futures', 'Crypto'], oauthSupported: true, paperTrading: false, liveTrading: true, available: true, permissions: ['Read Account', 'Read Buying Power', 'Read Positions', 'Read Orders', 'Submit Orders'], description: 'Derivatives-focused brokerage and multi-asset execution.' },
+  { provider: 'robinhood', name: 'Robinhood', monogram: 'RH', assets: ['Stocks', 'Options', 'Crypto'], oauthSupported: false, paperTrading: false, liveTrading: true, available: false, permissions: [], description: 'Retail equities, options, and crypto brokerage.' },
+  { provider: 'schwab', name: 'Charles Schwab', monogram: 'CS', assets: ['Stocks', 'Options'], oauthSupported: false, paperTrading: false, liveTrading: true, available: false, permissions: [], description: 'Full-service investing and brokerage accounts.' },
+  { provider: 'tradestation', name: 'TradeStation', monogram: 'TS', assets: ['Stocks', 'Options', 'Futures', 'Crypto'], oauthSupported: false, paperTrading: true, liveTrading: true, available: false, permissions: [], description: 'Active trading across multiple asset classes.' },
+  { provider: 'webull', name: 'Webull', monogram: 'WB', assets: ['Stocks', 'Options', 'Crypto'], oauthSupported: false, paperTrading: true, liveTrading: true, available: false, permissions: [], description: 'Multi-asset brokerage and market access.' },
+  { provider: 'fidelity', name: 'Fidelity', monogram: 'F', assets: ['Stocks', 'Options'], oauthSupported: false, paperTrading: false, liveTrading: true, available: false, permissions: [], description: 'Investment and brokerage account access.' },
+  { provider: 'moomoo', name: 'Moomoo', monogram: 'M', assets: ['Stocks', 'Options'], oauthSupported: false, paperTrading: true, liveTrading: true, available: false, permissions: [], description: 'Equities and options trading platform.' },
+  { provider: 'etrade', name: 'E*Trade', monogram: 'ET', assets: ['Stocks', 'Options', 'Futures'], oauthSupported: false, paperTrading: false, liveTrading: true, available: false, permissions: [], description: 'Brokerage and active trading accounts.' },
+  { provider: 'public', name: 'Public', monogram: 'P', assets: ['Stocks', 'Options', 'Crypto'], oauthSupported: false, paperTrading: false, liveTrading: true, available: false, permissions: [], description: 'Investing platform for stocks, options, and crypto.' },
+];
+
+export const ACTIVE_BROKER_PROVIDERS = new Set<BrokerProvider>(['alpaca', 'ibkr', 'tradier', 'tastytrade']);
+
+export function getBrokerEntry(provider: string): BrokerDirectoryEntry | null {
+  return BROKER_DIRECTORY.find(item => item.provider === provider) ?? null;
+}

--- a/server/src/features/brokerage/brokerage.routes.ts
+++ b/server/src/features/brokerage/brokerage.routes.ts
@@ -1,0 +1,119 @@
+import express from 'express';
+import type { NextFunction, Request, Response } from 'express';
+import { requireAuthenticated, requireMongoIdentity } from '../identity/identity.middleware';
+import { requireCsrf } from '../../shared/identity/csrf';
+import { getIdentityConfig } from '../../shared/identity/config';
+import { recordAuditFromRequest } from '../identity/services/auditService';
+import { AuditLogModel } from '../identity/models/auditLog.model';
+import { SessionModel } from '../identity/models/session.model';
+import { BROKER_DIRECTORY, ACTIVE_BROKER_PROVIDERS, getBrokerEntry } from './brokerRegistry';
+import { isBrokerOAuthConfigured } from './brokerConfig';
+import {
+  beginBrokerOAuth, completeBrokerOAuth, connectionHealth, disconnectBroker,
+  listConnections, syncConnections,
+} from './brokerPlatform.service';
+import type { BrokerProvider } from '../identity/models/brokerConnection.model';
+
+export const brokerageRouter = express.Router();
+type ActiveProvider = Exclude<BrokerProvider, 'paper'>;
+type AsyncHandler = (req: Request, res: Response, next: NextFunction) => Promise<void>;
+const asyncRoute = (handler: AsyncHandler) => (req: Request, res: Response, next: NextFunction): void => { handler(req, res, next).catch(next); };
+
+function activeProvider(value: unknown): ActiveProvider | null {
+  const provider = String(value ?? '') as ActiveProvider;
+  return ACTIVE_BROKER_PROVIDERS.has(provider) ? provider : null;
+}
+
+function environment(value: unknown): 'paper' | 'live' {
+  return value === 'live' ? 'live' : 'paper';
+}
+
+brokerageRouter.get('/', requireMongoIdentity, requireAuthenticated, asyncRoute(async (req, res) => {
+  const connections = await listConnections(req.auth!.actorId);
+  res.json({
+    brokers: BROKER_DIRECTORY.map(broker => ({
+      ...broker,
+      configured: broker.available && isBrokerOAuthConfigured(broker.provider as ActiveProvider),
+      connections: connections.filter(connection => connection.provider === broker.provider),
+    })),
+  });
+}));
+
+brokerageRouter.get('/status', requireMongoIdentity, requireAuthenticated, asyncRoute(async (req, res) => {
+  res.json(await connectionHealth(req.auth!.actorId));
+}));
+
+brokerageRouter.get('/security', requireMongoIdentity, requireAuthenticated, asyncRoute(async (req, res) => {
+  const actorId = req.auth!.actorId;
+  const [sessions, activity, brokers] = await Promise.all([
+    SessionModel.find({ userId: actorId, revokedAt: null, expiresAt: { $gt: new Date() } }).sort({ lastUsedAt: -1 }).select('device lastUsedAt createdAt').lean(),
+    AuditLogModel.find({ actorId }).sort({ createdAt: -1 }).limit(20).select('action outcome createdAt ip ua targetType').lean(),
+    listConnections(actorId),
+  ]);
+  res.json({
+    controls: { oauthAuthentication: true, encryption: 'AES-256-GCM', transport: 'TLS 1.3', revocableAccess: true },
+    sessionStatus: 'active', lastLogin: activity.find(item => item.action === 'LOGIN')?.createdAt ?? null,
+    connectedDevices: sessions.map(session => ({ id: String(session._id), device: session.device, lastUsedAt: session.lastUsedAt, createdAt: session.createdAt })),
+    connectedBrokers: brokers, activity,
+  });
+}));
+
+brokerageRouter.post('/sync', requireMongoIdentity, requireAuthenticated, requireCsrf, asyncRoute(async (req, res) => {
+  const resolvedProvider = req.body?.provider ? activeProvider(req.body.provider) : undefined;
+  if (req.body?.provider && !resolvedProvider) { res.status(404).json({ error: 'BROKER_NOT_SUPPORTED' }); return; }
+  const provider = resolvedProvider ?? undefined;
+  const results = await syncConnections(req.auth!.actorId, provider);
+  await recordAuditFromRequest(req, { actorId: req.auth!.actorId, action: 'BROKER_SYNCED', targetType: 'broker_connection', meta: { provider: provider ?? 'all', count: results.length } });
+  res.json({ results });
+}));
+
+brokerageRouter.get('/:provider', requireMongoIdentity, requireAuthenticated, asyncRoute(async (req, res) => {
+  const entry = getBrokerEntry(req.params.provider);
+  if (!entry) { res.status(404).json({ error: 'BROKER_NOT_FOUND' }); return; }
+  const connections = await listConnections(req.auth!.actorId);
+  res.json({ broker: { ...entry, configured: entry.available && isBrokerOAuthConfigured(entry.provider as ActiveProvider) }, connections: connections.filter(item => item.provider === entry.provider) });
+}));
+
+brokerageRouter.post('/:provider/connect', requireMongoIdentity, requireAuthenticated, requireCsrf, asyncRoute(async (req, res) => {
+  const provider = activeProvider(req.params.provider);
+  if (!provider) { res.status(404).json({ error: 'BROKER_NOT_SUPPORTED' }); return; }
+  const result = await beginBrokerOAuth({ actorId: req.auth!.actorId, provider, environment: environment(req.body?.environment), returnTo: req.body?.returnTo });
+  await recordAuditFromRequest(req, { actorId: req.auth!.actorId, action: 'BROKER_OAUTH_STARTED', targetType: 'broker_provider', targetId: provider, meta: { environment: environment(req.body?.environment) } });
+  res.status(201).json(result);
+}));
+
+brokerageRouter.get('/:provider/callback', requireMongoIdentity, asyncRoute(async (req, res) => {
+  const provider = activeProvider(req.params.provider);
+  if (!provider) { res.status(404).json({ error: 'BROKER_NOT_SUPPORTED' }); return; }
+  const state = String(req.query.state ?? '');
+  const code = String(req.query.code ?? '');
+  if (!state || !code || req.query.error) {
+    res.redirect(303, `${getIdentityConfig().appBaseUrl}/onboarding?broker=${encodeURIComponent(provider)}&connection=denied`);
+    return;
+  }
+  try {
+    const result = await completeBrokerOAuth({ provider, state, code });
+    await recordAuditFromRequest(req, { actorId: result.actorId, action: 'BROKER_CONNECTED', targetType: 'broker_connection', targetId: result.connection.id, meta: { provider } });
+    const separator = result.returnTo.includes('?') ? '&' : '?';
+    res.redirect(303, `${getIdentityConfig().appBaseUrl}${result.returnTo}${separator}broker=${encodeURIComponent(provider)}&connection=success`);
+  } catch (error) {
+    await recordAuditFromRequest(req, { actorId: 'broker-oauth', action: 'BROKER_OAUTH_FAILED', outcome: 'failure', targetType: 'broker_provider', targetId: provider });
+    res.redirect(303, `${getIdentityConfig().appBaseUrl}/onboarding?broker=${encodeURIComponent(provider)}&connection=failed`);
+  }
+}));
+
+brokerageRouter.post('/:provider/reconnect', requireMongoIdentity, requireAuthenticated, requireCsrf, asyncRoute(async (req, res) => {
+  const provider = activeProvider(req.params.provider);
+  if (!provider) { res.status(404).json({ error: 'BROKER_NOT_SUPPORTED' }); return; }
+  const result = await beginBrokerOAuth({ actorId: req.auth!.actorId, provider, environment: environment(req.body?.environment), returnTo: req.body?.returnTo ?? '/terminal?settings=brokers' });
+  await recordAuditFromRequest(req, { actorId: req.auth!.actorId, action: 'BROKER_RECONNECT_STARTED', targetType: 'broker_provider', targetId: provider });
+  res.status(201).json(result);
+}));
+
+brokerageRouter.post('/:provider/disconnect', requireMongoIdentity, requireAuthenticated, requireCsrf, asyncRoute(async (req, res) => {
+  const provider = activeProvider(req.params.provider);
+  if (!provider) { res.status(404).json({ error: 'BROKER_NOT_SUPPORTED' }); return; }
+  const result = await disconnectBroker({ actorId: req.auth!.actorId, provider, connectionId: req.body?.connectionId });
+  await recordAuditFromRequest(req, { actorId: req.auth!.actorId, action: 'BROKER_DISCONNECTED', targetType: 'broker_connection', targetId: result.connectionId, meta: { provider } });
+  res.json(result);
+}));

--- a/server/src/features/brokerage/models/brokerOAuthAttempt.model.ts
+++ b/server/src/features/brokerage/models/brokerOAuthAttempt.model.ts
@@ -1,0 +1,38 @@
+import mongoose, { Document, Schema, Types } from 'mongoose';
+import type { EnvelopeCiphertext } from '../../../shared/identity/crypto';
+import type { BrokerProvider } from '../../identity/models/brokerConnection.model';
+
+export interface BrokerOAuthAttemptDocument extends Document {
+  userId: Types.ObjectId;
+  workspaceId: Types.ObjectId;
+  provider: BrokerProvider;
+  environment: 'paper' | 'live';
+  stateHash: string;
+  verifierCiphertext: EnvelopeCiphertext;
+  returnTo: string;
+  expiresAt: Date;
+  consumedAt: Date | null;
+}
+
+const EnvelopeSchema = new Schema<EnvelopeCiphertext>({
+  v: { type: Number, required: true },
+  iv: { type: String, required: true },
+  tag: { type: String, required: true },
+  data: { type: String, required: true },
+}, { _id: false });
+
+const BrokerOAuthAttemptSchema = new Schema<BrokerOAuthAttemptDocument>({
+  userId: { type: Schema.Types.ObjectId, required: true, index: true },
+  workspaceId: { type: Schema.Types.ObjectId, required: true, index: true },
+  provider: { type: String, enum: ['alpaca', 'tradier', 'ibkr', 'tastytrade'], required: true },
+  environment: { type: String, enum: ['paper', 'live'], required: true },
+  stateHash: { type: String, required: true, unique: true },
+  verifierCiphertext: { type: EnvelopeSchema, required: true },
+  returnTo: { type: String, required: true },
+  expiresAt: { type: Date, required: true, index: { expires: 0 } },
+  consumedAt: { type: Date, default: null },
+}, { timestamps: true, collection: 'broker_oauth_attempts' });
+
+export const BrokerOAuthAttemptModel =
+  (mongoose.models.BrokerOAuthAttempt as mongoose.Model<BrokerOAuthAttemptDocument>) ||
+  mongoose.model<BrokerOAuthAttemptDocument>('BrokerOAuthAttempt', BrokerOAuthAttemptSchema);

--- a/server/src/features/brokerage/models/brokerPortfolio.model.ts
+++ b/server/src/features/brokerage/models/brokerPortfolio.model.ts
@@ -1,0 +1,43 @@
+import mongoose, { Document, Schema, Types } from 'mongoose';
+import type { BrokerProvider } from '../../identity/models/brokerConnection.model';
+
+export interface BrokerPortfolioDocument extends Document {
+  connectionId: Types.ObjectId;
+  userId: Types.ObjectId;
+  workspaceId: Types.ObjectId;
+  provider: BrokerProvider;
+  accountId: string;
+  account: Record<string, unknown>;
+  balances: { buyingPower: number | null; cash: number | null; equity: number | null; portfolioValue: number | null };
+  positions: unknown[];
+  optionPositions: unknown[];
+  openOrders: unknown[];
+  watchlists: unknown[];
+  accountConfiguration: Record<string, unknown>;
+  syncedAt: Date;
+}
+
+const BrokerPortfolioSchema = new Schema<BrokerPortfolioDocument>({
+  connectionId: { type: Schema.Types.ObjectId, required: true, unique: true, index: true },
+  userId: { type: Schema.Types.ObjectId, required: true, index: true },
+  workspaceId: { type: Schema.Types.ObjectId, required: true, index: true },
+  provider: { type: String, enum: ['alpaca', 'tradier', 'ibkr', 'tastytrade', 'paper'], required: true },
+  accountId: { type: String, required: true },
+  account: { type: Schema.Types.Mixed, required: true, default: {} },
+  balances: {
+    buyingPower: { type: Number, default: null }, cash: { type: Number, default: null },
+    equity: { type: Number, default: null }, portfolioValue: { type: Number, default: null },
+  },
+  positions: { type: [Schema.Types.Mixed], required: true, default: [] },
+  optionPositions: { type: [Schema.Types.Mixed], required: true, default: [] },
+  openOrders: { type: [Schema.Types.Mixed], required: true, default: [] },
+  watchlists: { type: [Schema.Types.Mixed], required: true, default: [] },
+  accountConfiguration: { type: Schema.Types.Mixed, required: true, default: {} },
+  syncedAt: { type: Date, required: true },
+}, { timestamps: true, collection: 'broker_portfolios' });
+
+BrokerPortfolioSchema.index({ userId: 1, provider: 1, accountId: 1 }, { unique: true });
+
+export const BrokerPortfolioModel =
+  (mongoose.models.BrokerPortfolio as mongoose.Model<BrokerPortfolioDocument>) ||
+  mongoose.model<BrokerPortfolioDocument>('BrokerPortfolio', BrokerPortfolioSchema);

--- a/server/src/features/identity/identity.migrations.ts
+++ b/server/src/features/identity/identity.migrations.ts
@@ -3,10 +3,16 @@ import { roleCatalog } from '../../shared/identity/rbac';
 import { isMongoReady } from '../../shared/db/mongo';
 import { writeStructuredLog } from '../../shared/logging/safeLogging';
 import { OAuthAttemptModel } from './models/oauthAttempt.model';
+import { BrokerConnectionModel } from './models/brokerConnection.model';
+import { BrokerOAuthAttemptModel } from '../brokerage/models/brokerOAuthAttempt.model';
+import { BrokerPortfolioModel } from '../brokerage/models/brokerPortfolio.model';
 
 export async function runIdentityMigrations(): Promise<void> {
   if (!isMongoReady()) return;
   await OAuthAttemptModel.syncIndexes();
+  await BrokerConnectionModel.syncIndexes();
+  await BrokerOAuthAttemptModel.syncIndexes();
+  await BrokerPortfolioModel.syncIndexes();
   for (const role of roleCatalog()) {
     await RoleModel.updateOne(
       { key: role.key },

--- a/server/src/features/identity/models/brokerConnection.model.ts
+++ b/server/src/features/identity/models/brokerConnection.model.ts
@@ -9,16 +9,32 @@ import type { EnvelopeCiphertext } from '../../../shared/identity/crypto';
 // existing Alpaca façade is untouched.
 
 export type BrokerProvider = 'alpaca' | 'tradier' | 'ibkr' | 'tastytrade' | 'paper';
-export type BrokerConnectionStatus = 'unconfigured' | 'connected' | 'error' | 'revoked';
+export type BrokerConnectionStatus = 'unconfigured' | 'connecting' | 'connected' | 'syncing' | 'error' | 'revoked';
 
 export interface BrokerConnectionDocument extends Document {
   userId: Types.ObjectId;
+  workspaceId: Types.ObjectId | null;
   provider: BrokerProvider;
   label: string;
+  nickname: string;
   status: BrokerConnectionStatus;
   accountId: string | null;
+  brokerUserId: string | null;
   accountType: string | null;
   paper: boolean;
+  live: boolean;
+  primary: boolean;
+  environment: 'paper' | 'live';
+  encryptedAccessToken: EnvelopeCiphertext | null;
+  encryptedRefreshToken: EnvelopeCiphertext | null;
+  expiresAt: Date | null;
+  scopes: string[];
+  permissions: string[];
+  connectedAt: Date | null;
+  lastSync: Date | null;
+  lastRefresh: Date | null;
+  reconnectStatus: 'not_required' | 'required' | 'in_progress';
+  oauthStatus: 'not_configured' | 'authorized' | 'expired' | 'revoked' | 'error';
   secretCiphertext: EnvelopeCiphertext | null; // never plaintext
   meta: Record<string, unknown>;
   createdAt: Date;
@@ -38,24 +54,45 @@ const EnvelopeSchema = new Schema<EnvelopeCiphertext>(
 const BrokerConnectionSchema = new Schema<BrokerConnectionDocument>(
   {
     userId: { type: Schema.Types.ObjectId, required: true, index: true },
+    workspaceId: { type: Schema.Types.ObjectId, default: null, index: true },
     provider: { type: String, enum: ['alpaca', 'tradier', 'ibkr', 'tastytrade', 'paper'], required: true },
     label: { type: String, required: true, trim: true, default: '' },
+    nickname: { type: String, required: true, trim: true, default: '' },
     status: {
       type: String,
-      enum: ['unconfigured', 'connected', 'error', 'revoked'],
+      enum: ['unconfigured', 'connecting', 'connected', 'syncing', 'error', 'revoked'],
       required: true,
       default: 'unconfigured',
     },
     accountId: { type: String, default: null },
+    brokerUserId: { type: String, default: null },
     accountType: { type: String, default: null },
     paper: { type: Boolean, required: true, default: false },
+    live: { type: Boolean, required: true, default: false },
+    primary: { type: Boolean, required: true, default: false },
+    environment: { type: String, enum: ['paper', 'live'], required: true, default: 'paper' },
+    encryptedAccessToken: { type: EnvelopeSchema, default: null, select: false },
+    encryptedRefreshToken: { type: EnvelopeSchema, default: null, select: false },
+    expiresAt: { type: Date, default: null },
+    scopes: { type: [String], required: true, default: [] },
+    permissions: { type: [String], required: true, default: [] },
+    connectedAt: { type: Date, default: null },
+    lastSync: { type: Date, default: null },
+    lastRefresh: { type: Date, default: null },
+    reconnectStatus: { type: String, enum: ['not_required', 'required', 'in_progress'], required: true, default: 'not_required' },
+    oauthStatus: { type: String, enum: ['not_configured', 'authorized', 'expired', 'revoked', 'error'], required: true, default: 'not_configured' },
     secretCiphertext: { type: EnvelopeSchema, default: null },
     meta: { type: Schema.Types.Mixed, default: {} },
   },
   { timestamps: true, collection: IDENTITY_COLLECTIONS.brokerConnections }
 );
 
-BrokerConnectionSchema.index({ userId: 1, provider: 1 }, { unique: true });
+BrokerConnectionSchema.index({ userId: 1, provider: 1, status: 1 });
+BrokerConnectionSchema.index(
+  { userId: 1, provider: 1, accountId: 1 },
+  { unique: true, partialFilterExpression: { accountId: { $type: 'string' } } }
+);
+BrokerConnectionSchema.index({ expiresAt: 1, status: 1 });
 
 export const BrokerConnectionModel =
   (mongoose.models.IdentityBrokerConnection as mongoose.Model<BrokerConnectionDocument>) ||

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -66,6 +66,8 @@ import {
 import { autonomousTradingRouter } from './features/autonomousTrading';
 import { learningRouter, startLearningScheduler, stopLearningScheduler } from './features/learning';
 import { identityRouter } from './features/identity/identity.routes';
+import { brokerageRouter } from './features/brokerage/brokerage.routes';
+import { startBrokerRefreshService, stopBrokerRefreshService } from './features/brokerage/brokerPlatform.service';
 import { runIdentityMigrations } from './features/identity/identity.migrations';
 import { isSessionActive } from './features/identity/services/sessionService';
 import { initializeAutomation } from './features/automation/services/sessionRecovery.service';
@@ -191,6 +193,7 @@ app.get(['/health', '/api/health'], (_req, res) => {
 });
 
 app.use('/api/auth', identityRouter);
+app.use('/api/brokers', brokerageRouter);
 app.use('/api/analyze', analyzeRouter);
 app.use('/api/agent', agentProxyRouter);
 app.use('/api/chat', chatRouter);
@@ -366,6 +369,7 @@ async function start() {
     startStrategyOrchestratorScheduler();
     startRiskEngineScheduler();
     startLearningScheduler();
+    startBrokerRefreshService();
   });
 
   // Automation safety foundation (Phase 2A): fail-closed init AFTER the HTTP
@@ -450,6 +454,7 @@ async function gracefulShutdown(signal: string) {
   stopStrategyOrchestratorScheduler();
   stopRiskEngineScheduler();
   stopLearningScheduler();
+  stopBrokerRefreshService();
   await stopTradeLifecycleScheduler().catch(() => undefined);
   stopAutomationVisibilityBroadcaster();
   stopOrderReconciliationWorker();

--- a/server/tests/brokerage.platform.test.mjs
+++ b/server/tests/brokerage.platform.test.mjs
@@ -1,0 +1,152 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import http from 'node:http';
+import cookieParser from 'cookie-parser';
+import { randomBytes } from 'node:crypto';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+
+process.env.IDENTITY_JWT_SECRET = 'test-identity-secret-at-least-32-bytes-long';
+process.env.IDENTITY_ENCRYPTION_KEY = randomBytes(32).toString('base64');
+process.env.IDENTITY_APP_BASE_URL = 'http://localhost:5173';
+process.env.IDENTITY_API_BASE_URL = 'http://localhost:4000';
+process.env.ALPACA_OAUTH_CLIENT_ID = 'alpaca-client';
+process.env.ALPACA_OAUTH_CLIENT_SECRET = 'alpaca-secret';
+process.env.ALPACA_OAUTH_AUTHORIZE_URL = 'https://broker.example/authorize';
+process.env.ALPACA_OAUTH_TOKEN_URL = 'https://broker.example/token';
+process.env.ALPACA_OAUTH_API_BASE_URL = 'https://broker.example/api';
+
+const { initMongo, closeMongo } = await import('../dist/shared/db/mongo.js');
+const { brokerageRouter } = await import('../dist/features/brokerage/brokerage.routes.js');
+const { setBrokerHttpRequest, refreshExpiringConnections } = await import('../dist/features/brokerage/brokerPlatform.service.js');
+const { BrokerConnectionModel } = await import('../dist/features/identity/models/brokerConnection.model.js');
+const { BrokerOAuthAttemptModel } = await import('../dist/features/brokerage/models/brokerOAuthAttempt.model.js');
+const { BrokerPortfolioModel } = await import('../dist/features/brokerage/models/brokerPortfolio.model.js');
+const { OrganizationModel } = await import('../dist/features/identity/models/organization.model.js');
+const { MembershipModel } = await import('../dist/features/identity/models/membership.model.js');
+const { WorkspaceProfileModel } = await import('../dist/features/identity/models/workspaceProfile.model.js');
+
+function startServer(handler) {
+  const server = http.createServer(handler);
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port })));
+}
+function closeServer(server) { return new Promise(resolve => server.close(() => resolve())); }
+
+let mongod;
+let appServer;
+let userId;
+let accountSequence = 1;
+let refreshGrantSeen = false;
+
+test.before(async () => {
+  mongod = await MongoMemoryServer.create();
+  await initMongo(mongod.getUri(), 'brokerage-platform-test');
+  userId = new mongoose.Types.ObjectId();
+  const org = await OrganizationModel.create({ name: 'Institutional Desk', slug: 'institutional-desk', ownerId: userId, status: 'active' });
+  await MembershipModel.create({ userId, orgId: org._id, roles: ['admin'] });
+  await WorkspaceProfileModel.create({ userId, orgId: org._id });
+
+  setBrokerHttpRequest(async config => {
+    if (config.method === 'POST' && config.url.endsWith('/token')) {
+      if (String(config.data).includes('grant_type=refresh_token')) refreshGrantSeen = true;
+      return { data: { access_token: refreshGrantSeen ? 'refreshed-access-token' : `access-token-${accountSequence}`, refresh_token: `refresh-token-${accountSequence}`, expires_in: 3600, scope: 'account trading', user_id: `broker-user-${accountSequence}` } };
+    }
+    if (config.url.endsWith('/v2/account')) return { data: { id: `alpaca-account-${accountSequence}`, account_type: 'margin', status: 'ACTIVE', buying_power: '250000', cash: '100000', equity: '300000', portfolio_value: '300000' } };
+    if (config.url.includes('/v2/positions')) return { data: [{ symbol: 'SPY', asset_class: 'us_equity', unrealized_intraday_pl: '125.50' }, { symbol: 'SPY260101C00600000', asset_class: 'us_option', unrealized_intraday_pl: '-25.50' }] };
+    if (config.url.includes('/v2/orders')) return { data: [{ id: 'order-1', status: 'new' }] };
+    if (config.url.includes('/v2/watchlists')) return { data: [{ id: 'watchlist-1', name: 'Core' }] };
+    if (config.url.includes('/v2/account/configurations')) return { data: { dtbp_check: 'entry' } };
+    throw new Error(`Unexpected broker request: ${config.method} ${config.url}`);
+  });
+
+  const app = express();
+  app.use(cookieParser());
+  app.use((req, _res, next) => { req.auth = { authenticated: true, actorId: String(userId), accountId: 'workspace', roles: ['administrator'], authMethod: 'session', enforcementMode: 'required', sessionId: 'session-1' }; next(); });
+  app.use(express.json());
+  app.use('/api/brokers', brokerageRouter);
+  app.use((error, _req, res, _next) => res.status(error.status ?? 500).json({ error: error.message }));
+  appServer = await startServer(app);
+});
+
+test.after(async () => {
+  setBrokerHttpRequest(null);
+  await closeServer(appServer.server);
+  await closeMongo();
+  await mongod.stop();
+});
+
+function request(path, options = {}) {
+  return fetch(`http://127.0.0.1:${appServer.port}${path}`, { redirect: 'manual', ...options, headers: { cookie: 'id_csrf=csrf-token', 'x-csrf-token': 'csrf-token', ...(options.headers ?? {}) } });
+}
+
+async function beginAndCompleteConnection() {
+  const begin = await request('/api/brokers/alpaca/connect', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ environment: 'paper', returnTo: '/onboarding' }) });
+  assert.equal(begin.status, 201);
+  const authorizationUrl = new URL((await begin.json()).authorizationUrl);
+  assert.equal(authorizationUrl.origin, 'https://broker.example');
+  assert.equal(authorizationUrl.searchParams.get('code_challenge_method'), 'S256');
+  const state = authorizationUrl.searchParams.get('state');
+  assert.ok(state);
+  const callback = await request(`/api/brokers/alpaca/callback?state=${encodeURIComponent(state)}&code=authorization-code`, { headers: {} });
+  assert.equal(callback.status, 303);
+  assert.match(callback.headers.get('location'), /connection=success/);
+}
+
+test('OAuth callback encrypts tokens, imports the full portfolio, and exposes only safe status', async () => {
+  await beginAndCompleteConnection();
+  const connection = await BrokerConnectionModel.findOne({ userId, provider: 'alpaca', accountId: 'alpaca-account-1' }).select('+encryptedAccessToken +encryptedRefreshToken');
+  assert.ok(connection);
+  assert.notEqual(connection.encryptedAccessToken.data, 'access-token-1');
+  assert.notEqual(connection.encryptedRefreshToken.data, 'refresh-token-1');
+  assert.equal(connection.status, 'connected');
+  assert.equal(connection.oauthStatus, 'authorized');
+  assert.ok(connection.lastSync);
+  const portfolio = await BrokerPortfolioModel.findOne({ connectionId: connection._id }).lean();
+  assert.equal(portfolio.positions.length, 2);
+  assert.equal(portfolio.optionPositions.length, 1);
+  assert.equal(portfolio.openOrders.length, 1);
+  assert.equal(portfolio.watchlists.length, 1);
+  assert.equal(portfolio.balances.buyingPower, 250000);
+
+  const status = await request('/api/brokers/status', { headers: {} });
+  assert.equal(status.status, 200);
+  const payload = await status.json();
+  assert.equal(payload.connections[0].metrics.todayPl, 100);
+  assert.equal(payload.connections[0].metrics.openPositions, 2);
+  assert.equal(JSON.stringify(payload).includes('encryptedAccessToken'), false);
+  assert.equal(JSON.stringify(payload).includes('access-token-1'), false);
+
+  const replay = await request(`/api/brokers/alpaca/callback?state=invalid&code=authorization-code`, { headers: {} });
+  assert.equal(replay.status, 303);
+  assert.match(replay.headers.get('location'), /connection=failed/);
+  assert.equal(await BrokerOAuthAttemptModel.countDocuments({ consumedAt: { $ne: null } }), 1);
+});
+
+test('supports multiple accounts and refreshes expiring OAuth credentials', async () => {
+  accountSequence = 2;
+  await beginAndCompleteConnection();
+  assert.equal(await BrokerConnectionModel.countDocuments({ userId, provider: 'alpaca', status: 'connected' }), 2);
+  const expiring = await BrokerConnectionModel.findOne({ accountId: 'alpaca-account-2' });
+  expiring.expiresAt = new Date(Date.now() + 10_000);
+  await expiring.save();
+  const refreshed = await refreshExpiringConnections();
+  assert.equal(refreshed, 1);
+  assert.equal(refreshGrantSeen, true);
+  const after = await BrokerConnectionModel.findById(expiring._id);
+  assert.ok(after.lastRefresh);
+  assert.equal(after.reconnectStatus, 'not_required');
+});
+
+test('disconnect revokes local credentials and removes only broker caches', async () => {
+  const connection = await BrokerConnectionModel.findOne({ accountId: 'alpaca-account-2' });
+  const response = await request('/api/brokers/alpaca/disconnect', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ connectionId: String(connection._id) }) });
+  assert.equal(response.status, 200);
+  const after = await BrokerConnectionModel.findById(connection._id).select('+encryptedAccessToken +encryptedRefreshToken');
+  assert.equal(after.status, 'revoked');
+  assert.equal(after.encryptedAccessToken, null);
+  assert.equal(after.encryptedRefreshToken, null);
+  assert.equal(await BrokerPortfolioModel.countDocuments({ connectionId: connection._id }), 0);
+  assert.equal(await WorkspaceProfileModel.countDocuments({ userId }), 1);
+  assert.equal(await MembershipModel.countDocuments({ userId }), 1);
+});


### PR DESCRIPTION
## Summary
- adds multi-broker OAuth with PKCE, encrypted token persistence, refresh, health, sync, reconnect, and disconnect services
- adds enterprise onboarding, broker directory/settings, security center, and terminal portfolio status
- preserves the PR #61 identity foundation and existing trading engine

## Certification
- server: 476 passed
- client: 173 passed
- Playwright: 96 passed across Chromium, Firefox, WebKit, iPad, and mobile profiles
- lint and production build: passed
- npm audit: 0 vulnerabilities

## Stack
Draft PR stacked on #61. Do not merge until #61 lands and broker OAuth registrations are configured in the deployment.